### PR TITLE
Updated Xamarin.Forms package to avoid Warnings in Android Project

### DIFF
--- a/XFGloss.Droid/Resources/Resource.designer.cs
+++ b/XFGloss.Droid/Resources/Resource.designer.cs
@@ -85,956 +85,1038 @@ namespace XFGloss.Droid
 			}
 		}
 		
+		public partial class Animator
+		{
+			
+			// aapt resource value: 0x7f050000
+			public static int design_appbar_state_list_animator = 2131034112;
+			
+			static Animator()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Animator()
+			{
+			}
+		}
+		
 		public partial class Attribute
 		{
 			
-			// aapt resource value: 0x7f010000
-			public static int MediaRouteControllerWindowBackground = 2130771968;
-			
-			// aapt resource value: 0x7f0100a6
-			public static int actionBarDivider = 2130772134;
-			
-			// aapt resource value: 0x7f0100a7
-			public static int actionBarItemBackground = 2130772135;
-			
-			// aapt resource value: 0x7f0100a0
-			public static int actionBarPopupTheme = 2130772128;
-			
-			// aapt resource value: 0x7f0100a5
-			public static int actionBarSize = 2130772133;
-			
-			// aapt resource value: 0x7f0100a2
-			public static int actionBarSplitStyle = 2130772130;
-			
-			// aapt resource value: 0x7f0100a1
-			public static int actionBarStyle = 2130772129;
-			
-			// aapt resource value: 0x7f01009c
-			public static int actionBarTabBarStyle = 2130772124;
-			
-			// aapt resource value: 0x7f01009b
-			public static int actionBarTabStyle = 2130772123;
-			
-			// aapt resource value: 0x7f01009d
-			public static int actionBarTabTextStyle = 2130772125;
-			
-			// aapt resource value: 0x7f0100a3
-			public static int actionBarTheme = 2130772131;
-			
-			// aapt resource value: 0x7f0100a4
-			public static int actionBarWidgetTheme = 2130772132;
-			
-			// aapt resource value: 0x7f0100c0
-			public static int actionButtonStyle = 2130772160;
-			
-			// aapt resource value: 0x7f0100bc
-			public static int actionDropDownStyle = 2130772156;
-			
-			// aapt resource value: 0x7f01010e
-			public static int actionLayout = 2130772238;
-			
-			// aapt resource value: 0x7f0100a8
-			public static int actionMenuTextAppearance = 2130772136;
-			
-			// aapt resource value: 0x7f0100a9
-			public static int actionMenuTextColor = 2130772137;
-			
-			// aapt resource value: 0x7f0100ac
-			public static int actionModeBackground = 2130772140;
-			
-			// aapt resource value: 0x7f0100ab
-			public static int actionModeCloseButtonStyle = 2130772139;
-			
-			// aapt resource value: 0x7f0100ae
-			public static int actionModeCloseDrawable = 2130772142;
-			
-			// aapt resource value: 0x7f0100b0
-			public static int actionModeCopyDrawable = 2130772144;
-			
-			// aapt resource value: 0x7f0100af
-			public static int actionModeCutDrawable = 2130772143;
-			
-			// aapt resource value: 0x7f0100b4
-			public static int actionModeFindDrawable = 2130772148;
-			
-			// aapt resource value: 0x7f0100b1
-			public static int actionModePasteDrawable = 2130772145;
-			
-			// aapt resource value: 0x7f0100b6
-			public static int actionModePopupWindowStyle = 2130772150;
-			
-			// aapt resource value: 0x7f0100b2
-			public static int actionModeSelectAllDrawable = 2130772146;
-			
-			// aapt resource value: 0x7f0100b3
-			public static int actionModeShareDrawable = 2130772147;
-			
-			// aapt resource value: 0x7f0100ad
-			public static int actionModeSplitBackground = 2130772141;
-			
-			// aapt resource value: 0x7f0100aa
-			public static int actionModeStyle = 2130772138;
-			
-			// aapt resource value: 0x7f0100b5
-			public static int actionModeWebSearchDrawable = 2130772149;
-			
-			// aapt resource value: 0x7f01009e
-			public static int actionOverflowButtonStyle = 2130772126;
-			
-			// aapt resource value: 0x7f01009f
-			public static int actionOverflowMenuStyle = 2130772127;
-			
-			// aapt resource value: 0x7f010110
-			public static int actionProviderClass = 2130772240;
-			
-			// aapt resource value: 0x7f01010f
-			public static int actionViewClass = 2130772239;
-			
-			// aapt resource value: 0x7f0100c8
-			public static int activityChooserViewStyle = 2130772168;
-			
-			// aapt resource value: 0x7f0100eb
-			public static int alertDialogButtonGroupStyle = 2130772203;
-			
-			// aapt resource value: 0x7f0100ec
-			public static int alertDialogCenterButtons = 2130772204;
-			
-			// aapt resource value: 0x7f0100ea
-			public static int alertDialogStyle = 2130772202;
-			
-			// aapt resource value: 0x7f0100ed
-			public static int alertDialogTheme = 2130772205;
-			
-			// aapt resource value: 0x7f0100ff
-			public static int allowStacking = 2130772223;
-			
-			// aapt resource value: 0x7f010106
-			public static int arrowHeadLength = 2130772230;
-			
-			// aapt resource value: 0x7f010107
-			public static int arrowShaftLength = 2130772231;
-			
-			// aapt resource value: 0x7f0100f2
-			public static int autoCompleteTextViewStyle = 2130772210;
-			
-			// aapt resource value: 0x7f010077
-			public static int background = 2130772087;
-			
-			// aapt resource value: 0x7f010079
-			public static int backgroundSplit = 2130772089;
-			
-			// aapt resource value: 0x7f010078
-			public static int backgroundStacked = 2130772088;
-			
-			// aapt resource value: 0x7f01013a
-			public static int backgroundTint = 2130772282;
-			
-			// aapt resource value: 0x7f01013b
-			public static int backgroundTintMode = 2130772283;
-			
-			// aapt resource value: 0x7f010108
-			public static int barLength = 2130772232;
-			
-			// aapt resource value: 0x7f010026
-			public static int behavior_hideable = 2130772006;
-			
-			// aapt resource value: 0x7f01004c
-			public static int behavior_overlapTop = 2130772044;
-			
-			// aapt resource value: 0x7f010025
-			public static int behavior_peekHeight = 2130772005;
-			
-			// aapt resource value: 0x7f010042
-			public static int borderWidth = 2130772034;
-			
-			// aapt resource value: 0x7f0100c5
-			public static int borderlessButtonStyle = 2130772165;
-			
-			// aapt resource value: 0x7f01003c
-			public static int bottomSheetDialogTheme = 2130772028;
-			
-			// aapt resource value: 0x7f01003d
-			public static int bottomSheetStyle = 2130772029;
-			
-			// aapt resource value: 0x7f0100c2
-			public static int buttonBarButtonStyle = 2130772162;
-			
-			// aapt resource value: 0x7f0100f0
-			public static int buttonBarNegativeButtonStyle = 2130772208;
-			
-			// aapt resource value: 0x7f0100f1
-			public static int buttonBarNeutralButtonStyle = 2130772209;
-			
-			// aapt resource value: 0x7f0100ef
-			public static int buttonBarPositiveButtonStyle = 2130772207;
-			
-			// aapt resource value: 0x7f0100c1
-			public static int buttonBarStyle = 2130772161;
-			
-			// aapt resource value: 0x7f01008a
-			public static int buttonPanelSideLayout = 2130772106;
-			
-			// aapt resource value: 0x7f0100f3
-			public static int buttonStyle = 2130772211;
-			
-			// aapt resource value: 0x7f0100f4
-			public static int buttonStyleSmall = 2130772212;
-			
-			// aapt resource value: 0x7f010100
-			public static int buttonTint = 2130772224;
-			
-			// aapt resource value: 0x7f010101
-			public static int buttonTintMode = 2130772225;
-			
-			// aapt resource value: 0x7f010017
-			public static int cardBackgroundColor = 2130771991;
-			
-			// aapt resource value: 0x7f010018
-			public static int cardCornerRadius = 2130771992;
-			
-			// aapt resource value: 0x7f010019
-			public static int cardElevation = 2130771993;
-			
-			// aapt resource value: 0x7f01001a
-			public static int cardMaxElevation = 2130771994;
-			
-			// aapt resource value: 0x7f01001c
-			public static int cardPreventCornerOverlap = 2130771996;
-			
-			// aapt resource value: 0x7f01001b
-			public static int cardUseCompatPadding = 2130771995;
-			
-			// aapt resource value: 0x7f0100f5
-			public static int checkboxStyle = 2130772213;
-			
-			// aapt resource value: 0x7f0100f6
-			public static int checkedTextViewStyle = 2130772214;
-			
-			// aapt resource value: 0x7f010118
-			public static int closeIcon = 2130772248;
-			
-			// aapt resource value: 0x7f010087
-			public static int closeItemLayout = 2130772103;
-			
-			// aapt resource value: 0x7f010131
-			public static int collapseContentDescription = 2130772273;
-			
-			// aapt resource value: 0x7f010130
-			public static int collapseIcon = 2130772272;
-			
-			// aapt resource value: 0x7f010033
-			public static int collapsedTitleGravity = 2130772019;
-			
-			// aapt resource value: 0x7f01002f
-			public static int collapsedTitleTextAppearance = 2130772015;
-			
-			// aapt resource value: 0x7f010102
-			public static int color = 2130772226;
-			
-			// aapt resource value: 0x7f0100e3
-			public static int colorAccent = 2130772195;
-			
-			// aapt resource value: 0x7f0100e7
-			public static int colorButtonNormal = 2130772199;
-			
-			// aapt resource value: 0x7f0100e5
-			public static int colorControlActivated = 2130772197;
-			
-			// aapt resource value: 0x7f0100e6
-			public static int colorControlHighlight = 2130772198;
-			
-			// aapt resource value: 0x7f0100e4
-			public static int colorControlNormal = 2130772196;
-			
-			// aapt resource value: 0x7f0100e1
-			public static int colorPrimary = 2130772193;
-			
-			// aapt resource value: 0x7f0100e2
-			public static int colorPrimaryDark = 2130772194;
-			
-			// aapt resource value: 0x7f0100e8
-			public static int colorSwitchThumbNormal = 2130772200;
-			
-			// aapt resource value: 0x7f01011d
-			public static int commitIcon = 2130772253;
-			
-			// aapt resource value: 0x7f010082
-			public static int contentInsetEnd = 2130772098;
-			
-			// aapt resource value: 0x7f010083
-			public static int contentInsetLeft = 2130772099;
-			
-			// aapt resource value: 0x7f010084
-			public static int contentInsetRight = 2130772100;
-			
-			// aapt resource value: 0x7f010081
-			public static int contentInsetStart = 2130772097;
-			
-			// aapt resource value: 0x7f01001d
-			public static int contentPadding = 2130771997;
-			
-			// aapt resource value: 0x7f010021
-			public static int contentPaddingBottom = 2130772001;
-			
-			// aapt resource value: 0x7f01001e
-			public static int contentPaddingLeft = 2130771998;
-			
-			// aapt resource value: 0x7f01001f
-			public static int contentPaddingRight = 2130771999;
-			
-			// aapt resource value: 0x7f010020
-			public static int contentPaddingTop = 2130772000;
-			
-			// aapt resource value: 0x7f010030
-			public static int contentScrim = 2130772016;
-			
-			// aapt resource value: 0x7f0100e9
-			public static int controlBackground = 2130772201;
-			
-			// aapt resource value: 0x7f010062
-			public static int counterEnabled = 2130772066;
-			
-			// aapt resource value: 0x7f010063
-			public static int counterMaxLength = 2130772067;
-			
-			// aapt resource value: 0x7f010065
-			public static int counterOverflowTextAppearance = 2130772069;
-			
-			// aapt resource value: 0x7f010064
-			public static int counterTextAppearance = 2130772068;
-			
-			// aapt resource value: 0x7f01007a
-			public static int customNavigationLayout = 2130772090;
-			
-			// aapt resource value: 0x7f010117
-			public static int defaultQueryHint = 2130772247;
-			
-			// aapt resource value: 0x7f0100ba
-			public static int dialogPreferredPadding = 2130772154;
-			
-			// aapt resource value: 0x7f0100b9
-			public static int dialogTheme = 2130772153;
-			
-			// aapt resource value: 0x7f010070
-			public static int displayOptions = 2130772080;
-			
-			// aapt resource value: 0x7f010076
-			public static int divider = 2130772086;
-			
-			// aapt resource value: 0x7f0100c7
-			public static int dividerHorizontal = 2130772167;
-			
-			// aapt resource value: 0x7f01010c
-			public static int dividerPadding = 2130772236;
-			
-			// aapt resource value: 0x7f0100c6
-			public static int dividerVertical = 2130772166;
-			
-			// aapt resource value: 0x7f010104
-			public static int drawableSize = 2130772228;
-			
-			// aapt resource value: 0x7f01006b
-			public static int drawerArrowStyle = 2130772075;
-			
-			// aapt resource value: 0x7f0100d9
-			public static int dropDownListViewStyle = 2130772185;
-			
-			// aapt resource value: 0x7f0100bd
-			public static int dropdownListPreferredItemHeight = 2130772157;
-			
-			// aapt resource value: 0x7f0100ce
-			public static int editTextBackground = 2130772174;
-			
-			// aapt resource value: 0x7f0100cd
-			public static int editTextColor = 2130772173;
-			
-			// aapt resource value: 0x7f0100f7
-			public static int editTextStyle = 2130772215;
-			
-			// aapt resource value: 0x7f010085
-			public static int elevation = 2130772101;
-			
-			// aapt resource value: 0x7f010060
-			public static int errorEnabled = 2130772064;
-			
-			// aapt resource value: 0x7f010061
-			public static int errorTextAppearance = 2130772065;
-			
-			// aapt resource value: 0x7f010089
-			public static int expandActivityOverflowButtonDrawable = 2130772105;
-			
-			// aapt resource value: 0x7f010022
-			public static int expanded = 2130772002;
-			
-			// aapt resource value: 0x7f010034
-			public static int expandedTitleGravity = 2130772020;
-			
-			// aapt resource value: 0x7f010029
-			public static int expandedTitleMargin = 2130772009;
-			
-			// aapt resource value: 0x7f01002d
-			public static int expandedTitleMarginBottom = 2130772013;
-			
-			// aapt resource value: 0x7f01002c
-			public static int expandedTitleMarginEnd = 2130772012;
-			
-			// aapt resource value: 0x7f01002a
-			public static int expandedTitleMarginStart = 2130772010;
-			
-			// aapt resource value: 0x7f01002b
-			public static int expandedTitleMarginTop = 2130772011;
-			
-			// aapt resource value: 0x7f01002e
-			public static int expandedTitleTextAppearance = 2130772014;
-			
-			// aapt resource value: 0x7f010016
-			public static int externalRouteEnabledDrawable = 2130771990;
-			
-			// aapt resource value: 0x7f010040
-			public static int fabSize = 2130772032;
-			
-			// aapt resource value: 0x7f010044
-			public static int foregroundInsidePadding = 2130772036;
-			
-			// aapt resource value: 0x7f010105
-			public static int gapBetweenBars = 2130772229;
-			
-			// aapt resource value: 0x7f010119
-			public static int goIcon = 2130772249;
-			
-			// aapt resource value: 0x7f01004a
-			public static int headerLayout = 2130772042;
-			
-			// aapt resource value: 0x7f01006c
-			public static int height = 2130772076;
-			
-			// aapt resource value: 0x7f010080
-			public static int hideOnContentScroll = 2130772096;
-			
-			// aapt resource value: 0x7f010066
-			public static int hintAnimationEnabled = 2130772070;
-			
-			// aapt resource value: 0x7f01005f
-			public static int hintEnabled = 2130772063;
+			// aapt resource value: 0x7f01005d
+			public static int actionBarDivider = 2130772061;
 			
 			// aapt resource value: 0x7f01005e
-			public static int hintTextAppearance = 2130772062;
-			
-			// aapt resource value: 0x7f0100bf
-			public static int homeAsUpIndicator = 2130772159;
-			
-			// aapt resource value: 0x7f01007b
-			public static int homeLayout = 2130772091;
-			
-			// aapt resource value: 0x7f010074
-			public static int icon = 2130772084;
-			
-			// aapt resource value: 0x7f010115
-			public static int iconifiedByDefault = 2130772245;
-			
-			// aapt resource value: 0x7f0100cf
-			public static int imageButtonStyle = 2130772175;
-			
-			// aapt resource value: 0x7f01007d
-			public static int indeterminateProgressStyle = 2130772093;
-			
-			// aapt resource value: 0x7f010088
-			public static int initialActivityCount = 2130772104;
-			
-			// aapt resource value: 0x7f01004b
-			public static int insetForeground = 2130772043;
-			
-			// aapt resource value: 0x7f01006d
-			public static int isLightTheme = 2130772077;
-			
-			// aapt resource value: 0x7f010048
-			public static int itemBackground = 2130772040;
-			
-			// aapt resource value: 0x7f010046
-			public static int itemIconTint = 2130772038;
-			
-			// aapt resource value: 0x7f01007f
-			public static int itemPadding = 2130772095;
-			
-			// aapt resource value: 0x7f010049
-			public static int itemTextAppearance = 2130772041;
-			
-			// aapt resource value: 0x7f010047
-			public static int itemTextColor = 2130772039;
-			
-			// aapt resource value: 0x7f010036
-			public static int keylines = 2130772022;
-			
-			// aapt resource value: 0x7f010114
-			public static int layout = 2130772244;
-			
-			// aapt resource value: 0x7f010067
-			public static int layoutManager = 2130772071;
-			
-			// aapt resource value: 0x7f010039
-			public static int layout_anchor = 2130772025;
-			
-			// aapt resource value: 0x7f01003b
-			public static int layout_anchorGravity = 2130772027;
-			
-			// aapt resource value: 0x7f010038
-			public static int layout_behavior = 2130772024;
-			
-			// aapt resource value: 0x7f010027
-			public static int layout_collapseMode = 2130772007;
-			
-			// aapt resource value: 0x7f010028
-			public static int layout_collapseParallaxMultiplier = 2130772008;
-			
-			// aapt resource value: 0x7f01003a
-			public static int layout_keyline = 2130772026;
-			
-			// aapt resource value: 0x7f010023
-			public static int layout_scrollFlags = 2130772003;
-			
-			// aapt resource value: 0x7f010024
-			public static int layout_scrollInterpolator = 2130772004;
-			
-			// aapt resource value: 0x7f0100e0
-			public static int listChoiceBackgroundIndicator = 2130772192;
-			
-			// aapt resource value: 0x7f0100bb
-			public static int listDividerAlertDialog = 2130772155;
-			
-			// aapt resource value: 0x7f01008e
-			public static int listItemLayout = 2130772110;
-			
-			// aapt resource value: 0x7f01008b
-			public static int listLayout = 2130772107;
-			
-			// aapt resource value: 0x7f0100da
-			public static int listPopupWindowStyle = 2130772186;
-			
-			// aapt resource value: 0x7f0100d4
-			public static int listPreferredItemHeight = 2130772180;
-			
-			// aapt resource value: 0x7f0100d6
-			public static int listPreferredItemHeightLarge = 2130772182;
-			
-			// aapt resource value: 0x7f0100d5
-			public static int listPreferredItemHeightSmall = 2130772181;
-			
-			// aapt resource value: 0x7f0100d7
-			public static int listPreferredItemPaddingLeft = 2130772183;
-			
-			// aapt resource value: 0x7f0100d8
-			public static int listPreferredItemPaddingRight = 2130772184;
-			
-			// aapt resource value: 0x7f010075
-			public static int logo = 2130772085;
-			
-			// aapt resource value: 0x7f010134
-			public static int logoDescription = 2130772276;
-			
-			// aapt resource value: 0x7f01004d
-			public static int maxActionInlineWidth = 2130772045;
-			
-			// aapt resource value: 0x7f01012f
-			public static int maxButtonHeight = 2130772271;
-			
-			// aapt resource value: 0x7f01010a
-			public static int measureWithLargestChild = 2130772234;
-			
-			// aapt resource value: 0x7f010001
-			public static int mediaRouteAudioTrackDrawable = 2130771969;
-			
-			// aapt resource value: 0x7f010002
-			public static int mediaRouteBluetoothIconDrawable = 2130771970;
-			
-			// aapt resource value: 0x7f010003
-			public static int mediaRouteButtonStyle = 2130771971;
-			
-			// aapt resource value: 0x7f010004
-			public static int mediaRouteCastDrawable = 2130771972;
-			
-			// aapt resource value: 0x7f010005
-			public static int mediaRouteChooserPrimaryTextStyle = 2130771973;
-			
-			// aapt resource value: 0x7f010006
-			public static int mediaRouteChooserSecondaryTextStyle = 2130771974;
-			
-			// aapt resource value: 0x7f010007
-			public static int mediaRouteCloseDrawable = 2130771975;
-			
-			// aapt resource value: 0x7f010008
-			public static int mediaRouteCollapseGroupDrawable = 2130771976;
-			
-			// aapt resource value: 0x7f010009
-			public static int mediaRouteConnectingDrawable = 2130771977;
-			
-			// aapt resource value: 0x7f01000a
-			public static int mediaRouteControllerPrimaryTextStyle = 2130771978;
-			
-			// aapt resource value: 0x7f01000b
-			public static int mediaRouteControllerSecondaryTextStyle = 2130771979;
-			
-			// aapt resource value: 0x7f01000c
-			public static int mediaRouteControllerTitleTextStyle = 2130771980;
-			
-			// aapt resource value: 0x7f01000d
-			public static int mediaRouteDefaultIconDrawable = 2130771981;
-			
-			// aapt resource value: 0x7f01000e
-			public static int mediaRouteExpandGroupDrawable = 2130771982;
-			
-			// aapt resource value: 0x7f01000f
-			public static int mediaRouteOffDrawable = 2130771983;
-			
-			// aapt resource value: 0x7f010010
-			public static int mediaRouteOnDrawable = 2130771984;
-			
-			// aapt resource value: 0x7f010011
-			public static int mediaRoutePauseDrawable = 2130771985;
-			
-			// aapt resource value: 0x7f010012
-			public static int mediaRoutePlayDrawable = 2130771986;
-			
-			// aapt resource value: 0x7f010013
-			public static int mediaRouteSpeakerGroupIconDrawable = 2130771987;
-			
-			// aapt resource value: 0x7f010014
-			public static int mediaRouteSpeakerIconDrawable = 2130771988;
-			
-			// aapt resource value: 0x7f010015
-			public static int mediaRouteTvIconDrawable = 2130771989;
-			
-			// aapt resource value: 0x7f010045
-			public static int menu = 2130772037;
-			
-			// aapt resource value: 0x7f01008c
-			public static int multiChoiceItemLayout = 2130772108;
-			
-			// aapt resource value: 0x7f010133
-			public static int navigationContentDescription = 2130772275;
-			
-			// aapt resource value: 0x7f010132
-			public static int navigationIcon = 2130772274;
-			
-			// aapt resource value: 0x7f01006f
-			public static int navigationMode = 2130772079;
-			
-			// aapt resource value: 0x7f010112
-			public static int overlapAnchor = 2130772242;
-			
-			// aapt resource value: 0x7f010138
-			public static int paddingEnd = 2130772280;
-			
-			// aapt resource value: 0x7f010137
-			public static int paddingStart = 2130772279;
-			
-			// aapt resource value: 0x7f0100dd
-			public static int panelBackground = 2130772189;
-			
-			// aapt resource value: 0x7f0100df
-			public static int panelMenuListTheme = 2130772191;
-			
-			// aapt resource value: 0x7f0100de
-			public static int panelMenuListWidth = 2130772190;
-			
-			// aapt resource value: 0x7f0100cb
-			public static int popupMenuStyle = 2130772171;
-			
-			// aapt resource value: 0x7f010086
-			public static int popupTheme = 2130772102;
-			
-			// aapt resource value: 0x7f0100cc
-			public static int popupWindowStyle = 2130772172;
-			
-			// aapt resource value: 0x7f010111
-			public static int preserveIconSpacing = 2130772241;
-			
-			// aapt resource value: 0x7f010041
-			public static int pressedTranslationZ = 2130772033;
-			
-			// aapt resource value: 0x7f01007e
-			public static int progressBarPadding = 2130772094;
-			
-			// aapt resource value: 0x7f01007c
-			public static int progressBarStyle = 2130772092;
-			
-			// aapt resource value: 0x7f01011f
-			public static int queryBackground = 2130772255;
-			
-			// aapt resource value: 0x7f010116
-			public static int queryHint = 2130772246;
-			
-			// aapt resource value: 0x7f0100f8
-			public static int radioButtonStyle = 2130772216;
-			
-			// aapt resource value: 0x7f0100f9
-			public static int ratingBarStyle = 2130772217;
-			
-			// aapt resource value: 0x7f0100fa
-			public static int ratingBarStyleIndicator = 2130772218;
-			
-			// aapt resource value: 0x7f0100fb
-			public static int ratingBarStyleSmall = 2130772219;
-			
-			// aapt resource value: 0x7f010069
-			public static int reverseLayout = 2130772073;
-			
-			// aapt resource value: 0x7f01003f
-			public static int rippleColor = 2130772031;
-			
-			// aapt resource value: 0x7f01011b
-			public static int searchHintIcon = 2130772251;
-			
-			// aapt resource value: 0x7f01011a
-			public static int searchIcon = 2130772250;
-			
-			// aapt resource value: 0x7f0100d3
-			public static int searchViewStyle = 2130772179;
-			
-			// aapt resource value: 0x7f0100fc
-			public static int seekBarStyle = 2130772220;
-			
-			// aapt resource value: 0x7f0100c3
-			public static int selectableItemBackground = 2130772163;
-			
-			// aapt resource value: 0x7f0100c4
-			public static int selectableItemBackgroundBorderless = 2130772164;
-			
-			// aapt resource value: 0x7f01010d
-			public static int showAsAction = 2130772237;
-			
-			// aapt resource value: 0x7f01010b
-			public static int showDividers = 2130772235;
-			
-			// aapt resource value: 0x7f010127
-			public static int showText = 2130772263;
-			
-			// aapt resource value: 0x7f01008d
-			public static int singleChoiceItemLayout = 2130772109;
-			
-			// aapt resource value: 0x7f010068
-			public static int spanCount = 2130772072;
-			
-			// aapt resource value: 0x7f010103
-			public static int spinBars = 2130772227;
-			
-			// aapt resource value: 0x7f0100be
-			public static int spinnerDropDownItemStyle = 2130772158;
-			
-			// aapt resource value: 0x7f0100fd
-			public static int spinnerStyle = 2130772221;
-			
-			// aapt resource value: 0x7f010126
-			public static int splitTrack = 2130772262;
-			
-			// aapt resource value: 0x7f01008f
-			public static int srcCompat = 2130772111;
-			
-			// aapt resource value: 0x7f01006a
-			public static int stackFromEnd = 2130772074;
-			
-			// aapt resource value: 0x7f010113
-			public static int state_above_anchor = 2130772243;
-			
-			// aapt resource value: 0x7f010037
-			public static int statusBarBackground = 2130772023;
-			
-			// aapt resource value: 0x7f010031
-			public static int statusBarScrim = 2130772017;
-			
-			// aapt resource value: 0x7f010120
-			public static int submitBackground = 2130772256;
-			
-			// aapt resource value: 0x7f010071
-			public static int subtitle = 2130772081;
-			
-			// aapt resource value: 0x7f010129
-			public static int subtitleTextAppearance = 2130772265;
-			
-			// aapt resource value: 0x7f010136
-			public static int subtitleTextColor = 2130772278;
-			
-			// aapt resource value: 0x7f010073
-			public static int subtitleTextStyle = 2130772083;
-			
-			// aapt resource value: 0x7f01011e
-			public static int suggestionRowLayout = 2130772254;
-			
-			// aapt resource value: 0x7f010124
-			public static int switchMinWidth = 2130772260;
-			
-			// aapt resource value: 0x7f010125
-			public static int switchPadding = 2130772261;
-			
-			// aapt resource value: 0x7f0100fe
-			public static int switchStyle = 2130772222;
-			
-			// aapt resource value: 0x7f010123
-			public static int switchTextAppearance = 2130772259;
-			
-			// aapt resource value: 0x7f010051
-			public static int tabBackground = 2130772049;
-			
-			// aapt resource value: 0x7f010050
-			public static int tabContentStart = 2130772048;
-			
-			// aapt resource value: 0x7f010053
-			public static int tabGravity = 2130772051;
-			
-			// aapt resource value: 0x7f01004e
-			public static int tabIndicatorColor = 2130772046;
-			
-			// aapt resource value: 0x7f01004f
-			public static int tabIndicatorHeight = 2130772047;
-			
-			// aapt resource value: 0x7f010055
-			public static int tabMaxWidth = 2130772053;
-			
-			// aapt resource value: 0x7f010054
-			public static int tabMinWidth = 2130772052;
-			
-			// aapt resource value: 0x7f010052
-			public static int tabMode = 2130772050;
-			
-			// aapt resource value: 0x7f01005d
-			public static int tabPadding = 2130772061;
-			
-			// aapt resource value: 0x7f01005c
-			public static int tabPaddingBottom = 2130772060;
-			
-			// aapt resource value: 0x7f01005b
-			public static int tabPaddingEnd = 2130772059;
-			
-			// aapt resource value: 0x7f010059
-			public static int tabPaddingStart = 2130772057;
-			
-			// aapt resource value: 0x7f01005a
-			public static int tabPaddingTop = 2130772058;
-			
-			// aapt resource value: 0x7f010058
-			public static int tabSelectedTextColor = 2130772056;
-			
-			// aapt resource value: 0x7f010056
-			public static int tabTextAppearance = 2130772054;
+			public static int actionBarItemBackground = 2130772062;
 			
 			// aapt resource value: 0x7f010057
-			public static int tabTextColor = 2130772055;
+			public static int actionBarPopupTheme = 2130772055;
 			
-			// aapt resource value: 0x7f010090
-			public static int textAllCaps = 2130772112;
+			// aapt resource value: 0x7f01005c
+			public static int actionBarSize = 2130772060;
 			
-			// aapt resource value: 0x7f0100b7
-			public static int textAppearanceLargePopupMenu = 2130772151;
+			// aapt resource value: 0x7f010059
+			public static int actionBarSplitStyle = 2130772057;
 			
-			// aapt resource value: 0x7f0100db
-			public static int textAppearanceListItem = 2130772187;
+			// aapt resource value: 0x7f010058
+			public static int actionBarStyle = 2130772056;
 			
-			// aapt resource value: 0x7f0100dc
-			public static int textAppearanceListItemSmall = 2130772188;
+			// aapt resource value: 0x7f010053
+			public static int actionBarTabBarStyle = 2130772051;
 			
-			// aapt resource value: 0x7f0100d1
-			public static int textAppearanceSearchResultSubtitle = 2130772177;
+			// aapt resource value: 0x7f010052
+			public static int actionBarTabStyle = 2130772050;
 			
-			// aapt resource value: 0x7f0100d0
-			public static int textAppearanceSearchResultTitle = 2130772176;
+			// aapt resource value: 0x7f010054
+			public static int actionBarTabTextStyle = 2130772052;
 			
-			// aapt resource value: 0x7f0100b8
-			public static int textAppearanceSmallPopupMenu = 2130772152;
+			// aapt resource value: 0x7f01005a
+			public static int actionBarTheme = 2130772058;
 			
-			// aapt resource value: 0x7f0100ee
-			public static int textColorAlertDialogListItem = 2130772206;
+			// aapt resource value: 0x7f01005b
+			public static int actionBarWidgetTheme = 2130772059;
 			
-			// aapt resource value: 0x7f01003e
-			public static int textColorError = 2130772030;
+			// aapt resource value: 0x7f010078
+			public static int actionButtonStyle = 2130772088;
 			
-			// aapt resource value: 0x7f0100d2
-			public static int textColorSearchUrl = 2130772178;
-			
-			// aapt resource value: 0x7f010139
-			public static int theme = 2130772281;
-			
-			// aapt resource value: 0x7f010109
-			public static int thickness = 2130772233;
-			
-			// aapt resource value: 0x7f010122
-			public static int thumbTextPadding = 2130772258;
-			
-			// aapt resource value: 0x7f01006e
-			public static int title = 2130772078;
-			
-			// aapt resource value: 0x7f010035
-			public static int titleEnabled = 2130772021;
-			
-			// aapt resource value: 0x7f01012e
-			public static int titleMarginBottom = 2130772270;
-			
-			// aapt resource value: 0x7f01012c
-			public static int titleMarginEnd = 2130772268;
-			
-			// aapt resource value: 0x7f01012b
-			public static int titleMarginStart = 2130772267;
-			
-			// aapt resource value: 0x7f01012d
-			public static int titleMarginTop = 2130772269;
-			
-			// aapt resource value: 0x7f01012a
-			public static int titleMargins = 2130772266;
-			
-			// aapt resource value: 0x7f010128
-			public static int titleTextAppearance = 2130772264;
-			
-			// aapt resource value: 0x7f010135
-			public static int titleTextColor = 2130772277;
-			
-			// aapt resource value: 0x7f010072
-			public static int titleTextStyle = 2130772082;
-			
-			// aapt resource value: 0x7f010032
-			public static int toolbarId = 2130772018;
-			
-			// aapt resource value: 0x7f0100ca
-			public static int toolbarNavigationButtonStyle = 2130772170;
+			// aapt resource value: 0x7f010074
+			public static int actionDropDownStyle = 2130772084;
 			
 			// aapt resource value: 0x7f0100c9
-			public static int toolbarStyle = 2130772169;
+			public static int actionLayout = 2130772169;
+			
+			// aapt resource value: 0x7f01005f
+			public static int actionMenuTextAppearance = 2130772063;
+			
+			// aapt resource value: 0x7f010060
+			public static int actionMenuTextColor = 2130772064;
+			
+			// aapt resource value: 0x7f010063
+			public static int actionModeBackground = 2130772067;
+			
+			// aapt resource value: 0x7f010062
+			public static int actionModeCloseButtonStyle = 2130772066;
+			
+			// aapt resource value: 0x7f010065
+			public static int actionModeCloseDrawable = 2130772069;
+			
+			// aapt resource value: 0x7f010067
+			public static int actionModeCopyDrawable = 2130772071;
+			
+			// aapt resource value: 0x7f010066
+			public static int actionModeCutDrawable = 2130772070;
+			
+			// aapt resource value: 0x7f01006b
+			public static int actionModeFindDrawable = 2130772075;
+			
+			// aapt resource value: 0x7f010068
+			public static int actionModePasteDrawable = 2130772072;
+			
+			// aapt resource value: 0x7f01006d
+			public static int actionModePopupWindowStyle = 2130772077;
+			
+			// aapt resource value: 0x7f010069
+			public static int actionModeSelectAllDrawable = 2130772073;
+			
+			// aapt resource value: 0x7f01006a
+			public static int actionModeShareDrawable = 2130772074;
+			
+			// aapt resource value: 0x7f010064
+			public static int actionModeSplitBackground = 2130772068;
+			
+			// aapt resource value: 0x7f010061
+			public static int actionModeStyle = 2130772065;
+			
+			// aapt resource value: 0x7f01006c
+			public static int actionModeWebSearchDrawable = 2130772076;
+			
+			// aapt resource value: 0x7f010055
+			public static int actionOverflowButtonStyle = 2130772053;
+			
+			// aapt resource value: 0x7f010056
+			public static int actionOverflowMenuStyle = 2130772054;
+			
+			// aapt resource value: 0x7f0100cb
+			public static int actionProviderClass = 2130772171;
+			
+			// aapt resource value: 0x7f0100ca
+			public static int actionViewClass = 2130772170;
+			
+			// aapt resource value: 0x7f010080
+			public static int activityChooserViewStyle = 2130772096;
+			
+			// aapt resource value: 0x7f0100a4
+			public static int alertDialogButtonGroupStyle = 2130772132;
+			
+			// aapt resource value: 0x7f0100a5
+			public static int alertDialogCenterButtons = 2130772133;
+			
+			// aapt resource value: 0x7f0100a3
+			public static int alertDialogStyle = 2130772131;
+			
+			// aapt resource value: 0x7f0100a6
+			public static int alertDialogTheme = 2130772134;
+			
+			// aapt resource value: 0x7f0100b9
+			public static int allowStacking = 2130772153;
+			
+			// aapt resource value: 0x7f0100ba
+			public static int alpha = 2130772154;
+			
+			// aapt resource value: 0x7f0100c1
+			public static int arrowHeadLength = 2130772161;
+			
+			// aapt resource value: 0x7f0100c2
+			public static int arrowShaftLength = 2130772162;
+			
+			// aapt resource value: 0x7f0100ab
+			public static int autoCompleteTextViewStyle = 2130772139;
+			
+			// aapt resource value: 0x7f010028
+			public static int background = 2130772008;
+			
+			// aapt resource value: 0x7f01002a
+			public static int backgroundSplit = 2130772010;
+			
+			// aapt resource value: 0x7f010029
+			public static int backgroundStacked = 2130772009;
+			
+			// aapt resource value: 0x7f0100fe
+			public static int backgroundTint = 2130772222;
+			
+			// aapt resource value: 0x7f0100ff
+			public static int backgroundTintMode = 2130772223;
+			
+			// aapt resource value: 0x7f0100c3
+			public static int barLength = 2130772163;
+			
+			// aapt resource value: 0x7f010129
+			public static int behavior_autoHide = 2130772265;
+			
+			// aapt resource value: 0x7f010106
+			public static int behavior_hideable = 2130772230;
+			
+			// aapt resource value: 0x7f010132
+			public static int behavior_overlapTop = 2130772274;
+			
+			// aapt resource value: 0x7f010105
+			public static int behavior_peekHeight = 2130772229;
+			
+			// aapt resource value: 0x7f010107
+			public static int behavior_skipCollapsed = 2130772231;
+			
+			// aapt resource value: 0x7f010127
+			public static int borderWidth = 2130772263;
+			
+			// aapt resource value: 0x7f01007d
+			public static int borderlessButtonStyle = 2130772093;
 			
 			// aapt resource value: 0x7f010121
-			public static int track = 2130772257;
+			public static int bottomSheetDialogTheme = 2130772257;
 			
-			// aapt resource value: 0x7f010043
-			public static int useCompatPadding = 2130772035;
+			// aapt resource value: 0x7f010122
+			public static int bottomSheetStyle = 2130772258;
 			
-			// aapt resource value: 0x7f01011c
-			public static int voiceIcon = 2130772252;
+			// aapt resource value: 0x7f01007a
+			public static int buttonBarButtonStyle = 2130772090;
 			
-			// aapt resource value: 0x7f010091
-			public static int windowActionBar = 2130772113;
+			// aapt resource value: 0x7f0100a9
+			public static int buttonBarNegativeButtonStyle = 2130772137;
 			
-			// aapt resource value: 0x7f010093
-			public static int windowActionBarOverlay = 2130772115;
+			// aapt resource value: 0x7f0100aa
+			public static int buttonBarNeutralButtonStyle = 2130772138;
 			
-			// aapt resource value: 0x7f010094
-			public static int windowActionModeOverlay = 2130772116;
+			// aapt resource value: 0x7f0100a8
+			public static int buttonBarPositiveButtonStyle = 2130772136;
 			
-			// aapt resource value: 0x7f010098
-			public static int windowFixedHeightMajor = 2130772120;
+			// aapt resource value: 0x7f010079
+			public static int buttonBarStyle = 2130772089;
 			
-			// aapt resource value: 0x7f010096
-			public static int windowFixedHeightMinor = 2130772118;
+			// aapt resource value: 0x7f0100f3
+			public static int buttonGravity = 2130772211;
 			
-			// aapt resource value: 0x7f010095
-			public static int windowFixedWidthMajor = 2130772117;
+			// aapt resource value: 0x7f01003d
+			public static int buttonPanelSideLayout = 2130772029;
 			
-			// aapt resource value: 0x7f010097
-			public static int windowFixedWidthMinor = 2130772119;
+			// aapt resource value: 0x7f0100ac
+			public static int buttonStyle = 2130772140;
+			
+			// aapt resource value: 0x7f0100ad
+			public static int buttonStyleSmall = 2130772141;
+			
+			// aapt resource value: 0x7f0100bb
+			public static int buttonTint = 2130772155;
+			
+			// aapt resource value: 0x7f0100bc
+			public static int buttonTintMode = 2130772156;
+			
+			// aapt resource value: 0x7f010011
+			public static int cardBackgroundColor = 2130771985;
+			
+			// aapt resource value: 0x7f010012
+			public static int cardCornerRadius = 2130771986;
+			
+			// aapt resource value: 0x7f010013
+			public static int cardElevation = 2130771987;
+			
+			// aapt resource value: 0x7f010014
+			public static int cardMaxElevation = 2130771988;
+			
+			// aapt resource value: 0x7f010016
+			public static int cardPreventCornerOverlap = 2130771990;
+			
+			// aapt resource value: 0x7f010015
+			public static int cardUseCompatPadding = 2130771989;
+			
+			// aapt resource value: 0x7f0100ae
+			public static int checkboxStyle = 2130772142;
+			
+			// aapt resource value: 0x7f0100af
+			public static int checkedTextViewStyle = 2130772143;
+			
+			// aapt resource value: 0x7f0100d6
+			public static int closeIcon = 2130772182;
+			
+			// aapt resource value: 0x7f01003a
+			public static int closeItemLayout = 2130772026;
+			
+			// aapt resource value: 0x7f0100f5
+			public static int collapseContentDescription = 2130772213;
+			
+			// aapt resource value: 0x7f0100f4
+			public static int collapseIcon = 2130772212;
+			
+			// aapt resource value: 0x7f010114
+			public static int collapsedTitleGravity = 2130772244;
+			
+			// aapt resource value: 0x7f01010e
+			public static int collapsedTitleTextAppearance = 2130772238;
+			
+			// aapt resource value: 0x7f0100bd
+			public static int color = 2130772157;
+			
+			// aapt resource value: 0x7f01009b
+			public static int colorAccent = 2130772123;
+			
+			// aapt resource value: 0x7f0100a2
+			public static int colorBackgroundFloating = 2130772130;
+			
+			// aapt resource value: 0x7f01009f
+			public static int colorButtonNormal = 2130772127;
+			
+			// aapt resource value: 0x7f01009d
+			public static int colorControlActivated = 2130772125;
+			
+			// aapt resource value: 0x7f01009e
+			public static int colorControlHighlight = 2130772126;
+			
+			// aapt resource value: 0x7f01009c
+			public static int colorControlNormal = 2130772124;
 			
 			// aapt resource value: 0x7f010099
-			public static int windowMinWidthMajor = 2130772121;
+			public static int colorPrimary = 2130772121;
 			
 			// aapt resource value: 0x7f01009a
-			public static int windowMinWidthMinor = 2130772122;
+			public static int colorPrimaryDark = 2130772122;
+			
+			// aapt resource value: 0x7f0100a0
+			public static int colorSwitchThumbNormal = 2130772128;
+			
+			// aapt resource value: 0x7f0100db
+			public static int commitIcon = 2130772187;
+			
+			// aapt resource value: 0x7f010033
+			public static int contentInsetEnd = 2130772019;
+			
+			// aapt resource value: 0x7f010037
+			public static int contentInsetEndWithActions = 2130772023;
+			
+			// aapt resource value: 0x7f010034
+			public static int contentInsetLeft = 2130772020;
+			
+			// aapt resource value: 0x7f010035
+			public static int contentInsetRight = 2130772021;
+			
+			// aapt resource value: 0x7f010032
+			public static int contentInsetStart = 2130772018;
+			
+			// aapt resource value: 0x7f010036
+			public static int contentInsetStartWithNavigation = 2130772022;
+			
+			// aapt resource value: 0x7f010017
+			public static int contentPadding = 2130771991;
+			
+			// aapt resource value: 0x7f01001b
+			public static int contentPaddingBottom = 2130771995;
+			
+			// aapt resource value: 0x7f010018
+			public static int contentPaddingLeft = 2130771992;
+			
+			// aapt resource value: 0x7f010019
+			public static int contentPaddingRight = 2130771993;
+			
+			// aapt resource value: 0x7f01001a
+			public static int contentPaddingTop = 2130771994;
+			
+			// aapt resource value: 0x7f01010f
+			public static int contentScrim = 2130772239;
+			
+			// aapt resource value: 0x7f0100a1
+			public static int controlBackground = 2130772129;
+			
+			// aapt resource value: 0x7f010148
+			public static int counterEnabled = 2130772296;
+			
+			// aapt resource value: 0x7f010149
+			public static int counterMaxLength = 2130772297;
+			
+			// aapt resource value: 0x7f01014b
+			public static int counterOverflowTextAppearance = 2130772299;
+			
+			// aapt resource value: 0x7f01014a
+			public static int counterTextAppearance = 2130772298;
+			
+			// aapt resource value: 0x7f01002b
+			public static int customNavigationLayout = 2130772011;
+			
+			// aapt resource value: 0x7f0100d5
+			public static int defaultQueryHint = 2130772181;
+			
+			// aapt resource value: 0x7f010072
+			public static int dialogPreferredPadding = 2130772082;
+			
+			// aapt resource value: 0x7f010071
+			public static int dialogTheme = 2130772081;
+			
+			// aapt resource value: 0x7f010021
+			public static int displayOptions = 2130772001;
+			
+			// aapt resource value: 0x7f010027
+			public static int divider = 2130772007;
+			
+			// aapt resource value: 0x7f01007f
+			public static int dividerHorizontal = 2130772095;
+			
+			// aapt resource value: 0x7f0100c7
+			public static int dividerPadding = 2130772167;
+			
+			// aapt resource value: 0x7f01007e
+			public static int dividerVertical = 2130772094;
+			
+			// aapt resource value: 0x7f0100bf
+			public static int drawableSize = 2130772159;
+			
+			// aapt resource value: 0x7f01001c
+			public static int drawerArrowStyle = 2130771996;
+			
+			// aapt resource value: 0x7f010091
+			public static int dropDownListViewStyle = 2130772113;
+			
+			// aapt resource value: 0x7f010075
+			public static int dropdownListPreferredItemHeight = 2130772085;
+			
+			// aapt resource value: 0x7f010086
+			public static int editTextBackground = 2130772102;
+			
+			// aapt resource value: 0x7f010085
+			public static int editTextColor = 2130772101;
+			
+			// aapt resource value: 0x7f0100b0
+			public static int editTextStyle = 2130772144;
+			
+			// aapt resource value: 0x7f010038
+			public static int elevation = 2130772024;
+			
+			// aapt resource value: 0x7f010146
+			public static int errorEnabled = 2130772294;
+			
+			// aapt resource value: 0x7f010147
+			public static int errorTextAppearance = 2130772295;
+			
+			// aapt resource value: 0x7f01003c
+			public static int expandActivityOverflowButtonDrawable = 2130772028;
+			
+			// aapt resource value: 0x7f010100
+			public static int expanded = 2130772224;
+			
+			// aapt resource value: 0x7f010115
+			public static int expandedTitleGravity = 2130772245;
+			
+			// aapt resource value: 0x7f010108
+			public static int expandedTitleMargin = 2130772232;
+			
+			// aapt resource value: 0x7f01010c
+			public static int expandedTitleMarginBottom = 2130772236;
+			
+			// aapt resource value: 0x7f01010b
+			public static int expandedTitleMarginEnd = 2130772235;
+			
+			// aapt resource value: 0x7f010109
+			public static int expandedTitleMarginStart = 2130772233;
+			
+			// aapt resource value: 0x7f01010a
+			public static int expandedTitleMarginTop = 2130772234;
+			
+			// aapt resource value: 0x7f01010d
+			public static int expandedTitleTextAppearance = 2130772237;
+			
+			// aapt resource value: 0x7f010010
+			public static int externalRouteEnabledDrawable = 2130771984;
+			
+			// aapt resource value: 0x7f010125
+			public static int fabSize = 2130772261;
+			
+			// aapt resource value: 0x7f01012a
+			public static int foregroundInsidePadding = 2130772266;
+			
+			// aapt resource value: 0x7f0100c0
+			public static int gapBetweenBars = 2130772160;
+			
+			// aapt resource value: 0x7f0100d7
+			public static int goIcon = 2130772183;
+			
+			// aapt resource value: 0x7f010130
+			public static int headerLayout = 2130772272;
+			
+			// aapt resource value: 0x7f01001d
+			public static int height = 2130771997;
+			
+			// aapt resource value: 0x7f010031
+			public static int hideOnContentScroll = 2130772017;
+			
+			// aapt resource value: 0x7f01014c
+			public static int hintAnimationEnabled = 2130772300;
+			
+			// aapt resource value: 0x7f010145
+			public static int hintEnabled = 2130772293;
+			
+			// aapt resource value: 0x7f010144
+			public static int hintTextAppearance = 2130772292;
+			
+			// aapt resource value: 0x7f010077
+			public static int homeAsUpIndicator = 2130772087;
+			
+			// aapt resource value: 0x7f01002c
+			public static int homeLayout = 2130772012;
+			
+			// aapt resource value: 0x7f010025
+			public static int icon = 2130772005;
+			
+			// aapt resource value: 0x7f0100d3
+			public static int iconifiedByDefault = 2130772179;
+			
+			// aapt resource value: 0x7f010087
+			public static int imageButtonStyle = 2130772103;
+			
+			// aapt resource value: 0x7f01002e
+			public static int indeterminateProgressStyle = 2130772014;
+			
+			// aapt resource value: 0x7f01003b
+			public static int initialActivityCount = 2130772027;
+			
+			// aapt resource value: 0x7f010131
+			public static int insetForeground = 2130772273;
+			
+			// aapt resource value: 0x7f01001e
+			public static int isLightTheme = 2130771998;
+			
+			// aapt resource value: 0x7f01012e
+			public static int itemBackground = 2130772270;
+			
+			// aapt resource value: 0x7f01012c
+			public static int itemIconTint = 2130772268;
+			
+			// aapt resource value: 0x7f010030
+			public static int itemPadding = 2130772016;
+			
+			// aapt resource value: 0x7f01012f
+			public static int itemTextAppearance = 2130772271;
+			
+			// aapt resource value: 0x7f01012d
+			public static int itemTextColor = 2130772269;
+			
+			// aapt resource value: 0x7f010119
+			public static int keylines = 2130772249;
+			
+			// aapt resource value: 0x7f0100d2
+			public static int layout = 2130772178;
+			
+			// aapt resource value: 0x7f010000
+			public static int layoutManager = 2130771968;
+			
+			// aapt resource value: 0x7f01011c
+			public static int layout_anchor = 2130772252;
+			
+			// aapt resource value: 0x7f01011e
+			public static int layout_anchorGravity = 2130772254;
+			
+			// aapt resource value: 0x7f01011b
+			public static int layout_behavior = 2130772251;
+			
+			// aapt resource value: 0x7f010117
+			public static int layout_collapseMode = 2130772247;
+			
+			// aapt resource value: 0x7f010118
+			public static int layout_collapseParallaxMultiplier = 2130772248;
+			
+			// aapt resource value: 0x7f010120
+			public static int layout_dodgeInsetEdges = 2130772256;
+			
+			// aapt resource value: 0x7f01011f
+			public static int layout_insetEdge = 2130772255;
+			
+			// aapt resource value: 0x7f01011d
+			public static int layout_keyline = 2130772253;
+			
+			// aapt resource value: 0x7f010103
+			public static int layout_scrollFlags = 2130772227;
+			
+			// aapt resource value: 0x7f010104
+			public static int layout_scrollInterpolator = 2130772228;
+			
+			// aapt resource value: 0x7f010098
+			public static int listChoiceBackgroundIndicator = 2130772120;
+			
+			// aapt resource value: 0x7f010073
+			public static int listDividerAlertDialog = 2130772083;
+			
+			// aapt resource value: 0x7f010041
+			public static int listItemLayout = 2130772033;
+			
+			// aapt resource value: 0x7f01003e
+			public static int listLayout = 2130772030;
+			
+			// aapt resource value: 0x7f0100b8
+			public static int listMenuViewStyle = 2130772152;
 			
 			// aapt resource value: 0x7f010092
-			public static int windowNoTitle = 2130772114;
+			public static int listPopupWindowStyle = 2130772114;
+			
+			// aapt resource value: 0x7f01008c
+			public static int listPreferredItemHeight = 2130772108;
+			
+			// aapt resource value: 0x7f01008e
+			public static int listPreferredItemHeightLarge = 2130772110;
+			
+			// aapt resource value: 0x7f01008d
+			public static int listPreferredItemHeightSmall = 2130772109;
+			
+			// aapt resource value: 0x7f01008f
+			public static int listPreferredItemPaddingLeft = 2130772111;
+			
+			// aapt resource value: 0x7f010090
+			public static int listPreferredItemPaddingRight = 2130772112;
+			
+			// aapt resource value: 0x7f010026
+			public static int logo = 2130772006;
+			
+			// aapt resource value: 0x7f0100f8
+			public static int logoDescription = 2130772216;
+			
+			// aapt resource value: 0x7f010133
+			public static int maxActionInlineWidth = 2130772275;
+			
+			// aapt resource value: 0x7f0100f2
+			public static int maxButtonHeight = 2130772210;
+			
+			// aapt resource value: 0x7f0100c5
+			public static int measureWithLargestChild = 2130772165;
+			
+			// aapt resource value: 0x7f010004
+			public static int mediaRouteAudioTrackDrawable = 2130771972;
+			
+			// aapt resource value: 0x7f010005
+			public static int mediaRouteButtonStyle = 2130771973;
+			
+			// aapt resource value: 0x7f010006
+			public static int mediaRouteCloseDrawable = 2130771974;
+			
+			// aapt resource value: 0x7f010007
+			public static int mediaRouteControlPanelThemeOverlay = 2130771975;
+			
+			// aapt resource value: 0x7f010008
+			public static int mediaRouteDefaultIconDrawable = 2130771976;
+			
+			// aapt resource value: 0x7f010009
+			public static int mediaRoutePauseDrawable = 2130771977;
+			
+			// aapt resource value: 0x7f01000a
+			public static int mediaRoutePlayDrawable = 2130771978;
+			
+			// aapt resource value: 0x7f01000b
+			public static int mediaRouteSpeakerGroupIconDrawable = 2130771979;
+			
+			// aapt resource value: 0x7f01000c
+			public static int mediaRouteSpeakerIconDrawable = 2130771980;
+			
+			// aapt resource value: 0x7f01000d
+			public static int mediaRouteStopDrawable = 2130771981;
+			
+			// aapt resource value: 0x7f01000e
+			public static int mediaRouteTheme = 2130771982;
+			
+			// aapt resource value: 0x7f01000f
+			public static int mediaRouteTvIconDrawable = 2130771983;
+			
+			// aapt resource value: 0x7f01012b
+			public static int menu = 2130772267;
+			
+			// aapt resource value: 0x7f01003f
+			public static int multiChoiceItemLayout = 2130772031;
+			
+			// aapt resource value: 0x7f0100f7
+			public static int navigationContentDescription = 2130772215;
+			
+			// aapt resource value: 0x7f0100f6
+			public static int navigationIcon = 2130772214;
+			
+			// aapt resource value: 0x7f010020
+			public static int navigationMode = 2130772000;
+			
+			// aapt resource value: 0x7f0100ce
+			public static int overlapAnchor = 2130772174;
+			
+			// aapt resource value: 0x7f0100d0
+			public static int paddingBottomNoButtons = 2130772176;
+			
+			// aapt resource value: 0x7f0100fc
+			public static int paddingEnd = 2130772220;
+			
+			// aapt resource value: 0x7f0100fb
+			public static int paddingStart = 2130772219;
+			
+			// aapt resource value: 0x7f0100d1
+			public static int paddingTopNoTitle = 2130772177;
+			
+			// aapt resource value: 0x7f010095
+			public static int panelBackground = 2130772117;
+			
+			// aapt resource value: 0x7f010097
+			public static int panelMenuListTheme = 2130772119;
+			
+			// aapt resource value: 0x7f010096
+			public static int panelMenuListWidth = 2130772118;
+			
+			// aapt resource value: 0x7f01014f
+			public static int passwordToggleContentDescription = 2130772303;
+			
+			// aapt resource value: 0x7f01014e
+			public static int passwordToggleDrawable = 2130772302;
+			
+			// aapt resource value: 0x7f01014d
+			public static int passwordToggleEnabled = 2130772301;
+			
+			// aapt resource value: 0x7f010150
+			public static int passwordToggleTint = 2130772304;
+			
+			// aapt resource value: 0x7f010151
+			public static int passwordToggleTintMode = 2130772305;
+			
+			// aapt resource value: 0x7f010083
+			public static int popupMenuStyle = 2130772099;
+			
+			// aapt resource value: 0x7f010039
+			public static int popupTheme = 2130772025;
+			
+			// aapt resource value: 0x7f010084
+			public static int popupWindowStyle = 2130772100;
+			
+			// aapt resource value: 0x7f0100cc
+			public static int preserveIconSpacing = 2130772172;
+			
+			// aapt resource value: 0x7f010126
+			public static int pressedTranslationZ = 2130772262;
+			
+			// aapt resource value: 0x7f01002f
+			public static int progressBarPadding = 2130772015;
+			
+			// aapt resource value: 0x7f01002d
+			public static int progressBarStyle = 2130772013;
+			
+			// aapt resource value: 0x7f0100dd
+			public static int queryBackground = 2130772189;
+			
+			// aapt resource value: 0x7f0100d4
+			public static int queryHint = 2130772180;
+			
+			// aapt resource value: 0x7f0100b1
+			public static int radioButtonStyle = 2130772145;
+			
+			// aapt resource value: 0x7f0100b2
+			public static int ratingBarStyle = 2130772146;
+			
+			// aapt resource value: 0x7f0100b3
+			public static int ratingBarStyleIndicator = 2130772147;
+			
+			// aapt resource value: 0x7f0100b4
+			public static int ratingBarStyleSmall = 2130772148;
+			
+			// aapt resource value: 0x7f010002
+			public static int reverseLayout = 2130771970;
+			
+			// aapt resource value: 0x7f010124
+			public static int rippleColor = 2130772260;
+			
+			// aapt resource value: 0x7f010113
+			public static int scrimAnimationDuration = 2130772243;
+			
+			// aapt resource value: 0x7f010112
+			public static int scrimVisibleHeightTrigger = 2130772242;
+			
+			// aapt resource value: 0x7f0100d9
+			public static int searchHintIcon = 2130772185;
+			
+			// aapt resource value: 0x7f0100d8
+			public static int searchIcon = 2130772184;
+			
+			// aapt resource value: 0x7f01008b
+			public static int searchViewStyle = 2130772107;
+			
+			// aapt resource value: 0x7f0100b5
+			public static int seekBarStyle = 2130772149;
+			
+			// aapt resource value: 0x7f01007b
+			public static int selectableItemBackground = 2130772091;
+			
+			// aapt resource value: 0x7f01007c
+			public static int selectableItemBackgroundBorderless = 2130772092;
+			
+			// aapt resource value: 0x7f0100c8
+			public static int showAsAction = 2130772168;
+			
+			// aapt resource value: 0x7f0100c6
+			public static int showDividers = 2130772166;
+			
+			// aapt resource value: 0x7f0100e9
+			public static int showText = 2130772201;
+			
+			// aapt resource value: 0x7f010042
+			public static int showTitle = 2130772034;
+			
+			// aapt resource value: 0x7f010040
+			public static int singleChoiceItemLayout = 2130772032;
+			
+			// aapt resource value: 0x7f010001
+			public static int spanCount = 2130771969;
+			
+			// aapt resource value: 0x7f0100be
+			public static int spinBars = 2130772158;
+			
+			// aapt resource value: 0x7f010076
+			public static int spinnerDropDownItemStyle = 2130772086;
+			
+			// aapt resource value: 0x7f0100b6
+			public static int spinnerStyle = 2130772150;
+			
+			// aapt resource value: 0x7f0100e8
+			public static int splitTrack = 2130772200;
+			
+			// aapt resource value: 0x7f010043
+			public static int srcCompat = 2130772035;
+			
+			// aapt resource value: 0x7f010003
+			public static int stackFromEnd = 2130771971;
+			
+			// aapt resource value: 0x7f0100cf
+			public static int state_above_anchor = 2130772175;
+			
+			// aapt resource value: 0x7f010101
+			public static int state_collapsed = 2130772225;
+			
+			// aapt resource value: 0x7f010102
+			public static int state_collapsible = 2130772226;
+			
+			// aapt resource value: 0x7f01011a
+			public static int statusBarBackground = 2130772250;
+			
+			// aapt resource value: 0x7f010110
+			public static int statusBarScrim = 2130772240;
+			
+			// aapt resource value: 0x7f0100cd
+			public static int subMenuArrow = 2130772173;
+			
+			// aapt resource value: 0x7f0100de
+			public static int submitBackground = 2130772190;
+			
+			// aapt resource value: 0x7f010022
+			public static int subtitle = 2130772002;
+			
+			// aapt resource value: 0x7f0100eb
+			public static int subtitleTextAppearance = 2130772203;
+			
+			// aapt resource value: 0x7f0100fa
+			public static int subtitleTextColor = 2130772218;
+			
+			// aapt resource value: 0x7f010024
+			public static int subtitleTextStyle = 2130772004;
+			
+			// aapt resource value: 0x7f0100dc
+			public static int suggestionRowLayout = 2130772188;
+			
+			// aapt resource value: 0x7f0100e6
+			public static int switchMinWidth = 2130772198;
+			
+			// aapt resource value: 0x7f0100e7
+			public static int switchPadding = 2130772199;
+			
+			// aapt resource value: 0x7f0100b7
+			public static int switchStyle = 2130772151;
+			
+			// aapt resource value: 0x7f0100e5
+			public static int switchTextAppearance = 2130772197;
+			
+			// aapt resource value: 0x7f010137
+			public static int tabBackground = 2130772279;
+			
+			// aapt resource value: 0x7f010136
+			public static int tabContentStart = 2130772278;
+			
+			// aapt resource value: 0x7f010139
+			public static int tabGravity = 2130772281;
+			
+			// aapt resource value: 0x7f010134
+			public static int tabIndicatorColor = 2130772276;
+			
+			// aapt resource value: 0x7f010135
+			public static int tabIndicatorHeight = 2130772277;
+			
+			// aapt resource value: 0x7f01013b
+			public static int tabMaxWidth = 2130772283;
+			
+			// aapt resource value: 0x7f01013a
+			public static int tabMinWidth = 2130772282;
+			
+			// aapt resource value: 0x7f010138
+			public static int tabMode = 2130772280;
+			
+			// aapt resource value: 0x7f010143
+			public static int tabPadding = 2130772291;
+			
+			// aapt resource value: 0x7f010142
+			public static int tabPaddingBottom = 2130772290;
+			
+			// aapt resource value: 0x7f010141
+			public static int tabPaddingEnd = 2130772289;
+			
+			// aapt resource value: 0x7f01013f
+			public static int tabPaddingStart = 2130772287;
+			
+			// aapt resource value: 0x7f010140
+			public static int tabPaddingTop = 2130772288;
+			
+			// aapt resource value: 0x7f01013e
+			public static int tabSelectedTextColor = 2130772286;
+			
+			// aapt resource value: 0x7f01013c
+			public static int tabTextAppearance = 2130772284;
+			
+			// aapt resource value: 0x7f01013d
+			public static int tabTextColor = 2130772285;
+			
+			// aapt resource value: 0x7f010047
+			public static int textAllCaps = 2130772039;
+			
+			// aapt resource value: 0x7f01006e
+			public static int textAppearanceLargePopupMenu = 2130772078;
+			
+			// aapt resource value: 0x7f010093
+			public static int textAppearanceListItem = 2130772115;
+			
+			// aapt resource value: 0x7f010094
+			public static int textAppearanceListItemSmall = 2130772116;
+			
+			// aapt resource value: 0x7f010070
+			public static int textAppearancePopupMenuHeader = 2130772080;
+			
+			// aapt resource value: 0x7f010089
+			public static int textAppearanceSearchResultSubtitle = 2130772105;
+			
+			// aapt resource value: 0x7f010088
+			public static int textAppearanceSearchResultTitle = 2130772104;
+			
+			// aapt resource value: 0x7f01006f
+			public static int textAppearanceSmallPopupMenu = 2130772079;
+			
+			// aapt resource value: 0x7f0100a7
+			public static int textColorAlertDialogListItem = 2130772135;
+			
+			// aapt resource value: 0x7f010123
+			public static int textColorError = 2130772259;
+			
+			// aapt resource value: 0x7f01008a
+			public static int textColorSearchUrl = 2130772106;
+			
+			// aapt resource value: 0x7f0100fd
+			public static int theme = 2130772221;
+			
+			// aapt resource value: 0x7f0100c4
+			public static int thickness = 2130772164;
+			
+			// aapt resource value: 0x7f0100e4
+			public static int thumbTextPadding = 2130772196;
+			
+			// aapt resource value: 0x7f0100df
+			public static int thumbTint = 2130772191;
+			
+			// aapt resource value: 0x7f0100e0
+			public static int thumbTintMode = 2130772192;
+			
+			// aapt resource value: 0x7f010044
+			public static int tickMark = 2130772036;
+			
+			// aapt resource value: 0x7f010045
+			public static int tickMarkTint = 2130772037;
+			
+			// aapt resource value: 0x7f010046
+			public static int tickMarkTintMode = 2130772038;
+			
+			// aapt resource value: 0x7f01001f
+			public static int title = 2130771999;
+			
+			// aapt resource value: 0x7f010116
+			public static int titleEnabled = 2130772246;
+			
+			// aapt resource value: 0x7f0100ec
+			public static int titleMargin = 2130772204;
+			
+			// aapt resource value: 0x7f0100f0
+			public static int titleMarginBottom = 2130772208;
+			
+			// aapt resource value: 0x7f0100ee
+			public static int titleMarginEnd = 2130772206;
+			
+			// aapt resource value: 0x7f0100ed
+			public static int titleMarginStart = 2130772205;
+			
+			// aapt resource value: 0x7f0100ef
+			public static int titleMarginTop = 2130772207;
+			
+			// aapt resource value: 0x7f0100f1
+			public static int titleMargins = 2130772209;
+			
+			// aapt resource value: 0x7f0100ea
+			public static int titleTextAppearance = 2130772202;
+			
+			// aapt resource value: 0x7f0100f9
+			public static int titleTextColor = 2130772217;
+			
+			// aapt resource value: 0x7f010023
+			public static int titleTextStyle = 2130772003;
+			
+			// aapt resource value: 0x7f010111
+			public static int toolbarId = 2130772241;
+			
+			// aapt resource value: 0x7f010082
+			public static int toolbarNavigationButtonStyle = 2130772098;
+			
+			// aapt resource value: 0x7f010081
+			public static int toolbarStyle = 2130772097;
+			
+			// aapt resource value: 0x7f0100e1
+			public static int track = 2130772193;
+			
+			// aapt resource value: 0x7f0100e2
+			public static int trackTint = 2130772194;
+			
+			// aapt resource value: 0x7f0100e3
+			public static int trackTintMode = 2130772195;
+			
+			// aapt resource value: 0x7f010128
+			public static int useCompatPadding = 2130772264;
+			
+			// aapt resource value: 0x7f0100da
+			public static int voiceIcon = 2130772186;
+			
+			// aapt resource value: 0x7f010048
+			public static int windowActionBar = 2130772040;
+			
+			// aapt resource value: 0x7f01004a
+			public static int windowActionBarOverlay = 2130772042;
+			
+			// aapt resource value: 0x7f01004b
+			public static int windowActionModeOverlay = 2130772043;
+			
+			// aapt resource value: 0x7f01004f
+			public static int windowFixedHeightMajor = 2130772047;
+			
+			// aapt resource value: 0x7f01004d
+			public static int windowFixedHeightMinor = 2130772045;
+			
+			// aapt resource value: 0x7f01004c
+			public static int windowFixedWidthMajor = 2130772044;
+			
+			// aapt resource value: 0x7f01004e
+			public static int windowFixedWidthMinor = 2130772046;
+			
+			// aapt resource value: 0x7f010050
+			public static int windowMinWidthMajor = 2130772048;
+			
+			// aapt resource value: 0x7f010051
+			public static int windowMinWidthMinor = 2130772049;
+			
+			// aapt resource value: 0x7f010049
+			public static int windowNoTitle = 2130772041;
 			
 			static Attribute()
 			{
@@ -1049,29 +1131,20 @@ namespace XFGloss.Droid
 		public partial class Boolean
 		{
 			
-			// aapt resource value: 0x7f0c0003
-			public static int abc_action_bar_embed_tabs = 2131492867;
+			// aapt resource value: 0x7f0d0000
+			public static int abc_action_bar_embed_tabs = 2131558400;
 			
-			// aapt resource value: 0x7f0c0001
-			public static int abc_action_bar_embed_tabs_pre_jb = 2131492865;
+			// aapt resource value: 0x7f0d0001
+			public static int abc_allow_stacked_button_bar = 2131558401;
 			
-			// aapt resource value: 0x7f0c0004
-			public static int abc_action_bar_expanded_action_views_exclusive = 2131492868;
+			// aapt resource value: 0x7f0d0002
+			public static int abc_config_actionMenuItemAllCaps = 2131558402;
 			
-			// aapt resource value: 0x7f0c0000
-			public static int abc_allow_stacked_button_bar = 2131492864;
+			// aapt resource value: 0x7f0d0003
+			public static int abc_config_closeDialogWhenTouchOutside = 2131558403;
 			
-			// aapt resource value: 0x7f0c0005
-			public static int abc_config_actionMenuItemAllCaps = 2131492869;
-			
-			// aapt resource value: 0x7f0c0002
-			public static int abc_config_allowActionMenuItemTextWithIcon = 2131492866;
-			
-			// aapt resource value: 0x7f0c0006
-			public static int abc_config_closeDialogWhenTouchOutside = 2131492870;
-			
-			// aapt resource value: 0x7f0c0007
-			public static int abc_config_showMenuShortcutsWhenKeyboardPresent = 2131492871;
+			// aapt resource value: 0x7f0d0004
+			public static int abc_config_showMenuShortcutsWhenKeyboardPresent = 2131558404;
 			
 			static Boolean()
 			{
@@ -1086,257 +1159,302 @@ namespace XFGloss.Droid
 		public partial class Color
 		{
 			
-			// aapt resource value: 0x7f0a0048
-			public static int abc_background_cache_hint_selector_material_dark = 2131361864;
+			// aapt resource value: 0x7f0c004a
+			public static int abc_background_cache_hint_selector_material_dark = 2131492938;
 			
-			// aapt resource value: 0x7f0a0049
-			public static int abc_background_cache_hint_selector_material_light = 2131361865;
+			// aapt resource value: 0x7f0c004b
+			public static int abc_background_cache_hint_selector_material_light = 2131492939;
 			
-			// aapt resource value: 0x7f0a004a
-			public static int abc_color_highlight_material = 2131361866;
+			// aapt resource value: 0x7f0c004c
+			public static int abc_btn_colored_borderless_text_material = 2131492940;
 			
-			// aapt resource value: 0x7f0a000e
-			public static int abc_input_method_navigation_guard = 2131361806;
+			// aapt resource value: 0x7f0c004d
+			public static int abc_btn_colored_text_material = 2131492941;
 			
-			// aapt resource value: 0x7f0a004b
-			public static int abc_primary_text_disable_only_material_dark = 2131361867;
+			// aapt resource value: 0x7f0c004e
+			public static int abc_color_highlight_material = 2131492942;
 			
-			// aapt resource value: 0x7f0a004c
-			public static int abc_primary_text_disable_only_material_light = 2131361868;
+			// aapt resource value: 0x7f0c004f
+			public static int abc_hint_foreground_material_dark = 2131492943;
 			
-			// aapt resource value: 0x7f0a004d
-			public static int abc_primary_text_material_dark = 2131361869;
+			// aapt resource value: 0x7f0c0050
+			public static int abc_hint_foreground_material_light = 2131492944;
 			
-			// aapt resource value: 0x7f0a004e
-			public static int abc_primary_text_material_light = 2131361870;
+			// aapt resource value: 0x7f0c0005
+			public static int abc_input_method_navigation_guard = 2131492869;
 			
-			// aapt resource value: 0x7f0a004f
-			public static int abc_search_url_text = 2131361871;
+			// aapt resource value: 0x7f0c0051
+			public static int abc_primary_text_disable_only_material_dark = 2131492945;
 			
-			// aapt resource value: 0x7f0a000f
-			public static int abc_search_url_text_normal = 2131361807;
+			// aapt resource value: 0x7f0c0052
+			public static int abc_primary_text_disable_only_material_light = 2131492946;
 			
-			// aapt resource value: 0x7f0a0010
-			public static int abc_search_url_text_pressed = 2131361808;
+			// aapt resource value: 0x7f0c0053
+			public static int abc_primary_text_material_dark = 2131492947;
 			
-			// aapt resource value: 0x7f0a0011
-			public static int abc_search_url_text_selected = 2131361809;
+			// aapt resource value: 0x7f0c0054
+			public static int abc_primary_text_material_light = 2131492948;
 			
-			// aapt resource value: 0x7f0a0050
-			public static int abc_secondary_text_material_dark = 2131361872;
+			// aapt resource value: 0x7f0c0055
+			public static int abc_search_url_text = 2131492949;
 			
-			// aapt resource value: 0x7f0a0051
-			public static int abc_secondary_text_material_light = 2131361873;
+			// aapt resource value: 0x7f0c0006
+			public static int abc_search_url_text_normal = 2131492870;
 			
-			// aapt resource value: 0x7f0a0012
-			public static int accent_material_dark = 2131361810;
+			// aapt resource value: 0x7f0c0007
+			public static int abc_search_url_text_pressed = 2131492871;
 			
-			// aapt resource value: 0x7f0a0013
-			public static int accent_material_light = 2131361811;
+			// aapt resource value: 0x7f0c0008
+			public static int abc_search_url_text_selected = 2131492872;
 			
-			// aapt resource value: 0x7f0a0014
-			public static int background_floating_material_dark = 2131361812;
+			// aapt resource value: 0x7f0c0056
+			public static int abc_secondary_text_material_dark = 2131492950;
 			
-			// aapt resource value: 0x7f0a0015
-			public static int background_floating_material_light = 2131361813;
+			// aapt resource value: 0x7f0c0057
+			public static int abc_secondary_text_material_light = 2131492951;
 			
-			// aapt resource value: 0x7f0a0016
-			public static int background_material_dark = 2131361814;
+			// aapt resource value: 0x7f0c0058
+			public static int abc_tint_btn_checkable = 2131492952;
 			
-			// aapt resource value: 0x7f0a0017
-			public static int background_material_light = 2131361815;
+			// aapt resource value: 0x7f0c0059
+			public static int abc_tint_default = 2131492953;
 			
-			// aapt resource value: 0x7f0a0018
-			public static int bright_foreground_disabled_material_dark = 2131361816;
+			// aapt resource value: 0x7f0c005a
+			public static int abc_tint_edittext = 2131492954;
 			
-			// aapt resource value: 0x7f0a0019
-			public static int bright_foreground_disabled_material_light = 2131361817;
+			// aapt resource value: 0x7f0c005b
+			public static int abc_tint_seek_thumb = 2131492955;
 			
-			// aapt resource value: 0x7f0a001a
-			public static int bright_foreground_inverse_material_dark = 2131361818;
+			// aapt resource value: 0x7f0c005c
+			public static int abc_tint_spinner = 2131492956;
 			
-			// aapt resource value: 0x7f0a001b
-			public static int bright_foreground_inverse_material_light = 2131361819;
+			// aapt resource value: 0x7f0c005d
+			public static int abc_tint_switch_thumb = 2131492957;
 			
-			// aapt resource value: 0x7f0a001c
-			public static int bright_foreground_material_dark = 2131361820;
+			// aapt resource value: 0x7f0c005e
+			public static int abc_tint_switch_track = 2131492958;
 			
-			// aapt resource value: 0x7f0a001d
-			public static int bright_foreground_material_light = 2131361821;
+			// aapt resource value: 0x7f0c0009
+			public static int accent_material_dark = 2131492873;
 			
-			// aapt resource value: 0x7f0a001e
-			public static int button_material_dark = 2131361822;
+			// aapt resource value: 0x7f0c000a
+			public static int accent_material_light = 2131492874;
 			
-			// aapt resource value: 0x7f0a001f
-			public static int button_material_light = 2131361823;
+			// aapt resource value: 0x7f0c000b
+			public static int background_floating_material_dark = 2131492875;
 			
-			// aapt resource value: 0x7f0a0000
-			public static int cardview_dark_background = 2131361792;
+			// aapt resource value: 0x7f0c000c
+			public static int background_floating_material_light = 2131492876;
 			
-			// aapt resource value: 0x7f0a0001
-			public static int cardview_light_background = 2131361793;
+			// aapt resource value: 0x7f0c000d
+			public static int background_material_dark = 2131492877;
 			
-			// aapt resource value: 0x7f0a0002
-			public static int cardview_shadow_end_color = 2131361794;
+			// aapt resource value: 0x7f0c000e
+			public static int background_material_light = 2131492878;
 			
-			// aapt resource value: 0x7f0a0003
-			public static int cardview_shadow_start_color = 2131361795;
+			// aapt resource value: 0x7f0c000f
+			public static int bright_foreground_disabled_material_dark = 2131492879;
 			
-			// aapt resource value: 0x7f0a0004
-			public static int design_fab_shadow_end_color = 2131361796;
+			// aapt resource value: 0x7f0c0010
+			public static int bright_foreground_disabled_material_light = 2131492880;
 			
-			// aapt resource value: 0x7f0a0005
-			public static int design_fab_shadow_mid_color = 2131361797;
+			// aapt resource value: 0x7f0c0011
+			public static int bright_foreground_inverse_material_dark = 2131492881;
 			
-			// aapt resource value: 0x7f0a0006
-			public static int design_fab_shadow_start_color = 2131361798;
+			// aapt resource value: 0x7f0c0012
+			public static int bright_foreground_inverse_material_light = 2131492882;
 			
-			// aapt resource value: 0x7f0a0007
-			public static int design_fab_stroke_end_inner_color = 2131361799;
+			// aapt resource value: 0x7f0c0013
+			public static int bright_foreground_material_dark = 2131492883;
 			
-			// aapt resource value: 0x7f0a0008
-			public static int design_fab_stroke_end_outer_color = 2131361800;
+			// aapt resource value: 0x7f0c0014
+			public static int bright_foreground_material_light = 2131492884;
 			
-			// aapt resource value: 0x7f0a0009
-			public static int design_fab_stroke_top_inner_color = 2131361801;
+			// aapt resource value: 0x7f0c0015
+			public static int button_material_dark = 2131492885;
 			
-			// aapt resource value: 0x7f0a000a
-			public static int design_fab_stroke_top_outer_color = 2131361802;
+			// aapt resource value: 0x7f0c0016
+			public static int button_material_light = 2131492886;
 			
-			// aapt resource value: 0x7f0a000b
-			public static int design_snackbar_background_color = 2131361803;
+			// aapt resource value: 0x7f0c0000
+			public static int cardview_dark_background = 2131492864;
 			
-			// aapt resource value: 0x7f0a000c
-			public static int design_textinput_error_color_dark = 2131361804;
+			// aapt resource value: 0x7f0c0001
+			public static int cardview_light_background = 2131492865;
 			
-			// aapt resource value: 0x7f0a000d
-			public static int design_textinput_error_color_light = 2131361805;
+			// aapt resource value: 0x7f0c0002
+			public static int cardview_shadow_end_color = 2131492866;
 			
-			// aapt resource value: 0x7f0a0020
-			public static int dim_foreground_disabled_material_dark = 2131361824;
+			// aapt resource value: 0x7f0c0003
+			public static int cardview_shadow_start_color = 2131492867;
 			
-			// aapt resource value: 0x7f0a0021
-			public static int dim_foreground_disabled_material_light = 2131361825;
+			// aapt resource value: 0x7f0c003f
+			public static int design_bottom_navigation_shadow_color = 2131492927;
 			
-			// aapt resource value: 0x7f0a0022
-			public static int dim_foreground_material_dark = 2131361826;
+			// aapt resource value: 0x7f0c005f
+			public static int design_error = 2131492959;
 			
-			// aapt resource value: 0x7f0a0023
-			public static int dim_foreground_material_light = 2131361827;
+			// aapt resource value: 0x7f0c0040
+			public static int design_fab_shadow_end_color = 2131492928;
 			
-			// aapt resource value: 0x7f0a0024
-			public static int foreground_material_dark = 2131361828;
+			// aapt resource value: 0x7f0c0041
+			public static int design_fab_shadow_mid_color = 2131492929;
 			
-			// aapt resource value: 0x7f0a0025
-			public static int foreground_material_light = 2131361829;
+			// aapt resource value: 0x7f0c0042
+			public static int design_fab_shadow_start_color = 2131492930;
 			
-			// aapt resource value: 0x7f0a0026
-			public static int highlighted_text_material_dark = 2131361830;
+			// aapt resource value: 0x7f0c0043
+			public static int design_fab_stroke_end_inner_color = 2131492931;
 			
-			// aapt resource value: 0x7f0a0027
-			public static int highlighted_text_material_light = 2131361831;
+			// aapt resource value: 0x7f0c0044
+			public static int design_fab_stroke_end_outer_color = 2131492932;
 			
-			// aapt resource value: 0x7f0a0028
-			public static int hint_foreground_material_dark = 2131361832;
+			// aapt resource value: 0x7f0c0045
+			public static int design_fab_stroke_top_inner_color = 2131492933;
 			
-			// aapt resource value: 0x7f0a0029
-			public static int hint_foreground_material_light = 2131361833;
+			// aapt resource value: 0x7f0c0046
+			public static int design_fab_stroke_top_outer_color = 2131492934;
 			
-			// aapt resource value: 0x7f0a002a
-			public static int material_blue_grey_800 = 2131361834;
+			// aapt resource value: 0x7f0c0047
+			public static int design_snackbar_background_color = 2131492935;
 			
-			// aapt resource value: 0x7f0a002b
-			public static int material_blue_grey_900 = 2131361835;
+			// aapt resource value: 0x7f0c0048
+			public static int design_textinput_error_color_dark = 2131492936;
 			
-			// aapt resource value: 0x7f0a002c
-			public static int material_blue_grey_950 = 2131361836;
+			// aapt resource value: 0x7f0c0049
+			public static int design_textinput_error_color_light = 2131492937;
 			
-			// aapt resource value: 0x7f0a002d
-			public static int material_deep_teal_200 = 2131361837;
+			// aapt resource value: 0x7f0c0060
+			public static int design_tint_password_toggle = 2131492960;
 			
-			// aapt resource value: 0x7f0a002e
-			public static int material_deep_teal_500 = 2131361838;
+			// aapt resource value: 0x7f0c0017
+			public static int dim_foreground_disabled_material_dark = 2131492887;
 			
-			// aapt resource value: 0x7f0a002f
-			public static int material_grey_100 = 2131361839;
+			// aapt resource value: 0x7f0c0018
+			public static int dim_foreground_disabled_material_light = 2131492888;
 			
-			// aapt resource value: 0x7f0a0030
-			public static int material_grey_300 = 2131361840;
+			// aapt resource value: 0x7f0c0019
+			public static int dim_foreground_material_dark = 2131492889;
 			
-			// aapt resource value: 0x7f0a0031
-			public static int material_grey_50 = 2131361841;
+			// aapt resource value: 0x7f0c001a
+			public static int dim_foreground_material_light = 2131492890;
 			
-			// aapt resource value: 0x7f0a0032
-			public static int material_grey_600 = 2131361842;
+			// aapt resource value: 0x7f0c001b
+			public static int foreground_material_dark = 2131492891;
 			
-			// aapt resource value: 0x7f0a0033
-			public static int material_grey_800 = 2131361843;
+			// aapt resource value: 0x7f0c001c
+			public static int foreground_material_light = 2131492892;
 			
-			// aapt resource value: 0x7f0a0034
-			public static int material_grey_850 = 2131361844;
+			// aapt resource value: 0x7f0c001d
+			public static int highlighted_text_material_dark = 2131492893;
 			
-			// aapt resource value: 0x7f0a0035
-			public static int material_grey_900 = 2131361845;
+			// aapt resource value: 0x7f0c001e
+			public static int highlighted_text_material_light = 2131492894;
 			
-			// aapt resource value: 0x7f0a0036
-			public static int primary_dark_material_dark = 2131361846;
+			// aapt resource value: 0x7f0c001f
+			public static int material_blue_grey_800 = 2131492895;
 			
-			// aapt resource value: 0x7f0a0037
-			public static int primary_dark_material_light = 2131361847;
+			// aapt resource value: 0x7f0c0020
+			public static int material_blue_grey_900 = 2131492896;
 			
-			// aapt resource value: 0x7f0a0038
-			public static int primary_material_dark = 2131361848;
+			// aapt resource value: 0x7f0c0021
+			public static int material_blue_grey_950 = 2131492897;
 			
-			// aapt resource value: 0x7f0a0039
-			public static int primary_material_light = 2131361849;
+			// aapt resource value: 0x7f0c0022
+			public static int material_deep_teal_200 = 2131492898;
 			
-			// aapt resource value: 0x7f0a003a
-			public static int primary_text_default_material_dark = 2131361850;
+			// aapt resource value: 0x7f0c0023
+			public static int material_deep_teal_500 = 2131492899;
 			
-			// aapt resource value: 0x7f0a003b
-			public static int primary_text_default_material_light = 2131361851;
+			// aapt resource value: 0x7f0c0024
+			public static int material_grey_100 = 2131492900;
 			
-			// aapt resource value: 0x7f0a003c
-			public static int primary_text_disabled_material_dark = 2131361852;
+			// aapt resource value: 0x7f0c0025
+			public static int material_grey_300 = 2131492901;
 			
-			// aapt resource value: 0x7f0a003d
-			public static int primary_text_disabled_material_light = 2131361853;
+			// aapt resource value: 0x7f0c0026
+			public static int material_grey_50 = 2131492902;
 			
-			// aapt resource value: 0x7f0a003e
-			public static int ripple_material_dark = 2131361854;
+			// aapt resource value: 0x7f0c0027
+			public static int material_grey_600 = 2131492903;
 			
-			// aapt resource value: 0x7f0a003f
-			public static int ripple_material_light = 2131361855;
+			// aapt resource value: 0x7f0c0028
+			public static int material_grey_800 = 2131492904;
 			
-			// aapt resource value: 0x7f0a0040
-			public static int secondary_text_default_material_dark = 2131361856;
+			// aapt resource value: 0x7f0c0029
+			public static int material_grey_850 = 2131492905;
 			
-			// aapt resource value: 0x7f0a0041
-			public static int secondary_text_default_material_light = 2131361857;
+			// aapt resource value: 0x7f0c002a
+			public static int material_grey_900 = 2131492906;
 			
-			// aapt resource value: 0x7f0a0042
-			public static int secondary_text_disabled_material_dark = 2131361858;
+			// aapt resource value: 0x7f0c0004
+			public static int notification_action_color_filter = 2131492868;
 			
-			// aapt resource value: 0x7f0a0043
-			public static int secondary_text_disabled_material_light = 2131361859;
+			// aapt resource value: 0x7f0c002b
+			public static int notification_icon_bg_color = 2131492907;
 			
-			// aapt resource value: 0x7f0a0044
-			public static int switch_thumb_disabled_material_dark = 2131361860;
+			// aapt resource value: 0x7f0c002c
+			public static int notification_material_background_media_default_color = 2131492908;
 			
-			// aapt resource value: 0x7f0a0045
-			public static int switch_thumb_disabled_material_light = 2131361861;
+			// aapt resource value: 0x7f0c002d
+			public static int primary_dark_material_dark = 2131492909;
 			
-			// aapt resource value: 0x7f0a0052
-			public static int switch_thumb_material_dark = 2131361874;
+			// aapt resource value: 0x7f0c002e
+			public static int primary_dark_material_light = 2131492910;
 			
-			// aapt resource value: 0x7f0a0053
-			public static int switch_thumb_material_light = 2131361875;
+			// aapt resource value: 0x7f0c002f
+			public static int primary_material_dark = 2131492911;
 			
-			// aapt resource value: 0x7f0a0046
-			public static int switch_thumb_normal_material_dark = 2131361862;
+			// aapt resource value: 0x7f0c0030
+			public static int primary_material_light = 2131492912;
 			
-			// aapt resource value: 0x7f0a0047
-			public static int switch_thumb_normal_material_light = 2131361863;
+			// aapt resource value: 0x7f0c0031
+			public static int primary_text_default_material_dark = 2131492913;
+			
+			// aapt resource value: 0x7f0c0032
+			public static int primary_text_default_material_light = 2131492914;
+			
+			// aapt resource value: 0x7f0c0033
+			public static int primary_text_disabled_material_dark = 2131492915;
+			
+			// aapt resource value: 0x7f0c0034
+			public static int primary_text_disabled_material_light = 2131492916;
+			
+			// aapt resource value: 0x7f0c0035
+			public static int ripple_material_dark = 2131492917;
+			
+			// aapt resource value: 0x7f0c0036
+			public static int ripple_material_light = 2131492918;
+			
+			// aapt resource value: 0x7f0c0037
+			public static int secondary_text_default_material_dark = 2131492919;
+			
+			// aapt resource value: 0x7f0c0038
+			public static int secondary_text_default_material_light = 2131492920;
+			
+			// aapt resource value: 0x7f0c0039
+			public static int secondary_text_disabled_material_dark = 2131492921;
+			
+			// aapt resource value: 0x7f0c003a
+			public static int secondary_text_disabled_material_light = 2131492922;
+			
+			// aapt resource value: 0x7f0c003b
+			public static int switch_thumb_disabled_material_dark = 2131492923;
+			
+			// aapt resource value: 0x7f0c003c
+			public static int switch_thumb_disabled_material_light = 2131492924;
+			
+			// aapt resource value: 0x7f0c0061
+			public static int switch_thumb_material_dark = 2131492961;
+			
+			// aapt resource value: 0x7f0c0062
+			public static int switch_thumb_material_light = 2131492962;
+			
+			// aapt resource value: 0x7f0c003d
+			public static int switch_thumb_normal_material_dark = 2131492925;
+			
+			// aapt resource value: 0x7f0c003e
+			public static int switch_thumb_normal_material_light = 2131492926;
 			
 			static Color()
 			{
@@ -1351,353 +1469,449 @@ namespace XFGloss.Droid
 		public partial class Dimension
 		{
 			
-			// aapt resource value: 0x7f070036
-			public static int abc_action_bar_content_inset_material = 2131165238;
-			
-			// aapt resource value: 0x7f07002a
-			public static int abc_action_bar_default_height_material = 2131165226;
-			
-			// aapt resource value: 0x7f070037
-			public static int abc_action_bar_default_padding_end_material = 2131165239;
-			
-			// aapt resource value: 0x7f070038
-			public static int abc_action_bar_default_padding_start_material = 2131165240;
-			
-			// aapt resource value: 0x7f07003a
-			public static int abc_action_bar_icon_vertical_padding_material = 2131165242;
-			
-			// aapt resource value: 0x7f07003b
-			public static int abc_action_bar_overflow_padding_end_material = 2131165243;
-			
-			// aapt resource value: 0x7f07003c
-			public static int abc_action_bar_overflow_padding_start_material = 2131165244;
-			
-			// aapt resource value: 0x7f07002b
-			public static int abc_action_bar_progress_bar_size = 2131165227;
-			
-			// aapt resource value: 0x7f07003d
-			public static int abc_action_bar_stacked_max_height = 2131165245;
-			
-			// aapt resource value: 0x7f07003e
-			public static int abc_action_bar_stacked_tab_max_width = 2131165246;
-			
-			// aapt resource value: 0x7f07003f
-			public static int abc_action_bar_subtitle_bottom_margin_material = 2131165247;
-			
-			// aapt resource value: 0x7f070040
-			public static int abc_action_bar_subtitle_top_margin_material = 2131165248;
-			
-			// aapt resource value: 0x7f070041
-			public static int abc_action_button_min_height_material = 2131165249;
-			
-			// aapt resource value: 0x7f070042
-			public static int abc_action_button_min_width_material = 2131165250;
-			
-			// aapt resource value: 0x7f070043
-			public static int abc_action_button_min_width_overflow_material = 2131165251;
-			
-			// aapt resource value: 0x7f070029
-			public static int abc_alert_dialog_button_bar_height = 2131165225;
-			
-			// aapt resource value: 0x7f070044
-			public static int abc_button_inset_horizontal_material = 2131165252;
-			
-			// aapt resource value: 0x7f070045
-			public static int abc_button_inset_vertical_material = 2131165253;
-			
-			// aapt resource value: 0x7f070046
-			public static int abc_button_padding_horizontal_material = 2131165254;
-			
-			// aapt resource value: 0x7f070047
-			public static int abc_button_padding_vertical_material = 2131165255;
-			
-			// aapt resource value: 0x7f07002e
-			public static int abc_config_prefDialogWidth = 2131165230;
-			
-			// aapt resource value: 0x7f070048
-			public static int abc_control_corner_material = 2131165256;
-			
-			// aapt resource value: 0x7f070049
-			public static int abc_control_inset_material = 2131165257;
-			
-			// aapt resource value: 0x7f07004a
-			public static int abc_control_padding_material = 2131165258;
-			
-			// aapt resource value: 0x7f07002f
-			public static int abc_dialog_fixed_height_major = 2131165231;
-			
-			// aapt resource value: 0x7f070030
-			public static int abc_dialog_fixed_height_minor = 2131165232;
-			
-			// aapt resource value: 0x7f070031
-			public static int abc_dialog_fixed_width_major = 2131165233;
-			
-			// aapt resource value: 0x7f070032
-			public static int abc_dialog_fixed_width_minor = 2131165234;
-			
-			// aapt resource value: 0x7f07004b
-			public static int abc_dialog_list_padding_vertical_material = 2131165259;
-			
-			// aapt resource value: 0x7f070033
-			public static int abc_dialog_min_width_major = 2131165235;
-			
-			// aapt resource value: 0x7f070034
-			public static int abc_dialog_min_width_minor = 2131165236;
-			
-			// aapt resource value: 0x7f07004c
-			public static int abc_dialog_padding_material = 2131165260;
-			
-			// aapt resource value: 0x7f07004d
-			public static int abc_dialog_padding_top_material = 2131165261;
-			
-			// aapt resource value: 0x7f07004e
-			public static int abc_disabled_alpha_material_dark = 2131165262;
-			
-			// aapt resource value: 0x7f07004f
-			public static int abc_disabled_alpha_material_light = 2131165263;
-			
-			// aapt resource value: 0x7f070050
-			public static int abc_dropdownitem_icon_width = 2131165264;
-			
-			// aapt resource value: 0x7f070051
-			public static int abc_dropdownitem_text_padding_left = 2131165265;
-			
-			// aapt resource value: 0x7f070052
-			public static int abc_dropdownitem_text_padding_right = 2131165266;
-			
-			// aapt resource value: 0x7f070053
-			public static int abc_edit_text_inset_bottom_material = 2131165267;
-			
-			// aapt resource value: 0x7f070054
-			public static int abc_edit_text_inset_horizontal_material = 2131165268;
-			
-			// aapt resource value: 0x7f070055
-			public static int abc_edit_text_inset_top_material = 2131165269;
-			
-			// aapt resource value: 0x7f070056
-			public static int abc_floating_window_z = 2131165270;
-			
-			// aapt resource value: 0x7f070057
-			public static int abc_list_item_padding_horizontal_material = 2131165271;
-			
-			// aapt resource value: 0x7f070058
-			public static int abc_panel_menu_list_width = 2131165272;
-			
-			// aapt resource value: 0x7f070059
-			public static int abc_search_view_preferred_width = 2131165273;
-			
-			// aapt resource value: 0x7f070035
-			public static int abc_search_view_text_min_width = 2131165237;
-			
-			// aapt resource value: 0x7f07005a
-			public static int abc_seekbar_track_background_height_material = 2131165274;
-			
-			// aapt resource value: 0x7f07005b
-			public static int abc_seekbar_track_progress_height_material = 2131165275;
-			
-			// aapt resource value: 0x7f07005c
-			public static int abc_select_dialog_padding_start_material = 2131165276;
-			
-			// aapt resource value: 0x7f070039
-			public static int abc_switch_padding = 2131165241;
-			
-			// aapt resource value: 0x7f07005d
-			public static int abc_text_size_body_1_material = 2131165277;
-			
-			// aapt resource value: 0x7f07005e
-			public static int abc_text_size_body_2_material = 2131165278;
-			
-			// aapt resource value: 0x7f07005f
-			public static int abc_text_size_button_material = 2131165279;
-			
-			// aapt resource value: 0x7f070060
-			public static int abc_text_size_caption_material = 2131165280;
-			
-			// aapt resource value: 0x7f070061
-			public static int abc_text_size_display_1_material = 2131165281;
-			
-			// aapt resource value: 0x7f070062
-			public static int abc_text_size_display_2_material = 2131165282;
-			
-			// aapt resource value: 0x7f070063
-			public static int abc_text_size_display_3_material = 2131165283;
-			
-			// aapt resource value: 0x7f070064
-			public static int abc_text_size_display_4_material = 2131165284;
-			
-			// aapt resource value: 0x7f070065
-			public static int abc_text_size_headline_material = 2131165285;
-			
-			// aapt resource value: 0x7f070066
-			public static int abc_text_size_large_material = 2131165286;
-			
-			// aapt resource value: 0x7f070067
-			public static int abc_text_size_medium_material = 2131165287;
-			
-			// aapt resource value: 0x7f070068
-			public static int abc_text_size_menu_material = 2131165288;
-			
-			// aapt resource value: 0x7f070069
-			public static int abc_text_size_small_material = 2131165289;
-			
-			// aapt resource value: 0x7f07006a
-			public static int abc_text_size_subhead_material = 2131165290;
-			
-			// aapt resource value: 0x7f07002c
-			public static int abc_text_size_subtitle_material_toolbar = 2131165228;
-			
-			// aapt resource value: 0x7f07006b
-			public static int abc_text_size_title_material = 2131165291;
-			
-			// aapt resource value: 0x7f07002d
-			public static int abc_text_size_title_material_toolbar = 2131165229;
-			
-			// aapt resource value: 0x7f070006
-			public static int cardview_compat_inset_shadow = 2131165190;
-			
-			// aapt resource value: 0x7f070007
-			public static int cardview_default_elevation = 2131165191;
-			
-			// aapt resource value: 0x7f070008
-			public static int cardview_default_radius = 2131165192;
-			
-			// aapt resource value: 0x7f070011
-			public static int design_appbar_elevation = 2131165201;
-			
-			// aapt resource value: 0x7f070012
-			public static int design_bottom_sheet_modal_elevation = 2131165202;
-			
-			// aapt resource value: 0x7f070013
-			public static int design_bottom_sheet_modal_peek_height = 2131165203;
-			
-			// aapt resource value: 0x7f070014
-			public static int design_fab_border_width = 2131165204;
-			
-			// aapt resource value: 0x7f070015
-			public static int design_fab_elevation = 2131165205;
-			
-			// aapt resource value: 0x7f070016
-			public static int design_fab_image_size = 2131165206;
-			
-			// aapt resource value: 0x7f070017
-			public static int design_fab_size_mini = 2131165207;
-			
 			// aapt resource value: 0x7f070018
-			public static int design_fab_size_normal = 2131165208;
+			public static int abc_action_bar_content_inset_material = 2131165208;
 			
 			// aapt resource value: 0x7f070019
-			public static int design_fab_translation_z_pressed = 2131165209;
-			
-			// aapt resource value: 0x7f07001a
-			public static int design_navigation_elevation = 2131165210;
-			
-			// aapt resource value: 0x7f07001b
-			public static int design_navigation_icon_padding = 2131165211;
-			
-			// aapt resource value: 0x7f07001c
-			public static int design_navigation_icon_size = 2131165212;
-			
-			// aapt resource value: 0x7f070009
-			public static int design_navigation_max_width = 2131165193;
-			
-			// aapt resource value: 0x7f07001d
-			public static int design_navigation_padding_bottom = 2131165213;
-			
-			// aapt resource value: 0x7f07001e
-			public static int design_navigation_separator_vertical_padding = 2131165214;
-			
-			// aapt resource value: 0x7f07000a
-			public static int design_snackbar_action_inline_max_width = 2131165194;
-			
-			// aapt resource value: 0x7f07000b
-			public static int design_snackbar_background_corner_radius = 2131165195;
-			
-			// aapt resource value: 0x7f07001f
-			public static int design_snackbar_elevation = 2131165215;
-			
-			// aapt resource value: 0x7f07000c
-			public static int design_snackbar_extra_spacing_horizontal = 2131165196;
+			public static int abc_action_bar_content_inset_with_nav = 2131165209;
 			
 			// aapt resource value: 0x7f07000d
-			public static int design_snackbar_max_width = 2131165197;
+			public static int abc_action_bar_default_height_material = 2131165197;
 			
-			// aapt resource value: 0x7f07000e
-			public static int design_snackbar_min_width = 2131165198;
+			// aapt resource value: 0x7f07001a
+			public static int abc_action_bar_default_padding_end_material = 2131165210;
 			
-			// aapt resource value: 0x7f070020
-			public static int design_snackbar_padding_horizontal = 2131165216;
+			// aapt resource value: 0x7f07001b
+			public static int abc_action_bar_default_padding_start_material = 2131165211;
 			
 			// aapt resource value: 0x7f070021
-			public static int design_snackbar_padding_vertical = 2131165217;
-			
-			// aapt resource value: 0x7f07000f
-			public static int design_snackbar_padding_vertical_2lines = 2131165199;
+			public static int abc_action_bar_elevation_material = 2131165217;
 			
 			// aapt resource value: 0x7f070022
-			public static int design_snackbar_text_size = 2131165218;
+			public static int abc_action_bar_icon_vertical_padding_material = 2131165218;
 			
 			// aapt resource value: 0x7f070023
-			public static int design_tab_max_width = 2131165219;
-			
-			// aapt resource value: 0x7f070010
-			public static int design_tab_scrollable_min_width = 2131165200;
+			public static int abc_action_bar_overflow_padding_end_material = 2131165219;
 			
 			// aapt resource value: 0x7f070024
-			public static int design_tab_text_size = 2131165220;
+			public static int abc_action_bar_overflow_padding_start_material = 2131165220;
+			
+			// aapt resource value: 0x7f07000e
+			public static int abc_action_bar_progress_bar_size = 2131165198;
 			
 			// aapt resource value: 0x7f070025
-			public static int design_tab_text_size_2line = 2131165221;
-			
-			// aapt resource value: 0x7f07006c
-			public static int disabled_alpha_material_dark = 2131165292;
-			
-			// aapt resource value: 0x7f07006d
-			public static int disabled_alpha_material_light = 2131165293;
-			
-			// aapt resource value: 0x7f07006e
-			public static int highlight_alpha_material_colored = 2131165294;
-			
-			// aapt resource value: 0x7f07006f
-			public static int highlight_alpha_material_dark = 2131165295;
-			
-			// aapt resource value: 0x7f070070
-			public static int highlight_alpha_material_light = 2131165296;
+			public static int abc_action_bar_stacked_max_height = 2131165221;
 			
 			// aapt resource value: 0x7f070026
-			public static int item_touch_helper_max_drag_scroll_per_frame = 2131165222;
+			public static int abc_action_bar_stacked_tab_max_width = 2131165222;
 			
 			// aapt resource value: 0x7f070027
-			public static int item_touch_helper_swipe_escape_max_velocity = 2131165223;
+			public static int abc_action_bar_subtitle_bottom_margin_material = 2131165223;
 			
 			// aapt resource value: 0x7f070028
-			public static int item_touch_helper_swipe_escape_velocity = 2131165224;
+			public static int abc_action_bar_subtitle_top_margin_material = 2131165224;
 			
-			// aapt resource value: 0x7f070000
-			public static int mr_controller_volume_group_list_item_height = 2131165184;
+			// aapt resource value: 0x7f070029
+			public static int abc_action_button_min_height_material = 2131165225;
 			
-			// aapt resource value: 0x7f070001
-			public static int mr_controller_volume_group_list_item_icon_size = 2131165185;
+			// aapt resource value: 0x7f07002a
+			public static int abc_action_button_min_width_material = 2131165226;
 			
-			// aapt resource value: 0x7f070002
-			public static int mr_controller_volume_group_list_max_height = 2131165186;
+			// aapt resource value: 0x7f07002b
+			public static int abc_action_button_min_width_overflow_material = 2131165227;
 			
-			// aapt resource value: 0x7f070005
-			public static int mr_controller_volume_group_list_padding_top = 2131165189;
+			// aapt resource value: 0x7f07000c
+			public static int abc_alert_dialog_button_bar_height = 2131165196;
 			
-			// aapt resource value: 0x7f070003
-			public static int mr_dialog_fixed_width_major = 2131165187;
+			// aapt resource value: 0x7f07002c
+			public static int abc_button_inset_horizontal_material = 2131165228;
 			
-			// aapt resource value: 0x7f070004
-			public static int mr_dialog_fixed_width_minor = 2131165188;
+			// aapt resource value: 0x7f07002d
+			public static int abc_button_inset_vertical_material = 2131165229;
+			
+			// aapt resource value: 0x7f07002e
+			public static int abc_button_padding_horizontal_material = 2131165230;
+			
+			// aapt resource value: 0x7f07002f
+			public static int abc_button_padding_vertical_material = 2131165231;
+			
+			// aapt resource value: 0x7f070030
+			public static int abc_cascading_menus_min_smallest_width = 2131165232;
+			
+			// aapt resource value: 0x7f070011
+			public static int abc_config_prefDialogWidth = 2131165201;
+			
+			// aapt resource value: 0x7f070031
+			public static int abc_control_corner_material = 2131165233;
+			
+			// aapt resource value: 0x7f070032
+			public static int abc_control_inset_material = 2131165234;
+			
+			// aapt resource value: 0x7f070033
+			public static int abc_control_padding_material = 2131165235;
+			
+			// aapt resource value: 0x7f070012
+			public static int abc_dialog_fixed_height_major = 2131165202;
+			
+			// aapt resource value: 0x7f070013
+			public static int abc_dialog_fixed_height_minor = 2131165203;
+			
+			// aapt resource value: 0x7f070014
+			public static int abc_dialog_fixed_width_major = 2131165204;
+			
+			// aapt resource value: 0x7f070015
+			public static int abc_dialog_fixed_width_minor = 2131165205;
+			
+			// aapt resource value: 0x7f070034
+			public static int abc_dialog_list_padding_bottom_no_buttons = 2131165236;
+			
+			// aapt resource value: 0x7f070035
+			public static int abc_dialog_list_padding_top_no_title = 2131165237;
+			
+			// aapt resource value: 0x7f070016
+			public static int abc_dialog_min_width_major = 2131165206;
+			
+			// aapt resource value: 0x7f070017
+			public static int abc_dialog_min_width_minor = 2131165207;
+			
+			// aapt resource value: 0x7f070036
+			public static int abc_dialog_padding_material = 2131165238;
+			
+			// aapt resource value: 0x7f070037
+			public static int abc_dialog_padding_top_material = 2131165239;
+			
+			// aapt resource value: 0x7f070038
+			public static int abc_dialog_title_divider_material = 2131165240;
+			
+			// aapt resource value: 0x7f070039
+			public static int abc_disabled_alpha_material_dark = 2131165241;
+			
+			// aapt resource value: 0x7f07003a
+			public static int abc_disabled_alpha_material_light = 2131165242;
+			
+			// aapt resource value: 0x7f07003b
+			public static int abc_dropdownitem_icon_width = 2131165243;
+			
+			// aapt resource value: 0x7f07003c
+			public static int abc_dropdownitem_text_padding_left = 2131165244;
+			
+			// aapt resource value: 0x7f07003d
+			public static int abc_dropdownitem_text_padding_right = 2131165245;
+			
+			// aapt resource value: 0x7f07003e
+			public static int abc_edit_text_inset_bottom_material = 2131165246;
+			
+			// aapt resource value: 0x7f07003f
+			public static int abc_edit_text_inset_horizontal_material = 2131165247;
+			
+			// aapt resource value: 0x7f070040
+			public static int abc_edit_text_inset_top_material = 2131165248;
+			
+			// aapt resource value: 0x7f070041
+			public static int abc_floating_window_z = 2131165249;
+			
+			// aapt resource value: 0x7f070042
+			public static int abc_list_item_padding_horizontal_material = 2131165250;
+			
+			// aapt resource value: 0x7f070043
+			public static int abc_panel_menu_list_width = 2131165251;
+			
+			// aapt resource value: 0x7f070044
+			public static int abc_progress_bar_height_material = 2131165252;
+			
+			// aapt resource value: 0x7f070045
+			public static int abc_search_view_preferred_height = 2131165253;
+			
+			// aapt resource value: 0x7f070046
+			public static int abc_search_view_preferred_width = 2131165254;
+			
+			// aapt resource value: 0x7f070047
+			public static int abc_seekbar_track_background_height_material = 2131165255;
+			
+			// aapt resource value: 0x7f070048
+			public static int abc_seekbar_track_progress_height_material = 2131165256;
+			
+			// aapt resource value: 0x7f070049
+			public static int abc_select_dialog_padding_start_material = 2131165257;
+			
+			// aapt resource value: 0x7f07001d
+			public static int abc_switch_padding = 2131165213;
+			
+			// aapt resource value: 0x7f07004a
+			public static int abc_text_size_body_1_material = 2131165258;
+			
+			// aapt resource value: 0x7f07004b
+			public static int abc_text_size_body_2_material = 2131165259;
+			
+			// aapt resource value: 0x7f07004c
+			public static int abc_text_size_button_material = 2131165260;
+			
+			// aapt resource value: 0x7f07004d
+			public static int abc_text_size_caption_material = 2131165261;
+			
+			// aapt resource value: 0x7f07004e
+			public static int abc_text_size_display_1_material = 2131165262;
+			
+			// aapt resource value: 0x7f07004f
+			public static int abc_text_size_display_2_material = 2131165263;
+			
+			// aapt resource value: 0x7f070050
+			public static int abc_text_size_display_3_material = 2131165264;
+			
+			// aapt resource value: 0x7f070051
+			public static int abc_text_size_display_4_material = 2131165265;
+			
+			// aapt resource value: 0x7f070052
+			public static int abc_text_size_headline_material = 2131165266;
+			
+			// aapt resource value: 0x7f070053
+			public static int abc_text_size_large_material = 2131165267;
+			
+			// aapt resource value: 0x7f070054
+			public static int abc_text_size_medium_material = 2131165268;
+			
+			// aapt resource value: 0x7f070055
+			public static int abc_text_size_menu_header_material = 2131165269;
+			
+			// aapt resource value: 0x7f070056
+			public static int abc_text_size_menu_material = 2131165270;
+			
+			// aapt resource value: 0x7f070057
+			public static int abc_text_size_small_material = 2131165271;
+			
+			// aapt resource value: 0x7f070058
+			public static int abc_text_size_subhead_material = 2131165272;
+			
+			// aapt resource value: 0x7f07000f
+			public static int abc_text_size_subtitle_material_toolbar = 2131165199;
+			
+			// aapt resource value: 0x7f070059
+			public static int abc_text_size_title_material = 2131165273;
+			
+			// aapt resource value: 0x7f070010
+			public static int abc_text_size_title_material_toolbar = 2131165200;
+			
+			// aapt resource value: 0x7f070009
+			public static int cardview_compat_inset_shadow = 2131165193;
+			
+			// aapt resource value: 0x7f07000a
+			public static int cardview_default_elevation = 2131165194;
+			
+			// aapt resource value: 0x7f07000b
+			public static int cardview_default_radius = 2131165195;
+			
+			// aapt resource value: 0x7f070076
+			public static int design_appbar_elevation = 2131165302;
+			
+			// aapt resource value: 0x7f070077
+			public static int design_bottom_navigation_active_item_max_width = 2131165303;
+			
+			// aapt resource value: 0x7f070078
+			public static int design_bottom_navigation_active_text_size = 2131165304;
+			
+			// aapt resource value: 0x7f070079
+			public static int design_bottom_navigation_elevation = 2131165305;
+			
+			// aapt resource value: 0x7f07007a
+			public static int design_bottom_navigation_height = 2131165306;
+			
+			// aapt resource value: 0x7f07007b
+			public static int design_bottom_navigation_item_max_width = 2131165307;
+			
+			// aapt resource value: 0x7f07007c
+			public static int design_bottom_navigation_item_min_width = 2131165308;
+			
+			// aapt resource value: 0x7f07007d
+			public static int design_bottom_navigation_margin = 2131165309;
+			
+			// aapt resource value: 0x7f07007e
+			public static int design_bottom_navigation_shadow_height = 2131165310;
+			
+			// aapt resource value: 0x7f07007f
+			public static int design_bottom_navigation_text_size = 2131165311;
+			
+			// aapt resource value: 0x7f070080
+			public static int design_bottom_sheet_modal_elevation = 2131165312;
+			
+			// aapt resource value: 0x7f070081
+			public static int design_bottom_sheet_peek_height_min = 2131165313;
+			
+			// aapt resource value: 0x7f070082
+			public static int design_fab_border_width = 2131165314;
+			
+			// aapt resource value: 0x7f070083
+			public static int design_fab_elevation = 2131165315;
+			
+			// aapt resource value: 0x7f070084
+			public static int design_fab_image_size = 2131165316;
+			
+			// aapt resource value: 0x7f070085
+			public static int design_fab_size_mini = 2131165317;
+			
+			// aapt resource value: 0x7f070086
+			public static int design_fab_size_normal = 2131165318;
+			
+			// aapt resource value: 0x7f070087
+			public static int design_fab_translation_z_pressed = 2131165319;
+			
+			// aapt resource value: 0x7f070088
+			public static int design_navigation_elevation = 2131165320;
+			
+			// aapt resource value: 0x7f070089
+			public static int design_navigation_icon_padding = 2131165321;
+			
+			// aapt resource value: 0x7f07008a
+			public static int design_navigation_icon_size = 2131165322;
+			
+			// aapt resource value: 0x7f07006e
+			public static int design_navigation_max_width = 2131165294;
+			
+			// aapt resource value: 0x7f07008b
+			public static int design_navigation_padding_bottom = 2131165323;
+			
+			// aapt resource value: 0x7f07008c
+			public static int design_navigation_separator_vertical_padding = 2131165324;
+			
+			// aapt resource value: 0x7f07006f
+			public static int design_snackbar_action_inline_max_width = 2131165295;
+			
+			// aapt resource value: 0x7f070070
+			public static int design_snackbar_background_corner_radius = 2131165296;
+			
+			// aapt resource value: 0x7f07008d
+			public static int design_snackbar_elevation = 2131165325;
 			
 			// aapt resource value: 0x7f070071
-			public static int notification_large_icon_height = 2131165297;
+			public static int design_snackbar_extra_spacing_horizontal = 2131165297;
 			
 			// aapt resource value: 0x7f070072
-			public static int notification_large_icon_width = 2131165298;
+			public static int design_snackbar_max_width = 2131165298;
 			
 			// aapt resource value: 0x7f070073
-			public static int notification_subtext_size = 2131165299;
+			public static int design_snackbar_min_width = 2131165299;
+			
+			// aapt resource value: 0x7f07008e
+			public static int design_snackbar_padding_horizontal = 2131165326;
+			
+			// aapt resource value: 0x7f07008f
+			public static int design_snackbar_padding_vertical = 2131165327;
+			
+			// aapt resource value: 0x7f070074
+			public static int design_snackbar_padding_vertical_2lines = 2131165300;
+			
+			// aapt resource value: 0x7f070090
+			public static int design_snackbar_text_size = 2131165328;
+			
+			// aapt resource value: 0x7f070091
+			public static int design_tab_max_width = 2131165329;
+			
+			// aapt resource value: 0x7f070075
+			public static int design_tab_scrollable_min_width = 2131165301;
+			
+			// aapt resource value: 0x7f070092
+			public static int design_tab_text_size = 2131165330;
+			
+			// aapt resource value: 0x7f070093
+			public static int design_tab_text_size_2line = 2131165331;
+			
+			// aapt resource value: 0x7f07005a
+			public static int disabled_alpha_material_dark = 2131165274;
+			
+			// aapt resource value: 0x7f07005b
+			public static int disabled_alpha_material_light = 2131165275;
+			
+			// aapt resource value: 0x7f07005c
+			public static int highlight_alpha_material_colored = 2131165276;
+			
+			// aapt resource value: 0x7f07005d
+			public static int highlight_alpha_material_dark = 2131165277;
+			
+			// aapt resource value: 0x7f07005e
+			public static int highlight_alpha_material_light = 2131165278;
+			
+			// aapt resource value: 0x7f07005f
+			public static int hint_alpha_material_dark = 2131165279;
+			
+			// aapt resource value: 0x7f070060
+			public static int hint_alpha_material_light = 2131165280;
+			
+			// aapt resource value: 0x7f070061
+			public static int hint_pressed_alpha_material_dark = 2131165281;
+			
+			// aapt resource value: 0x7f070062
+			public static int hint_pressed_alpha_material_light = 2131165282;
+			
+			// aapt resource value: 0x7f070000
+			public static int item_touch_helper_max_drag_scroll_per_frame = 2131165184;
+			
+			// aapt resource value: 0x7f070001
+			public static int item_touch_helper_swipe_escape_max_velocity = 2131165185;
+			
+			// aapt resource value: 0x7f070002
+			public static int item_touch_helper_swipe_escape_velocity = 2131165186;
+			
+			// aapt resource value: 0x7f070003
+			public static int mr_controller_volume_group_list_item_height = 2131165187;
+			
+			// aapt resource value: 0x7f070004
+			public static int mr_controller_volume_group_list_item_icon_size = 2131165188;
+			
+			// aapt resource value: 0x7f070005
+			public static int mr_controller_volume_group_list_max_height = 2131165189;
+			
+			// aapt resource value: 0x7f070008
+			public static int mr_controller_volume_group_list_padding_top = 2131165192;
+			
+			// aapt resource value: 0x7f070006
+			public static int mr_dialog_fixed_width_major = 2131165190;
+			
+			// aapt resource value: 0x7f070007
+			public static int mr_dialog_fixed_width_minor = 2131165191;
+			
+			// aapt resource value: 0x7f070063
+			public static int notification_action_icon_size = 2131165283;
+			
+			// aapt resource value: 0x7f070064
+			public static int notification_action_text_size = 2131165284;
+			
+			// aapt resource value: 0x7f070065
+			public static int notification_big_circle_margin = 2131165285;
+			
+			// aapt resource value: 0x7f07001e
+			public static int notification_content_margin_start = 2131165214;
+			
+			// aapt resource value: 0x7f070066
+			public static int notification_large_icon_height = 2131165286;
+			
+			// aapt resource value: 0x7f070067
+			public static int notification_large_icon_width = 2131165287;
+			
+			// aapt resource value: 0x7f07001f
+			public static int notification_main_column_padding_top = 2131165215;
+			
+			// aapt resource value: 0x7f070020
+			public static int notification_media_narrow_margin = 2131165216;
+			
+			// aapt resource value: 0x7f070068
+			public static int notification_right_icon_size = 2131165288;
+			
+			// aapt resource value: 0x7f07001c
+			public static int notification_right_side_padding_top = 2131165212;
+			
+			// aapt resource value: 0x7f070069
+			public static int notification_small_icon_background_padding = 2131165289;
+			
+			// aapt resource value: 0x7f07006a
+			public static int notification_small_icon_size_as_large = 2131165290;
+			
+			// aapt resource value: 0x7f07006b
+			public static int notification_subtext_size = 2131165291;
+			
+			// aapt resource value: 0x7f07006c
+			public static int notification_top_pad = 2131165292;
+			
+			// aapt resource value: 0x7f07006d
+			public static int notification_top_pad_large_text = 2131165293;
 			
 			static Dimension()
 			{
@@ -1746,85 +1960,85 @@ namespace XFGloss.Droid
 			public static int abc_btn_radio_to_on_mtrl_015 = 2130837514;
 			
 			// aapt resource value: 0x7f02000b
-			public static int abc_btn_rating_star_off_mtrl_alpha = 2130837515;
+			public static int abc_btn_switch_to_on_mtrl_00001 = 2130837515;
 			
 			// aapt resource value: 0x7f02000c
-			public static int abc_btn_rating_star_on_mtrl_alpha = 2130837516;
+			public static int abc_btn_switch_to_on_mtrl_00012 = 2130837516;
 			
 			// aapt resource value: 0x7f02000d
-			public static int abc_btn_switch_to_on_mtrl_00001 = 2130837517;
+			public static int abc_cab_background_internal_bg = 2130837517;
 			
 			// aapt resource value: 0x7f02000e
-			public static int abc_btn_switch_to_on_mtrl_00012 = 2130837518;
+			public static int abc_cab_background_top_material = 2130837518;
 			
 			// aapt resource value: 0x7f02000f
-			public static int abc_cab_background_internal_bg = 2130837519;
+			public static int abc_cab_background_top_mtrl_alpha = 2130837519;
 			
 			// aapt resource value: 0x7f020010
-			public static int abc_cab_background_top_material = 2130837520;
+			public static int abc_control_background_material = 2130837520;
 			
 			// aapt resource value: 0x7f020011
-			public static int abc_cab_background_top_mtrl_alpha = 2130837521;
+			public static int abc_dialog_material_background = 2130837521;
 			
 			// aapt resource value: 0x7f020012
-			public static int abc_control_background_material = 2130837522;
+			public static int abc_edit_text_material = 2130837522;
 			
 			// aapt resource value: 0x7f020013
-			public static int abc_dialog_material_background_dark = 2130837523;
+			public static int abc_ic_ab_back_material = 2130837523;
 			
 			// aapt resource value: 0x7f020014
-			public static int abc_dialog_material_background_light = 2130837524;
+			public static int abc_ic_arrow_drop_right_black_24dp = 2130837524;
 			
 			// aapt resource value: 0x7f020015
-			public static int abc_edit_text_material = 2130837525;
+			public static int abc_ic_clear_material = 2130837525;
 			
 			// aapt resource value: 0x7f020016
-			public static int abc_ic_ab_back_mtrl_am_alpha = 2130837526;
+			public static int abc_ic_commit_search_api_mtrl_alpha = 2130837526;
 			
 			// aapt resource value: 0x7f020017
-			public static int abc_ic_clear_mtrl_alpha = 2130837527;
+			public static int abc_ic_go_search_api_material = 2130837527;
 			
 			// aapt resource value: 0x7f020018
-			public static int abc_ic_commit_search_api_mtrl_alpha = 2130837528;
+			public static int abc_ic_menu_copy_mtrl_am_alpha = 2130837528;
 			
 			// aapt resource value: 0x7f020019
-			public static int abc_ic_go_search_api_mtrl_alpha = 2130837529;
+			public static int abc_ic_menu_cut_mtrl_alpha = 2130837529;
 			
 			// aapt resource value: 0x7f02001a
-			public static int abc_ic_menu_copy_mtrl_am_alpha = 2130837530;
+			public static int abc_ic_menu_overflow_material = 2130837530;
 			
 			// aapt resource value: 0x7f02001b
-			public static int abc_ic_menu_cut_mtrl_alpha = 2130837531;
+			public static int abc_ic_menu_paste_mtrl_am_alpha = 2130837531;
 			
 			// aapt resource value: 0x7f02001c
-			public static int abc_ic_menu_moreoverflow_mtrl_alpha = 2130837532;
+			public static int abc_ic_menu_selectall_mtrl_alpha = 2130837532;
 			
 			// aapt resource value: 0x7f02001d
-			public static int abc_ic_menu_paste_mtrl_am_alpha = 2130837533;
+			public static int abc_ic_menu_share_mtrl_alpha = 2130837533;
 			
 			// aapt resource value: 0x7f02001e
-			public static int abc_ic_menu_selectall_mtrl_alpha = 2130837534;
+			public static int abc_ic_search_api_material = 2130837534;
 			
 			// aapt resource value: 0x7f02001f
-			public static int abc_ic_menu_share_mtrl_alpha = 2130837535;
+			public static int abc_ic_star_black_16dp = 2130837535;
 			
 			// aapt resource value: 0x7f020020
-			public static int abc_ic_search_api_mtrl_alpha = 2130837536;
+			public static int abc_ic_star_black_36dp = 2130837536;
 			
 			// aapt resource value: 0x7f020021
-			public static int abc_ic_star_black_16dp = 2130837537;
+			public static int abc_ic_star_black_48dp = 2130837537;
 			
 			// aapt resource value: 0x7f020022
-			public static int abc_ic_star_black_36dp = 2130837538;
+			public static int abc_ic_star_half_black_16dp = 2130837538;
 			
 			// aapt resource value: 0x7f020023
-			public static int abc_ic_star_half_black_16dp = 2130837539;
+			public static int abc_ic_star_half_black_36dp = 2130837539;
 			
 			// aapt resource value: 0x7f020024
-			public static int abc_ic_star_half_black_36dp = 2130837540;
+			public static int abc_ic_star_half_black_48dp = 2130837540;
 			
 			// aapt resource value: 0x7f020025
-			public static int abc_ic_voice_search_api_mtrl_alpha = 2130837541;
+			public static int abc_ic_voice_search_api_material = 2130837541;
 			
 			// aapt resource value: 0x7f020026
 			public static int abc_item_background_holo_dark = 2130837542;
@@ -1872,10 +2086,10 @@ namespace XFGloss.Droid
 			public static int abc_popup_background_mtrl_mult = 2130837556;
 			
 			// aapt resource value: 0x7f020035
-			public static int abc_ratingbar_full_material = 2130837557;
+			public static int abc_ratingbar_indicator_material = 2130837557;
 			
 			// aapt resource value: 0x7f020036
-			public static int abc_ratingbar_indicator_material = 2130837558;
+			public static int abc_ratingbar_material = 2130837558;
 			
 			// aapt resource value: 0x7f020037
 			public static int abc_ratingbar_small_material = 2130837559;
@@ -1899,301 +2113,643 @@ namespace XFGloss.Droid
 			public static int abc_seekbar_thumb_material = 2130837565;
 			
 			// aapt resource value: 0x7f02003e
-			public static int abc_seekbar_track_material = 2130837566;
+			public static int abc_seekbar_tick_mark_material = 2130837566;
 			
 			// aapt resource value: 0x7f02003f
-			public static int abc_spinner_mtrl_am_alpha = 2130837567;
+			public static int abc_seekbar_track_material = 2130837567;
 			
 			// aapt resource value: 0x7f020040
-			public static int abc_spinner_textfield_background_material = 2130837568;
+			public static int abc_spinner_mtrl_am_alpha = 2130837568;
 			
 			// aapt resource value: 0x7f020041
-			public static int abc_switch_thumb_material = 2130837569;
+			public static int abc_spinner_textfield_background_material = 2130837569;
 			
 			// aapt resource value: 0x7f020042
-			public static int abc_switch_track_mtrl_alpha = 2130837570;
+			public static int abc_switch_thumb_material = 2130837570;
 			
 			// aapt resource value: 0x7f020043
-			public static int abc_tab_indicator_material = 2130837571;
+			public static int abc_switch_track_mtrl_alpha = 2130837571;
 			
 			// aapt resource value: 0x7f020044
-			public static int abc_tab_indicator_mtrl_alpha = 2130837572;
+			public static int abc_tab_indicator_material = 2130837572;
 			
 			// aapt resource value: 0x7f020045
-			public static int abc_text_cursor_material = 2130837573;
+			public static int abc_tab_indicator_mtrl_alpha = 2130837573;
 			
 			// aapt resource value: 0x7f020046
-			public static int abc_textfield_activated_mtrl_alpha = 2130837574;
+			public static int abc_text_cursor_material = 2130837574;
 			
 			// aapt resource value: 0x7f020047
-			public static int abc_textfield_default_mtrl_alpha = 2130837575;
+			public static int abc_text_select_handle_left_mtrl_dark = 2130837575;
 			
 			// aapt resource value: 0x7f020048
-			public static int abc_textfield_search_activated_mtrl_alpha = 2130837576;
+			public static int abc_text_select_handle_left_mtrl_light = 2130837576;
 			
 			// aapt resource value: 0x7f020049
-			public static int abc_textfield_search_default_mtrl_alpha = 2130837577;
+			public static int abc_text_select_handle_middle_mtrl_dark = 2130837577;
 			
 			// aapt resource value: 0x7f02004a
-			public static int abc_textfield_search_material = 2130837578;
+			public static int abc_text_select_handle_middle_mtrl_light = 2130837578;
 			
 			// aapt resource value: 0x7f02004b
-			public static int design_fab_background = 2130837579;
+			public static int abc_text_select_handle_right_mtrl_dark = 2130837579;
 			
 			// aapt resource value: 0x7f02004c
-			public static int design_snackbar_background = 2130837580;
+			public static int abc_text_select_handle_right_mtrl_light = 2130837580;
 			
 			// aapt resource value: 0x7f02004d
-			public static int ic_audiotrack = 2130837581;
+			public static int abc_textfield_activated_mtrl_alpha = 2130837581;
 			
 			// aapt resource value: 0x7f02004e
-			public static int ic_audiotrack_light = 2130837582;
+			public static int abc_textfield_default_mtrl_alpha = 2130837582;
 			
 			// aapt resource value: 0x7f02004f
-			public static int ic_bluetooth_grey = 2130837583;
+			public static int abc_textfield_search_activated_mtrl_alpha = 2130837583;
 			
 			// aapt resource value: 0x7f020050
-			public static int ic_bluetooth_white = 2130837584;
+			public static int abc_textfield_search_default_mtrl_alpha = 2130837584;
 			
 			// aapt resource value: 0x7f020051
-			public static int ic_cast_dark = 2130837585;
+			public static int abc_textfield_search_material = 2130837585;
 			
 			// aapt resource value: 0x7f020052
-			public static int ic_cast_disabled_light = 2130837586;
+			public static int abc_vector_test = 2130837586;
 			
 			// aapt resource value: 0x7f020053
-			public static int ic_cast_grey = 2130837587;
+			public static int avd_hide_password = 2130837587;
+			
+			// aapt resource value: 0x7f02010d
+			public static int avd_hide_password_1 = 2130837773;
+			
+			// aapt resource value: 0x7f02010e
+			public static int avd_hide_password_2 = 2130837774;
+			
+			// aapt resource value: 0x7f02010f
+			public static int avd_hide_password_3 = 2130837775;
 			
 			// aapt resource value: 0x7f020054
-			public static int ic_cast_light = 2130837588;
+			public static int avd_show_password = 2130837588;
+			
+			// aapt resource value: 0x7f020110
+			public static int avd_show_password_1 = 2130837776;
+			
+			// aapt resource value: 0x7f020111
+			public static int avd_show_password_2 = 2130837777;
+			
+			// aapt resource value: 0x7f020112
+			public static int avd_show_password_3 = 2130837778;
 			
 			// aapt resource value: 0x7f020055
-			public static int ic_cast_off_light = 2130837589;
+			public static int design_bottom_navigation_item_background = 2130837589;
 			
 			// aapt resource value: 0x7f020056
-			public static int ic_cast_on_0_light = 2130837590;
+			public static int design_fab_background = 2130837590;
 			
 			// aapt resource value: 0x7f020057
-			public static int ic_cast_on_1_light = 2130837591;
+			public static int design_ic_visibility = 2130837591;
 			
 			// aapt resource value: 0x7f020058
-			public static int ic_cast_on_2_light = 2130837592;
+			public static int design_ic_visibility_off = 2130837592;
 			
 			// aapt resource value: 0x7f020059
-			public static int ic_cast_on_light = 2130837593;
+			public static int design_password_eye = 2130837593;
 			
 			// aapt resource value: 0x7f02005a
-			public static int ic_cast_white = 2130837594;
+			public static int design_snackbar_background = 2130837594;
 			
 			// aapt resource value: 0x7f02005b
-			public static int ic_close_dark = 2130837595;
+			public static int ic_audiotrack_dark = 2130837595;
 			
 			// aapt resource value: 0x7f02005c
-			public static int ic_close_light = 2130837596;
+			public static int ic_audiotrack_light = 2130837596;
 			
 			// aapt resource value: 0x7f02005d
-			public static int ic_collapse = 2130837597;
+			public static int ic_dialog_close_dark = 2130837597;
 			
 			// aapt resource value: 0x7f02005e
-			public static int ic_collapse_00000 = 2130837598;
+			public static int ic_dialog_close_light = 2130837598;
 			
 			// aapt resource value: 0x7f02005f
-			public static int ic_collapse_00001 = 2130837599;
+			public static int ic_group_collapse_00 = 2130837599;
 			
 			// aapt resource value: 0x7f020060
-			public static int ic_collapse_00002 = 2130837600;
+			public static int ic_group_collapse_01 = 2130837600;
 			
 			// aapt resource value: 0x7f020061
-			public static int ic_collapse_00003 = 2130837601;
+			public static int ic_group_collapse_02 = 2130837601;
 			
 			// aapt resource value: 0x7f020062
-			public static int ic_collapse_00004 = 2130837602;
+			public static int ic_group_collapse_03 = 2130837602;
 			
 			// aapt resource value: 0x7f020063
-			public static int ic_collapse_00005 = 2130837603;
+			public static int ic_group_collapse_04 = 2130837603;
 			
 			// aapt resource value: 0x7f020064
-			public static int ic_collapse_00006 = 2130837604;
+			public static int ic_group_collapse_05 = 2130837604;
 			
 			// aapt resource value: 0x7f020065
-			public static int ic_collapse_00007 = 2130837605;
+			public static int ic_group_collapse_06 = 2130837605;
 			
 			// aapt resource value: 0x7f020066
-			public static int ic_collapse_00008 = 2130837606;
+			public static int ic_group_collapse_07 = 2130837606;
 			
 			// aapt resource value: 0x7f020067
-			public static int ic_collapse_00009 = 2130837607;
+			public static int ic_group_collapse_08 = 2130837607;
 			
 			// aapt resource value: 0x7f020068
-			public static int ic_collapse_00010 = 2130837608;
+			public static int ic_group_collapse_09 = 2130837608;
 			
 			// aapt resource value: 0x7f020069
-			public static int ic_collapse_00011 = 2130837609;
+			public static int ic_group_collapse_10 = 2130837609;
 			
 			// aapt resource value: 0x7f02006a
-			public static int ic_collapse_00012 = 2130837610;
+			public static int ic_group_collapse_11 = 2130837610;
 			
 			// aapt resource value: 0x7f02006b
-			public static int ic_collapse_00013 = 2130837611;
+			public static int ic_group_collapse_12 = 2130837611;
 			
 			// aapt resource value: 0x7f02006c
-			public static int ic_collapse_00014 = 2130837612;
+			public static int ic_group_collapse_13 = 2130837612;
 			
 			// aapt resource value: 0x7f02006d
-			public static int ic_collapse_00015 = 2130837613;
+			public static int ic_group_collapse_14 = 2130837613;
 			
 			// aapt resource value: 0x7f02006e
-			public static int ic_expand = 2130837614;
+			public static int ic_group_collapse_15 = 2130837614;
 			
 			// aapt resource value: 0x7f02006f
-			public static int ic_expand_00000 = 2130837615;
+			public static int ic_group_expand_00 = 2130837615;
 			
 			// aapt resource value: 0x7f020070
-			public static int ic_expand_00001 = 2130837616;
+			public static int ic_group_expand_01 = 2130837616;
 			
 			// aapt resource value: 0x7f020071
-			public static int ic_expand_00002 = 2130837617;
+			public static int ic_group_expand_02 = 2130837617;
 			
 			// aapt resource value: 0x7f020072
-			public static int ic_expand_00003 = 2130837618;
+			public static int ic_group_expand_03 = 2130837618;
 			
 			// aapt resource value: 0x7f020073
-			public static int ic_expand_00004 = 2130837619;
+			public static int ic_group_expand_04 = 2130837619;
 			
 			// aapt resource value: 0x7f020074
-			public static int ic_expand_00005 = 2130837620;
+			public static int ic_group_expand_05 = 2130837620;
 			
 			// aapt resource value: 0x7f020075
-			public static int ic_expand_00006 = 2130837621;
+			public static int ic_group_expand_06 = 2130837621;
 			
 			// aapt resource value: 0x7f020076
-			public static int ic_expand_00007 = 2130837622;
+			public static int ic_group_expand_07 = 2130837622;
 			
 			// aapt resource value: 0x7f020077
-			public static int ic_expand_00008 = 2130837623;
+			public static int ic_group_expand_08 = 2130837623;
 			
 			// aapt resource value: 0x7f020078
-			public static int ic_expand_00009 = 2130837624;
+			public static int ic_group_expand_09 = 2130837624;
 			
 			// aapt resource value: 0x7f020079
-			public static int ic_expand_00010 = 2130837625;
+			public static int ic_group_expand_10 = 2130837625;
 			
 			// aapt resource value: 0x7f02007a
-			public static int ic_expand_00011 = 2130837626;
+			public static int ic_group_expand_11 = 2130837626;
 			
 			// aapt resource value: 0x7f02007b
-			public static int ic_expand_00012 = 2130837627;
+			public static int ic_group_expand_12 = 2130837627;
 			
 			// aapt resource value: 0x7f02007c
-			public static int ic_expand_00013 = 2130837628;
+			public static int ic_group_expand_13 = 2130837628;
 			
 			// aapt resource value: 0x7f02007d
-			public static int ic_expand_00014 = 2130837629;
+			public static int ic_group_expand_14 = 2130837629;
 			
 			// aapt resource value: 0x7f02007e
-			public static int ic_expand_00015 = 2130837630;
+			public static int ic_group_expand_15 = 2130837630;
 			
 			// aapt resource value: 0x7f02007f
-			public static int ic_media_pause = 2130837631;
+			public static int ic_media_pause_dark = 2130837631;
 			
 			// aapt resource value: 0x7f020080
-			public static int ic_media_play = 2130837632;
+			public static int ic_media_pause_light = 2130837632;
 			
 			// aapt resource value: 0x7f020081
-			public static int ic_media_route_disabled_mono_dark = 2130837633;
+			public static int ic_media_play_dark = 2130837633;
 			
 			// aapt resource value: 0x7f020082
-			public static int ic_media_route_off_mono_dark = 2130837634;
+			public static int ic_media_play_light = 2130837634;
 			
 			// aapt resource value: 0x7f020083
-			public static int ic_media_route_on_0_mono_dark = 2130837635;
+			public static int ic_media_stop_dark = 2130837635;
 			
 			// aapt resource value: 0x7f020084
-			public static int ic_media_route_on_1_mono_dark = 2130837636;
+			public static int ic_media_stop_light = 2130837636;
 			
 			// aapt resource value: 0x7f020085
-			public static int ic_media_route_on_2_mono_dark = 2130837637;
+			public static int ic_mr_button_connected_00_dark = 2130837637;
 			
 			// aapt resource value: 0x7f020086
-			public static int ic_media_route_on_mono_dark = 2130837638;
+			public static int ic_mr_button_connected_00_light = 2130837638;
 			
 			// aapt resource value: 0x7f020087
-			public static int ic_pause_dark = 2130837639;
+			public static int ic_mr_button_connected_01_dark = 2130837639;
 			
 			// aapt resource value: 0x7f020088
-			public static int ic_pause_light = 2130837640;
+			public static int ic_mr_button_connected_01_light = 2130837640;
 			
 			// aapt resource value: 0x7f020089
-			public static int ic_play_dark = 2130837641;
+			public static int ic_mr_button_connected_02_dark = 2130837641;
 			
 			// aapt resource value: 0x7f02008a
-			public static int ic_play_light = 2130837642;
+			public static int ic_mr_button_connected_02_light = 2130837642;
 			
 			// aapt resource value: 0x7f02008b
-			public static int ic_speaker_dark = 2130837643;
+			public static int ic_mr_button_connected_03_dark = 2130837643;
 			
 			// aapt resource value: 0x7f02008c
-			public static int ic_speaker_group_dark = 2130837644;
+			public static int ic_mr_button_connected_03_light = 2130837644;
 			
 			// aapt resource value: 0x7f02008d
-			public static int ic_speaker_group_light = 2130837645;
+			public static int ic_mr_button_connected_04_dark = 2130837645;
 			
 			// aapt resource value: 0x7f02008e
-			public static int ic_speaker_light = 2130837646;
+			public static int ic_mr_button_connected_04_light = 2130837646;
 			
 			// aapt resource value: 0x7f02008f
-			public static int ic_tv_dark = 2130837647;
+			public static int ic_mr_button_connected_05_dark = 2130837647;
 			
 			// aapt resource value: 0x7f020090
-			public static int ic_tv_light = 2130837648;
+			public static int ic_mr_button_connected_05_light = 2130837648;
 			
 			// aapt resource value: 0x7f020091
-			public static int mr_dialog_material_background_dark = 2130837649;
+			public static int ic_mr_button_connected_06_dark = 2130837649;
 			
 			// aapt resource value: 0x7f020092
-			public static int mr_dialog_material_background_light = 2130837650;
+			public static int ic_mr_button_connected_06_light = 2130837650;
 			
 			// aapt resource value: 0x7f020093
-			public static int mr_ic_audiotrack_light = 2130837651;
+			public static int ic_mr_button_connected_07_dark = 2130837651;
 			
 			// aapt resource value: 0x7f020094
-			public static int mr_ic_cast_dark = 2130837652;
+			public static int ic_mr_button_connected_07_light = 2130837652;
 			
 			// aapt resource value: 0x7f020095
-			public static int mr_ic_cast_light = 2130837653;
+			public static int ic_mr_button_connected_08_dark = 2130837653;
 			
 			// aapt resource value: 0x7f020096
-			public static int mr_ic_close_dark = 2130837654;
+			public static int ic_mr_button_connected_08_light = 2130837654;
 			
 			// aapt resource value: 0x7f020097
-			public static int mr_ic_close_light = 2130837655;
+			public static int ic_mr_button_connected_09_dark = 2130837655;
 			
 			// aapt resource value: 0x7f020098
-			public static int mr_ic_media_route_connecting_mono_dark = 2130837656;
+			public static int ic_mr_button_connected_09_light = 2130837656;
 			
 			// aapt resource value: 0x7f020099
-			public static int mr_ic_media_route_connecting_mono_light = 2130837657;
+			public static int ic_mr_button_connected_10_dark = 2130837657;
 			
 			// aapt resource value: 0x7f02009a
-			public static int mr_ic_media_route_mono_dark = 2130837658;
+			public static int ic_mr_button_connected_10_light = 2130837658;
 			
 			// aapt resource value: 0x7f02009b
-			public static int mr_ic_media_route_mono_light = 2130837659;
+			public static int ic_mr_button_connected_11_dark = 2130837659;
 			
 			// aapt resource value: 0x7f02009c
-			public static int mr_ic_pause_dark = 2130837660;
+			public static int ic_mr_button_connected_11_light = 2130837660;
 			
 			// aapt resource value: 0x7f02009d
-			public static int mr_ic_pause_light = 2130837661;
+			public static int ic_mr_button_connected_12_dark = 2130837661;
 			
 			// aapt resource value: 0x7f02009e
-			public static int mr_ic_play_dark = 2130837662;
+			public static int ic_mr_button_connected_12_light = 2130837662;
 			
 			// aapt resource value: 0x7f02009f
-			public static int mr_ic_play_light = 2130837663;
+			public static int ic_mr_button_connected_13_dark = 2130837663;
 			
 			// aapt resource value: 0x7f0200a0
-			public static int notification_template_icon_bg = 2130837664;
+			public static int ic_mr_button_connected_13_light = 2130837664;
+			
+			// aapt resource value: 0x7f0200a1
+			public static int ic_mr_button_connected_14_dark = 2130837665;
+			
+			// aapt resource value: 0x7f0200a2
+			public static int ic_mr_button_connected_14_light = 2130837666;
+			
+			// aapt resource value: 0x7f0200a3
+			public static int ic_mr_button_connected_15_dark = 2130837667;
+			
+			// aapt resource value: 0x7f0200a4
+			public static int ic_mr_button_connected_15_light = 2130837668;
+			
+			// aapt resource value: 0x7f0200a5
+			public static int ic_mr_button_connected_16_dark = 2130837669;
+			
+			// aapt resource value: 0x7f0200a6
+			public static int ic_mr_button_connected_16_light = 2130837670;
+			
+			// aapt resource value: 0x7f0200a7
+			public static int ic_mr_button_connected_17_dark = 2130837671;
+			
+			// aapt resource value: 0x7f0200a8
+			public static int ic_mr_button_connected_17_light = 2130837672;
+			
+			// aapt resource value: 0x7f0200a9
+			public static int ic_mr_button_connected_18_dark = 2130837673;
+			
+			// aapt resource value: 0x7f0200aa
+			public static int ic_mr_button_connected_18_light = 2130837674;
+			
+			// aapt resource value: 0x7f0200ab
+			public static int ic_mr_button_connected_19_dark = 2130837675;
+			
+			// aapt resource value: 0x7f0200ac
+			public static int ic_mr_button_connected_19_light = 2130837676;
+			
+			// aapt resource value: 0x7f0200ad
+			public static int ic_mr_button_connected_20_dark = 2130837677;
+			
+			// aapt resource value: 0x7f0200ae
+			public static int ic_mr_button_connected_20_light = 2130837678;
+			
+			// aapt resource value: 0x7f0200af
+			public static int ic_mr_button_connected_21_dark = 2130837679;
+			
+			// aapt resource value: 0x7f0200b0
+			public static int ic_mr_button_connected_21_light = 2130837680;
+			
+			// aapt resource value: 0x7f0200b1
+			public static int ic_mr_button_connected_22_dark = 2130837681;
+			
+			// aapt resource value: 0x7f0200b2
+			public static int ic_mr_button_connected_22_light = 2130837682;
+			
+			// aapt resource value: 0x7f0200b3
+			public static int ic_mr_button_connecting_00_dark = 2130837683;
+			
+			// aapt resource value: 0x7f0200b4
+			public static int ic_mr_button_connecting_00_light = 2130837684;
+			
+			// aapt resource value: 0x7f0200b5
+			public static int ic_mr_button_connecting_01_dark = 2130837685;
+			
+			// aapt resource value: 0x7f0200b6
+			public static int ic_mr_button_connecting_01_light = 2130837686;
+			
+			// aapt resource value: 0x7f0200b7
+			public static int ic_mr_button_connecting_02_dark = 2130837687;
+			
+			// aapt resource value: 0x7f0200b8
+			public static int ic_mr_button_connecting_02_light = 2130837688;
+			
+			// aapt resource value: 0x7f0200b9
+			public static int ic_mr_button_connecting_03_dark = 2130837689;
+			
+			// aapt resource value: 0x7f0200ba
+			public static int ic_mr_button_connecting_03_light = 2130837690;
+			
+			// aapt resource value: 0x7f0200bb
+			public static int ic_mr_button_connecting_04_dark = 2130837691;
+			
+			// aapt resource value: 0x7f0200bc
+			public static int ic_mr_button_connecting_04_light = 2130837692;
+			
+			// aapt resource value: 0x7f0200bd
+			public static int ic_mr_button_connecting_05_dark = 2130837693;
+			
+			// aapt resource value: 0x7f0200be
+			public static int ic_mr_button_connecting_05_light = 2130837694;
+			
+			// aapt resource value: 0x7f0200bf
+			public static int ic_mr_button_connecting_06_dark = 2130837695;
+			
+			// aapt resource value: 0x7f0200c0
+			public static int ic_mr_button_connecting_06_light = 2130837696;
+			
+			// aapt resource value: 0x7f0200c1
+			public static int ic_mr_button_connecting_07_dark = 2130837697;
+			
+			// aapt resource value: 0x7f0200c2
+			public static int ic_mr_button_connecting_07_light = 2130837698;
+			
+			// aapt resource value: 0x7f0200c3
+			public static int ic_mr_button_connecting_08_dark = 2130837699;
+			
+			// aapt resource value: 0x7f0200c4
+			public static int ic_mr_button_connecting_08_light = 2130837700;
+			
+			// aapt resource value: 0x7f0200c5
+			public static int ic_mr_button_connecting_09_dark = 2130837701;
+			
+			// aapt resource value: 0x7f0200c6
+			public static int ic_mr_button_connecting_09_light = 2130837702;
+			
+			// aapt resource value: 0x7f0200c7
+			public static int ic_mr_button_connecting_10_dark = 2130837703;
+			
+			// aapt resource value: 0x7f0200c8
+			public static int ic_mr_button_connecting_10_light = 2130837704;
+			
+			// aapt resource value: 0x7f0200c9
+			public static int ic_mr_button_connecting_11_dark = 2130837705;
+			
+			// aapt resource value: 0x7f0200ca
+			public static int ic_mr_button_connecting_11_light = 2130837706;
+			
+			// aapt resource value: 0x7f0200cb
+			public static int ic_mr_button_connecting_12_dark = 2130837707;
+			
+			// aapt resource value: 0x7f0200cc
+			public static int ic_mr_button_connecting_12_light = 2130837708;
+			
+			// aapt resource value: 0x7f0200cd
+			public static int ic_mr_button_connecting_13_dark = 2130837709;
+			
+			// aapt resource value: 0x7f0200ce
+			public static int ic_mr_button_connecting_13_light = 2130837710;
+			
+			// aapt resource value: 0x7f0200cf
+			public static int ic_mr_button_connecting_14_dark = 2130837711;
+			
+			// aapt resource value: 0x7f0200d0
+			public static int ic_mr_button_connecting_14_light = 2130837712;
+			
+			// aapt resource value: 0x7f0200d1
+			public static int ic_mr_button_connecting_15_dark = 2130837713;
+			
+			// aapt resource value: 0x7f0200d2
+			public static int ic_mr_button_connecting_15_light = 2130837714;
+			
+			// aapt resource value: 0x7f0200d3
+			public static int ic_mr_button_connecting_16_dark = 2130837715;
+			
+			// aapt resource value: 0x7f0200d4
+			public static int ic_mr_button_connecting_16_light = 2130837716;
+			
+			// aapt resource value: 0x7f0200d5
+			public static int ic_mr_button_connecting_17_dark = 2130837717;
+			
+			// aapt resource value: 0x7f0200d6
+			public static int ic_mr_button_connecting_17_light = 2130837718;
+			
+			// aapt resource value: 0x7f0200d7
+			public static int ic_mr_button_connecting_18_dark = 2130837719;
+			
+			// aapt resource value: 0x7f0200d8
+			public static int ic_mr_button_connecting_18_light = 2130837720;
+			
+			// aapt resource value: 0x7f0200d9
+			public static int ic_mr_button_connecting_19_dark = 2130837721;
+			
+			// aapt resource value: 0x7f0200da
+			public static int ic_mr_button_connecting_19_light = 2130837722;
+			
+			// aapt resource value: 0x7f0200db
+			public static int ic_mr_button_connecting_20_dark = 2130837723;
+			
+			// aapt resource value: 0x7f0200dc
+			public static int ic_mr_button_connecting_20_light = 2130837724;
+			
+			// aapt resource value: 0x7f0200dd
+			public static int ic_mr_button_connecting_21_dark = 2130837725;
+			
+			// aapt resource value: 0x7f0200de
+			public static int ic_mr_button_connecting_21_light = 2130837726;
+			
+			// aapt resource value: 0x7f0200df
+			public static int ic_mr_button_connecting_22_dark = 2130837727;
+			
+			// aapt resource value: 0x7f0200e0
+			public static int ic_mr_button_connecting_22_light = 2130837728;
+			
+			// aapt resource value: 0x7f0200e1
+			public static int ic_mr_button_disabled_dark = 2130837729;
+			
+			// aapt resource value: 0x7f0200e2
+			public static int ic_mr_button_disabled_light = 2130837730;
+			
+			// aapt resource value: 0x7f0200e3
+			public static int ic_mr_button_disconnected_dark = 2130837731;
+			
+			// aapt resource value: 0x7f0200e4
+			public static int ic_mr_button_disconnected_light = 2130837732;
+			
+			// aapt resource value: 0x7f0200e5
+			public static int ic_mr_button_grey = 2130837733;
+			
+			// aapt resource value: 0x7f0200e6
+			public static int ic_vol_type_speaker_dark = 2130837734;
+			
+			// aapt resource value: 0x7f0200e7
+			public static int ic_vol_type_speaker_group_dark = 2130837735;
+			
+			// aapt resource value: 0x7f0200e8
+			public static int ic_vol_type_speaker_group_light = 2130837736;
+			
+			// aapt resource value: 0x7f0200e9
+			public static int ic_vol_type_speaker_light = 2130837737;
+			
+			// aapt resource value: 0x7f0200ea
+			public static int ic_vol_type_tv_dark = 2130837738;
+			
+			// aapt resource value: 0x7f0200eb
+			public static int ic_vol_type_tv_light = 2130837739;
+			
+			// aapt resource value: 0x7f0200ec
+			public static int mr_button_connected_dark = 2130837740;
+			
+			// aapt resource value: 0x7f0200ed
+			public static int mr_button_connected_light = 2130837741;
+			
+			// aapt resource value: 0x7f0200ee
+			public static int mr_button_connecting_dark = 2130837742;
+			
+			// aapt resource value: 0x7f0200ef
+			public static int mr_button_connecting_light = 2130837743;
+			
+			// aapt resource value: 0x7f0200f0
+			public static int mr_button_dark = 2130837744;
+			
+			// aapt resource value: 0x7f0200f1
+			public static int mr_button_light = 2130837745;
+			
+			// aapt resource value: 0x7f0200f2
+			public static int mr_dialog_close_dark = 2130837746;
+			
+			// aapt resource value: 0x7f0200f3
+			public static int mr_dialog_close_light = 2130837747;
+			
+			// aapt resource value: 0x7f0200f4
+			public static int mr_dialog_material_background_dark = 2130837748;
+			
+			// aapt resource value: 0x7f0200f5
+			public static int mr_dialog_material_background_light = 2130837749;
+			
+			// aapt resource value: 0x7f0200f6
+			public static int mr_group_collapse = 2130837750;
+			
+			// aapt resource value: 0x7f0200f7
+			public static int mr_group_expand = 2130837751;
+			
+			// aapt resource value: 0x7f0200f8
+			public static int mr_media_pause_dark = 2130837752;
+			
+			// aapt resource value: 0x7f0200f9
+			public static int mr_media_pause_light = 2130837753;
+			
+			// aapt resource value: 0x7f0200fa
+			public static int mr_media_play_dark = 2130837754;
+			
+			// aapt resource value: 0x7f0200fb
+			public static int mr_media_play_light = 2130837755;
+			
+			// aapt resource value: 0x7f0200fc
+			public static int mr_media_stop_dark = 2130837756;
+			
+			// aapt resource value: 0x7f0200fd
+			public static int mr_media_stop_light = 2130837757;
+			
+			// aapt resource value: 0x7f0200fe
+			public static int mr_vol_type_audiotrack_dark = 2130837758;
+			
+			// aapt resource value: 0x7f0200ff
+			public static int mr_vol_type_audiotrack_light = 2130837759;
+			
+			// aapt resource value: 0x7f020100
+			public static int navigation_empty_icon = 2130837760;
+			
+			// aapt resource value: 0x7f020101
+			public static int notification_action_background = 2130837761;
+			
+			// aapt resource value: 0x7f020102
+			public static int notification_bg = 2130837762;
+			
+			// aapt resource value: 0x7f020103
+			public static int notification_bg_low = 2130837763;
+			
+			// aapt resource value: 0x7f020104
+			public static int notification_bg_low_normal = 2130837764;
+			
+			// aapt resource value: 0x7f020105
+			public static int notification_bg_low_pressed = 2130837765;
+			
+			// aapt resource value: 0x7f020106
+			public static int notification_bg_normal = 2130837766;
+			
+			// aapt resource value: 0x7f020107
+			public static int notification_bg_normal_pressed = 2130837767;
+			
+			// aapt resource value: 0x7f020108
+			public static int notification_icon_background = 2130837768;
+			
+			// aapt resource value: 0x7f02010b
+			public static int notification_template_icon_bg = 2130837771;
+			
+			// aapt resource value: 0x7f02010c
+			public static int notification_template_icon_low_bg = 2130837772;
+			
+			// aapt resource value: 0x7f020109
+			public static int notification_tile_bg = 2130837769;
+			
+			// aapt resource value: 0x7f02010a
+			public static int notify_panel_notification_icon_bg = 2130837770;
 			
 			static Drawable()
 			{
@@ -2208,461 +2764,539 @@ namespace XFGloss.Droid
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f0b008b
-			public static int action0 = 2131427467;
+			// aapt resource value: 0x7f08009c
+			public static int action0 = 2131230876;
 			
-			// aapt resource value: 0x7f0b005a
-			public static int action_bar = 2131427418;
+			// aapt resource value: 0x7f080064
+			public static int action_bar = 2131230820;
 			
-			// aapt resource value: 0x7f0b0002
-			public static int action_bar_activity_content = 2131427330;
+			// aapt resource value: 0x7f080001
+			public static int action_bar_activity_content = 2131230721;
 			
-			// aapt resource value: 0x7f0b0059
-			public static int action_bar_container = 2131427417;
+			// aapt resource value: 0x7f080063
+			public static int action_bar_container = 2131230819;
 			
-			// aapt resource value: 0x7f0b0055
-			public static int action_bar_root = 2131427413;
+			// aapt resource value: 0x7f08005f
+			public static int action_bar_root = 2131230815;
 			
-			// aapt resource value: 0x7f0b0003
-			public static int action_bar_spinner = 2131427331;
+			// aapt resource value: 0x7f080002
+			public static int action_bar_spinner = 2131230722;
 			
-			// aapt resource value: 0x7f0b003b
-			public static int action_bar_subtitle = 2131427387;
+			// aapt resource value: 0x7f080042
+			public static int action_bar_subtitle = 2131230786;
 			
-			// aapt resource value: 0x7f0b003a
-			public static int action_bar_title = 2131427386;
+			// aapt resource value: 0x7f080041
+			public static int action_bar_title = 2131230785;
 			
-			// aapt resource value: 0x7f0b005b
-			public static int action_context_bar = 2131427419;
+			// aapt resource value: 0x7f080099
+			public static int action_container = 2131230873;
 			
-			// aapt resource value: 0x7f0b008f
-			public static int action_divider = 2131427471;
+			// aapt resource value: 0x7f080065
+			public static int action_context_bar = 2131230821;
 			
-			// aapt resource value: 0x7f0b0004
-			public static int action_menu_divider = 2131427332;
+			// aapt resource value: 0x7f0800a0
+			public static int action_divider = 2131230880;
 			
-			// aapt resource value: 0x7f0b0005
-			public static int action_menu_presenter = 2131427333;
+			// aapt resource value: 0x7f08009a
+			public static int action_image = 2131230874;
 			
-			// aapt resource value: 0x7f0b0057
-			public static int action_mode_bar = 2131427415;
+			// aapt resource value: 0x7f080003
+			public static int action_menu_divider = 2131230723;
 			
-			// aapt resource value: 0x7f0b0056
-			public static int action_mode_bar_stub = 2131427414;
+			// aapt resource value: 0x7f080004
+			public static int action_menu_presenter = 2131230724;
 			
-			// aapt resource value: 0x7f0b003c
-			public static int action_mode_close_button = 2131427388;
+			// aapt resource value: 0x7f080061
+			public static int action_mode_bar = 2131230817;
 			
-			// aapt resource value: 0x7f0b003d
-			public static int activity_chooser_view_content = 2131427389;
+			// aapt resource value: 0x7f080060
+			public static int action_mode_bar_stub = 2131230816;
 			
-			// aapt resource value: 0x7f0b0049
-			public static int alertTitle = 2131427401;
+			// aapt resource value: 0x7f080043
+			public static int action_mode_close_button = 2131230787;
 			
-			// aapt resource value: 0x7f0b0035
-			public static int always = 2131427381;
+			// aapt resource value: 0x7f08009b
+			public static int action_text = 2131230875;
 			
-			// aapt resource value: 0x7f0b0033
-			public static int beginning = 2131427379;
+			// aapt resource value: 0x7f0800a9
+			public static int actions = 2131230889;
 			
-			// aapt resource value: 0x7f0b0013
-			public static int bottom = 2131427347;
+			// aapt resource value: 0x7f080044
+			public static int activity_chooser_view_content = 2131230788;
 			
-			// aapt resource value: 0x7f0b0044
-			public static int buttonPanel = 2131427396;
+			// aapt resource value: 0x7f080019
+			public static int add = 2131230745;
 			
-			// aapt resource value: 0x7f0b008c
-			public static int cancel_action = 2131427468;
+			// aapt resource value: 0x7f080058
+			public static int alertTitle = 2131230808;
 			
-			// aapt resource value: 0x7f0b0014
-			public static int center = 2131427348;
+			// aapt resource value: 0x7f08003d
+			public static int all = 2131230781;
 			
-			// aapt resource value: 0x7f0b0015
-			public static int center_horizontal = 2131427349;
+			// aapt resource value: 0x7f080023
+			public static int always = 2131230755;
 			
-			// aapt resource value: 0x7f0b0016
-			public static int center_vertical = 2131427350;
+			// aapt resource value: 0x7f08002f
+			public static int auto = 2131230767;
 			
-			// aapt resource value: 0x7f0b0052
-			public static int checkbox = 2131427410;
+			// aapt resource value: 0x7f080020
+			public static int beginning = 2131230752;
 			
-			// aapt resource value: 0x7f0b0092
-			public static int chronometer = 2131427474;
+			// aapt resource value: 0x7f080028
+			public static int bottom = 2131230760;
 			
-			// aapt resource value: 0x7f0b001d
-			public static int clip_horizontal = 2131427357;
+			// aapt resource value: 0x7f08004b
+			public static int buttonPanel = 2131230795;
 			
-			// aapt resource value: 0x7f0b001e
-			public static int clip_vertical = 2131427358;
+			// aapt resource value: 0x7f08009d
+			public static int cancel_action = 2131230877;
 			
-			// aapt resource value: 0x7f0b0036
-			public static int collapseActionView = 2131427382;
+			// aapt resource value: 0x7f080030
+			public static int center = 2131230768;
 			
-			// aapt resource value: 0x7f0b004a
-			public static int contentPanel = 2131427402;
+			// aapt resource value: 0x7f080031
+			public static int center_horizontal = 2131230769;
 			
-			// aapt resource value: 0x7f0b0050
-			public static int custom = 2131427408;
+			// aapt resource value: 0x7f080032
+			public static int center_vertical = 2131230770;
 			
-			// aapt resource value: 0x7f0b004f
-			public static int customPanel = 2131427407;
+			// aapt resource value: 0x7f08005b
+			public static int checkbox = 2131230811;
 			
-			// aapt resource value: 0x7f0b0058
-			public static int decor_content_parent = 2131427416;
+			// aapt resource value: 0x7f0800a5
+			public static int chronometer = 2131230885;
 			
-			// aapt resource value: 0x7f0b0040
-			public static int default_activity_button = 2131427392;
+			// aapt resource value: 0x7f080039
+			public static int clip_horizontal = 2131230777;
 			
-			// aapt resource value: 0x7f0b006a
-			public static int design_bottom_sheet = 2131427434;
+			// aapt resource value: 0x7f08003a
+			public static int clip_vertical = 2131230778;
 			
-			// aapt resource value: 0x7f0b0071
-			public static int design_menu_item_action_area = 2131427441;
+			// aapt resource value: 0x7f080024
+			public static int collapseActionView = 2131230756;
 			
-			// aapt resource value: 0x7f0b0070
-			public static int design_menu_item_action_area_stub = 2131427440;
+			// aapt resource value: 0x7f08004e
+			public static int contentPanel = 2131230798;
 			
-			// aapt resource value: 0x7f0b006f
-			public static int design_menu_item_text = 2131427439;
+			// aapt resource value: 0x7f080055
+			public static int custom = 2131230805;
 			
-			// aapt resource value: 0x7f0b006e
-			public static int design_navigation_view = 2131427438;
+			// aapt resource value: 0x7f080054
+			public static int customPanel = 2131230804;
 			
-			// aapt resource value: 0x7f0b0027
-			public static int disableHome = 2131427367;
+			// aapt resource value: 0x7f080062
+			public static int decor_content_parent = 2131230818;
 			
-			// aapt resource value: 0x7f0b005c
-			public static int edit_query = 2131427420;
+			// aapt resource value: 0x7f080047
+			public static int default_activity_button = 2131230791;
 			
-			// aapt resource value: 0x7f0b0017
-			public static int end = 2131427351;
+			// aapt resource value: 0x7f080076
+			public static int design_bottom_sheet = 2131230838;
 			
-			// aapt resource value: 0x7f0b0097
-			public static int end_padder = 2131427479;
+			// aapt resource value: 0x7f08007d
+			public static int design_menu_item_action_area = 2131230845;
 			
-			// aapt resource value: 0x7f0b000b
-			public static int enterAlways = 2131427339;
+			// aapt resource value: 0x7f08007c
+			public static int design_menu_item_action_area_stub = 2131230844;
 			
-			// aapt resource value: 0x7f0b000c
-			public static int enterAlwaysCollapsed = 2131427340;
+			// aapt resource value: 0x7f08007b
+			public static int design_menu_item_text = 2131230843;
 			
-			// aapt resource value: 0x7f0b000d
-			public static int exitUntilCollapsed = 2131427341;
+			// aapt resource value: 0x7f08007a
+			public static int design_navigation_view = 2131230842;
 			
-			// aapt resource value: 0x7f0b003e
-			public static int expand_activities_button = 2131427390;
+			// aapt resource value: 0x7f080012
+			public static int disableHome = 2131230738;
 			
-			// aapt resource value: 0x7f0b0051
-			public static int expanded_menu = 2131427409;
+			// aapt resource value: 0x7f080066
+			public static int edit_query = 2131230822;
 			
-			// aapt resource value: 0x7f0b001f
-			public static int fill = 2131427359;
+			// aapt resource value: 0x7f080021
+			public static int end = 2131230753;
 			
-			// aapt resource value: 0x7f0b0020
-			public static int fill_horizontal = 2131427360;
+			// aapt resource value: 0x7f0800af
+			public static int end_padder = 2131230895;
 			
-			// aapt resource value: 0x7f0b0018
-			public static int fill_vertical = 2131427352;
+			// aapt resource value: 0x7f08002a
+			public static int enterAlways = 2131230762;
 			
-			// aapt resource value: 0x7f0b0023
-			public static int @fixed = 2131427363;
+			// aapt resource value: 0x7f08002b
+			public static int enterAlwaysCollapsed = 2131230763;
 			
-			// aapt resource value: 0x7f0b0006
-			public static int home = 2131427334;
+			// aapt resource value: 0x7f08002c
+			public static int exitUntilCollapsed = 2131230764;
 			
-			// aapt resource value: 0x7f0b0028
-			public static int homeAsUp = 2131427368;
+			// aapt resource value: 0x7f080045
+			public static int expand_activities_button = 2131230789;
 			
-			// aapt resource value: 0x7f0b0042
-			public static int icon = 2131427394;
+			// aapt resource value: 0x7f08005a
+			public static int expanded_menu = 2131230810;
 			
-			// aapt resource value: 0x7f0b0037
-			public static int ifRoom = 2131427383;
+			// aapt resource value: 0x7f08003b
+			public static int fill = 2131230779;
 			
-			// aapt resource value: 0x7f0b003f
-			public static int image = 2131427391;
+			// aapt resource value: 0x7f08003c
+			public static int fill_horizontal = 2131230780;
 			
-			// aapt resource value: 0x7f0b0096
-			public static int info = 2131427478;
+			// aapt resource value: 0x7f080033
+			public static int fill_vertical = 2131230771;
 			
-			// aapt resource value: 0x7f0b0001
-			public static int item_touch_helper_previous_elevation = 2131427329;
+			// aapt resource value: 0x7f08003f
+			public static int @fixed = 2131230783;
 			
-			// aapt resource value: 0x7f0b0019
-			public static int left = 2131427353;
+			// aapt resource value: 0x7f080005
+			public static int home = 2131230725;
 			
-			// aapt resource value: 0x7f0b0090
-			public static int line1 = 2131427472;
+			// aapt resource value: 0x7f080013
+			public static int homeAsUp = 2131230739;
 			
-			// aapt resource value: 0x7f0b0094
-			public static int line3 = 2131427476;
+			// aapt resource value: 0x7f080049
+			public static int icon = 2131230793;
 			
-			// aapt resource value: 0x7f0b0025
-			public static int listMode = 2131427365;
+			// aapt resource value: 0x7f0800aa
+			public static int icon_group = 2131230890;
 			
-			// aapt resource value: 0x7f0b0041
-			public static int list_item = 2131427393;
+			// aapt resource value: 0x7f080025
+			public static int ifRoom = 2131230757;
 			
-			// aapt resource value: 0x7f0b008e
-			public static int media_actions = 2131427470;
+			// aapt resource value: 0x7f080046
+			public static int image = 2131230790;
 			
-			// aapt resource value: 0x7f0b0034
-			public static int middle = 2131427380;
+			// aapt resource value: 0x7f0800a6
+			public static int info = 2131230886;
 			
-			// aapt resource value: 0x7f0b0021
-			public static int mini = 2131427361;
+			// aapt resource value: 0x7f080000
+			public static int item_touch_helper_previous_elevation = 2131230720;
 			
-			// aapt resource value: 0x7f0b007d
-			public static int mr_art = 2131427453;
+			// aapt resource value: 0x7f080074
+			public static int largeLabel = 2131230836;
 			
-			// aapt resource value: 0x7f0b0072
-			public static int mr_chooser_list = 2131427442;
+			// aapt resource value: 0x7f080034
+			public static int left = 2131230772;
 			
-			// aapt resource value: 0x7f0b0075
-			public static int mr_chooser_route_desc = 2131427445;
+			// aapt resource value: 0x7f0800ab
+			public static int line1 = 2131230891;
 			
-			// aapt resource value: 0x7f0b0073
-			public static int mr_chooser_route_icon = 2131427443;
+			// aapt resource value: 0x7f0800ad
+			public static int line3 = 2131230893;
 			
-			// aapt resource value: 0x7f0b0074
-			public static int mr_chooser_route_name = 2131427444;
+			// aapt resource value: 0x7f08000f
+			public static int listMode = 2131230735;
 			
-			// aapt resource value: 0x7f0b007a
-			public static int mr_close = 2131427450;
+			// aapt resource value: 0x7f080048
+			public static int list_item = 2131230792;
 			
-			// aapt resource value: 0x7f0b0080
-			public static int mr_control_divider = 2131427456;
+			// aapt resource value: 0x7f0800b1
+			public static int masked = 2131230897;
 			
-			// aapt resource value: 0x7f0b0086
-			public static int mr_control_play_pause = 2131427462;
+			// aapt resource value: 0x7f08009f
+			public static int media_actions = 2131230879;
 			
-			// aapt resource value: 0x7f0b0089
-			public static int mr_control_subtitle = 2131427465;
+			// aapt resource value: 0x7f080022
+			public static int middle = 2131230754;
 			
-			// aapt resource value: 0x7f0b0088
-			public static int mr_control_title = 2131427464;
+			// aapt resource value: 0x7f08003e
+			public static int mini = 2131230782;
 			
-			// aapt resource value: 0x7f0b0087
-			public static int mr_control_title_container = 2131427463;
+			// aapt resource value: 0x7f08008b
+			public static int mr_art = 2131230859;
 			
-			// aapt resource value: 0x7f0b007b
-			public static int mr_custom_control = 2131427451;
+			// aapt resource value: 0x7f080080
+			public static int mr_chooser_list = 2131230848;
 			
-			// aapt resource value: 0x7f0b007c
-			public static int mr_default_control = 2131427452;
+			// aapt resource value: 0x7f080083
+			public static int mr_chooser_route_desc = 2131230851;
 			
-			// aapt resource value: 0x7f0b0077
-			public static int mr_dialog_area = 2131427447;
+			// aapt resource value: 0x7f080081
+			public static int mr_chooser_route_icon = 2131230849;
 			
-			// aapt resource value: 0x7f0b0076
-			public static int mr_expandable_area = 2131427446;
+			// aapt resource value: 0x7f080082
+			public static int mr_chooser_route_name = 2131230850;
 			
-			// aapt resource value: 0x7f0b008a
-			public static int mr_group_expand_collapse = 2131427466;
+			// aapt resource value: 0x7f08007f
+			public static int mr_chooser_title = 2131230847;
 			
-			// aapt resource value: 0x7f0b007e
-			public static int mr_media_main_control = 2131427454;
+			// aapt resource value: 0x7f080088
+			public static int mr_close = 2131230856;
 			
-			// aapt resource value: 0x7f0b0079
-			public static int mr_name = 2131427449;
+			// aapt resource value: 0x7f08008e
+			public static int mr_control_divider = 2131230862;
 			
-			// aapt resource value: 0x7f0b007f
-			public static int mr_playback_control = 2131427455;
+			// aapt resource value: 0x7f080094
+			public static int mr_control_playback_ctrl = 2131230868;
 			
-			// aapt resource value: 0x7f0b0078
-			public static int mr_title_bar = 2131427448;
+			// aapt resource value: 0x7f080097
+			public static int mr_control_subtitle = 2131230871;
 			
-			// aapt resource value: 0x7f0b0081
-			public static int mr_volume_control = 2131427457;
+			// aapt resource value: 0x7f080096
+			public static int mr_control_title = 2131230870;
 			
-			// aapt resource value: 0x7f0b0082
-			public static int mr_volume_group_list = 2131427458;
+			// aapt resource value: 0x7f080095
+			public static int mr_control_title_container = 2131230869;
 			
-			// aapt resource value: 0x7f0b0084
-			public static int mr_volume_item_icon = 2131427460;
+			// aapt resource value: 0x7f080089
+			public static int mr_custom_control = 2131230857;
 			
-			// aapt resource value: 0x7f0b0085
-			public static int mr_volume_slider = 2131427461;
+			// aapt resource value: 0x7f08008a
+			public static int mr_default_control = 2131230858;
 			
-			// aapt resource value: 0x7f0b002e
-			public static int multiply = 2131427374;
+			// aapt resource value: 0x7f080085
+			public static int mr_dialog_area = 2131230853;
 			
-			// aapt resource value: 0x7f0b006d
-			public static int navigation_header_container = 2131427437;
+			// aapt resource value: 0x7f080084
+			public static int mr_expandable_area = 2131230852;
 			
-			// aapt resource value: 0x7f0b0038
-			public static int never = 2131427384;
+			// aapt resource value: 0x7f080098
+			public static int mr_group_expand_collapse = 2131230872;
 			
-			// aapt resource value: 0x7f0b0010
-			public static int none = 2131427344;
+			// aapt resource value: 0x7f08008c
+			public static int mr_media_main_control = 2131230860;
 			
-			// aapt resource value: 0x7f0b0022
-			public static int normal = 2131427362;
+			// aapt resource value: 0x7f080087
+			public static int mr_name = 2131230855;
 			
-			// aapt resource value: 0x7f0b0011
-			public static int parallax = 2131427345;
+			// aapt resource value: 0x7f08008d
+			public static int mr_playback_control = 2131230861;
 			
-			// aapt resource value: 0x7f0b0046
-			public static int parentPanel = 2131427398;
+			// aapt resource value: 0x7f080086
+			public static int mr_title_bar = 2131230854;
 			
-			// aapt resource value: 0x7f0b0012
-			public static int pin = 2131427346;
+			// aapt resource value: 0x7f08008f
+			public static int mr_volume_control = 2131230863;
 			
-			// aapt resource value: 0x7f0b0007
-			public static int progress_circular = 2131427335;
+			// aapt resource value: 0x7f080090
+			public static int mr_volume_group_list = 2131230864;
 			
-			// aapt resource value: 0x7f0b0008
-			public static int progress_horizontal = 2131427336;
+			// aapt resource value: 0x7f080092
+			public static int mr_volume_item_icon = 2131230866;
 			
-			// aapt resource value: 0x7f0b0054
-			public static int radio = 2131427412;
+			// aapt resource value: 0x7f080093
+			public static int mr_volume_slider = 2131230867;
 			
-			// aapt resource value: 0x7f0b001a
-			public static int right = 2131427354;
+			// aapt resource value: 0x7f08001a
+			public static int multiply = 2131230746;
 			
-			// aapt resource value: 0x7f0b002f
-			public static int screen = 2131427375;
+			// aapt resource value: 0x7f080079
+			public static int navigation_header_container = 2131230841;
 			
-			// aapt resource value: 0x7f0b000e
-			public static int scroll = 2131427342;
+			// aapt resource value: 0x7f080026
+			public static int never = 2131230758;
 			
-			// aapt resource value: 0x7f0b004e
-			public static int scrollIndicatorDown = 2131427406;
+			// aapt resource value: 0x7f080014
+			public static int none = 2131230740;
 			
-			// aapt resource value: 0x7f0b004b
-			public static int scrollIndicatorUp = 2131427403;
+			// aapt resource value: 0x7f080010
+			public static int normal = 2131230736;
 			
-			// aapt resource value: 0x7f0b004c
-			public static int scrollView = 2131427404;
+			// aapt resource value: 0x7f0800a8
+			public static int notification_background = 2131230888;
 			
-			// aapt resource value: 0x7f0b0024
-			public static int scrollable = 2131427364;
+			// aapt resource value: 0x7f0800a2
+			public static int notification_main_column = 2131230882;
 			
-			// aapt resource value: 0x7f0b005e
-			public static int search_badge = 2131427422;
+			// aapt resource value: 0x7f0800a1
+			public static int notification_main_column_container = 2131230881;
 			
-			// aapt resource value: 0x7f0b005d
-			public static int search_bar = 2131427421;
+			// aapt resource value: 0x7f080037
+			public static int parallax = 2131230775;
 			
-			// aapt resource value: 0x7f0b005f
-			public static int search_button = 2131427423;
+			// aapt resource value: 0x7f08004d
+			public static int parentPanel = 2131230797;
 			
-			// aapt resource value: 0x7f0b0064
-			public static int search_close_btn = 2131427428;
+			// aapt resource value: 0x7f080038
+			public static int pin = 2131230776;
 			
-			// aapt resource value: 0x7f0b0060
-			public static int search_edit_frame = 2131427424;
+			// aapt resource value: 0x7f080006
+			public static int progress_circular = 2131230726;
 			
-			// aapt resource value: 0x7f0b0066
-			public static int search_go_btn = 2131427430;
+			// aapt resource value: 0x7f080007
+			public static int progress_horizontal = 2131230727;
 			
-			// aapt resource value: 0x7f0b0061
-			public static int search_mag_icon = 2131427425;
+			// aapt resource value: 0x7f08005d
+			public static int radio = 2131230813;
 			
-			// aapt resource value: 0x7f0b0062
-			public static int search_plate = 2131427426;
+			// aapt resource value: 0x7f080035
+			public static int right = 2131230773;
 			
-			// aapt resource value: 0x7f0b0063
-			public static int search_src_text = 2131427427;
+			// aapt resource value: 0x7f0800a7
+			public static int right_icon = 2131230887;
 			
-			// aapt resource value: 0x7f0b0067
-			public static int search_voice_btn = 2131427431;
+			// aapt resource value: 0x7f0800a3
+			public static int right_side = 2131230883;
 			
-			// aapt resource value: 0x7f0b0068
-			public static int select_dialog_listview = 2131427432;
+			// aapt resource value: 0x7f08001b
+			public static int screen = 2131230747;
 			
-			// aapt resource value: 0x7f0b0053
-			public static int shortcut = 2131427411;
+			// aapt resource value: 0x7f08002d
+			public static int scroll = 2131230765;
 			
-			// aapt resource value: 0x7f0b0029
-			public static int showCustom = 2131427369;
+			// aapt resource value: 0x7f080053
+			public static int scrollIndicatorDown = 2131230803;
 			
-			// aapt resource value: 0x7f0b002a
-			public static int showHome = 2131427370;
+			// aapt resource value: 0x7f08004f
+			public static int scrollIndicatorUp = 2131230799;
 			
-			// aapt resource value: 0x7f0b002b
-			public static int showTitle = 2131427371;
+			// aapt resource value: 0x7f080050
+			public static int scrollView = 2131230800;
 			
-			// aapt resource value: 0x7f0b006c
-			public static int snackbar_action = 2131427436;
+			// aapt resource value: 0x7f080040
+			public static int scrollable = 2131230784;
 			
-			// aapt resource value: 0x7f0b006b
-			public static int snackbar_text = 2131427435;
+			// aapt resource value: 0x7f080068
+			public static int search_badge = 2131230824;
 			
-			// aapt resource value: 0x7f0b000f
-			public static int snap = 2131427343;
+			// aapt resource value: 0x7f080067
+			public static int search_bar = 2131230823;
 			
-			// aapt resource value: 0x7f0b0045
-			public static int spacer = 2131427397;
+			// aapt resource value: 0x7f080069
+			public static int search_button = 2131230825;
 			
-			// aapt resource value: 0x7f0b0009
-			public static int split_action_bar = 2131427337;
+			// aapt resource value: 0x7f08006e
+			public static int search_close_btn = 2131230830;
 			
-			// aapt resource value: 0x7f0b0030
-			public static int src_atop = 2131427376;
+			// aapt resource value: 0x7f08006a
+			public static int search_edit_frame = 2131230826;
 			
-			// aapt resource value: 0x7f0b0031
-			public static int src_in = 2131427377;
+			// aapt resource value: 0x7f080070
+			public static int search_go_btn = 2131230832;
 			
-			// aapt resource value: 0x7f0b0032
-			public static int src_over = 2131427378;
+			// aapt resource value: 0x7f08006b
+			public static int search_mag_icon = 2131230827;
 			
-			// aapt resource value: 0x7f0b001b
-			public static int start = 2131427355;
+			// aapt resource value: 0x7f08006c
+			public static int search_plate = 2131230828;
 			
-			// aapt resource value: 0x7f0b008d
-			public static int status_bar_latest_event_content = 2131427469;
+			// aapt resource value: 0x7f08006d
+			public static int search_src_text = 2131230829;
 			
-			// aapt resource value: 0x7f0b0065
-			public static int submit_area = 2131427429;
+			// aapt resource value: 0x7f080071
+			public static int search_voice_btn = 2131230833;
 			
-			// aapt resource value: 0x7f0b0026
-			public static int tabMode = 2131427366;
+			// aapt resource value: 0x7f080072
+			public static int select_dialog_listview = 2131230834;
 			
-			// aapt resource value: 0x7f0b0095
-			public static int text = 2131427477;
+			// aapt resource value: 0x7f08005c
+			public static int shortcut = 2131230812;
 			
-			// aapt resource value: 0x7f0b0093
-			public static int text2 = 2131427475;
+			// aapt resource value: 0x7f080015
+			public static int showCustom = 2131230741;
 			
-			// aapt resource value: 0x7f0b004d
-			public static int textSpacerNoButtons = 2131427405;
+			// aapt resource value: 0x7f080016
+			public static int showHome = 2131230742;
 			
-			// aapt resource value: 0x7f0b0091
-			public static int time = 2131427473;
+			// aapt resource value: 0x7f080017
+			public static int showTitle = 2131230743;
 			
-			// aapt resource value: 0x7f0b0043
-			public static int title = 2131427395;
+			// aapt resource value: 0x7f080073
+			public static int smallLabel = 2131230835;
 			
-			// aapt resource value: 0x7f0b0048
-			public static int title_template = 2131427400;
+			// aapt resource value: 0x7f080078
+			public static int snackbar_action = 2131230840;
 			
-			// aapt resource value: 0x7f0b001c
-			public static int top = 2131427356;
+			// aapt resource value: 0x7f080077
+			public static int snackbar_text = 2131230839;
 			
-			// aapt resource value: 0x7f0b0047
-			public static int topPanel = 2131427399;
+			// aapt resource value: 0x7f08002e
+			public static int snap = 2131230766;
 			
-			// aapt resource value: 0x7f0b0069
-			public static int touch_outside = 2131427433;
+			// aapt resource value: 0x7f08004c
+			public static int spacer = 2131230796;
 			
-			// aapt resource value: 0x7f0b000a
-			public static int up = 2131427338;
+			// aapt resource value: 0x7f080008
+			public static int split_action_bar = 2131230728;
 			
-			// aapt resource value: 0x7f0b002c
-			public static int useLogo = 2131427372;
+			// aapt resource value: 0x7f08001c
+			public static int src_atop = 2131230748;
 			
-			// aapt resource value: 0x7f0b0000
-			public static int view_offset_helper = 2131427328;
+			// aapt resource value: 0x7f08001d
+			public static int src_in = 2131230749;
 			
-			// aapt resource value: 0x7f0b0083
-			public static int volume_item_container = 2131427459;
+			// aapt resource value: 0x7f08001e
+			public static int src_over = 2131230750;
 			
-			// aapt resource value: 0x7f0b0039
-			public static int withText = 2131427385;
+			// aapt resource value: 0x7f080036
+			public static int start = 2131230774;
 			
-			// aapt resource value: 0x7f0b002d
-			public static int wrap_content = 2131427373;
+			// aapt resource value: 0x7f08009e
+			public static int status_bar_latest_event_content = 2131230878;
+			
+			// aapt resource value: 0x7f08005e
+			public static int submenuarrow = 2131230814;
+			
+			// aapt resource value: 0x7f08006f
+			public static int submit_area = 2131230831;
+			
+			// aapt resource value: 0x7f080011
+			public static int tabMode = 2131230737;
+			
+			// aapt resource value: 0x7f0800ae
+			public static int text = 2131230894;
+			
+			// aapt resource value: 0x7f0800ac
+			public static int text2 = 2131230892;
+			
+			// aapt resource value: 0x7f080052
+			public static int textSpacerNoButtons = 2131230802;
+			
+			// aapt resource value: 0x7f080051
+			public static int textSpacerNoTitle = 2131230801;
+			
+			// aapt resource value: 0x7f08007e
+			public static int text_input_password_toggle = 2131230846;
+			
+			// aapt resource value: 0x7f08000c
+			public static int textinput_counter = 2131230732;
+			
+			// aapt resource value: 0x7f08000d
+			public static int textinput_error = 2131230733;
+			
+			// aapt resource value: 0x7f0800a4
+			public static int time = 2131230884;
+			
+			// aapt resource value: 0x7f08004a
+			public static int title = 2131230794;
+			
+			// aapt resource value: 0x7f080059
+			public static int titleDividerNoCustom = 2131230809;
+			
+			// aapt resource value: 0x7f080057
+			public static int title_template = 2131230807;
+			
+			// aapt resource value: 0x7f080029
+			public static int top = 2131230761;
+			
+			// aapt resource value: 0x7f080056
+			public static int topPanel = 2131230806;
+			
+			// aapt resource value: 0x7f080075
+			public static int touch_outside = 2131230837;
+			
+			// aapt resource value: 0x7f08000a
+			public static int transition_current_scene = 2131230730;
+			
+			// aapt resource value: 0x7f08000b
+			public static int transition_scene_layoutid_cache = 2131230731;
+			
+			// aapt resource value: 0x7f080009
+			public static int up = 2131230729;
+			
+			// aapt resource value: 0x7f080018
+			public static int useLogo = 2131230744;
+			
+			// aapt resource value: 0x7f08000e
+			public static int view_offset_helper = 2131230734;
+			
+			// aapt resource value: 0x7f0800b0
+			public static int visible = 2131230896;
+			
+			// aapt resource value: 0x7f080091
+			public static int volume_item_container = 2131230865;
+			
+			// aapt resource value: 0x7f080027
+			public static int withText = 2131230759;
+			
+			// aapt resource value: 0x7f08001f
+			public static int wrap_content = 2131230751;
 			
 			static Id()
 			{
@@ -2677,35 +3311,41 @@ namespace XFGloss.Droid
 		public partial class Integer
 		{
 			
-			// aapt resource value: 0x7f080006
-			public static int abc_config_activityDefaultDur = 2131230726;
+			// aapt resource value: 0x7f0a0003
+			public static int abc_config_activityDefaultDur = 2131361795;
 			
-			// aapt resource value: 0x7f080007
-			public static int abc_config_activityShortDur = 2131230727;
+			// aapt resource value: 0x7f0a0004
+			public static int abc_config_activityShortDur = 2131361796;
 			
-			// aapt resource value: 0x7f080005
-			public static int abc_max_action_buttons = 2131230725;
+			// aapt resource value: 0x7f0a0008
+			public static int app_bar_elevation_anim_duration = 2131361800;
 			
-			// aapt resource value: 0x7f080004
-			public static int bottom_sheet_slide_duration = 2131230724;
+			// aapt resource value: 0x7f0a0009
+			public static int bottom_sheet_slide_duration = 2131361801;
 			
-			// aapt resource value: 0x7f080008
-			public static int cancel_button_image_alpha = 2131230728;
+			// aapt resource value: 0x7f0a0005
+			public static int cancel_button_image_alpha = 2131361797;
 			
-			// aapt resource value: 0x7f080003
-			public static int design_snackbar_text_max_lines = 2131230723;
+			// aapt resource value: 0x7f0a0007
+			public static int design_snackbar_text_max_lines = 2131361799;
 			
-			// aapt resource value: 0x7f080000
-			public static int mr_controller_volume_group_list_animation_duration_ms = 2131230720;
+			// aapt resource value: 0x7f0a000a
+			public static int hide_password_duration = 2131361802;
 			
-			// aapt resource value: 0x7f080001
-			public static int mr_controller_volume_group_list_fade_in_duration_ms = 2131230721;
+			// aapt resource value: 0x7f0a0000
+			public static int mr_controller_volume_group_list_animation_duration_ms = 2131361792;
 			
-			// aapt resource value: 0x7f080002
-			public static int mr_controller_volume_group_list_fade_out_duration_ms = 2131230722;
+			// aapt resource value: 0x7f0a0001
+			public static int mr_controller_volume_group_list_fade_in_duration_ms = 2131361793;
 			
-			// aapt resource value: 0x7f080009
-			public static int status_bar_notification_info_maxnum = 2131230729;
+			// aapt resource value: 0x7f0a0002
+			public static int mr_controller_volume_group_list_fade_out_duration_ms = 2131361794;
+			
+			// aapt resource value: 0x7f0a000b
+			public static int show_password_duration = 2131361803;
+			
+			// aapt resource value: 0x7f0a0006
+			public static int status_bar_notification_info_maxnum = 2131361798;
 			
 			static Integer()
 			{
@@ -2720,11 +3360,11 @@ namespace XFGloss.Droid
 		public partial class Interpolator
 		{
 			
-			// aapt resource value: 0x7f050000
-			public static int mr_fast_out_slow_in = 2131034112;
+			// aapt resource value: 0x7f060000
+			public static int mr_fast_out_slow_in = 2131099648;
 			
-			// aapt resource value: 0x7f050001
-			public static int mr_linear_out_slow_in = 2131034113;
+			// aapt resource value: 0x7f060001
+			public static int mr_linear_out_slow_in = 2131099649;
 			
 			static Interpolator()
 			{
@@ -2773,136 +3413,169 @@ namespace XFGloss.Droid
 			public static int abc_alert_dialog_material = 2130903050;
 			
 			// aapt resource value: 0x7f03000b
-			public static int abc_dialog_title_material = 2130903051;
+			public static int abc_alert_dialog_title_material = 2130903051;
 			
 			// aapt resource value: 0x7f03000c
-			public static int abc_expanded_menu_layout = 2130903052;
+			public static int abc_dialog_title_material = 2130903052;
 			
 			// aapt resource value: 0x7f03000d
-			public static int abc_list_menu_item_checkbox = 2130903053;
+			public static int abc_expanded_menu_layout = 2130903053;
 			
 			// aapt resource value: 0x7f03000e
-			public static int abc_list_menu_item_icon = 2130903054;
+			public static int abc_list_menu_item_checkbox = 2130903054;
 			
 			// aapt resource value: 0x7f03000f
-			public static int abc_list_menu_item_layout = 2130903055;
+			public static int abc_list_menu_item_icon = 2130903055;
 			
 			// aapt resource value: 0x7f030010
-			public static int abc_list_menu_item_radio = 2130903056;
+			public static int abc_list_menu_item_layout = 2130903056;
 			
 			// aapt resource value: 0x7f030011
-			public static int abc_popup_menu_item_layout = 2130903057;
+			public static int abc_list_menu_item_radio = 2130903057;
 			
 			// aapt resource value: 0x7f030012
-			public static int abc_screen_content_include = 2130903058;
+			public static int abc_popup_menu_header_item_layout = 2130903058;
 			
 			// aapt resource value: 0x7f030013
-			public static int abc_screen_simple = 2130903059;
+			public static int abc_popup_menu_item_layout = 2130903059;
 			
 			// aapt resource value: 0x7f030014
-			public static int abc_screen_simple_overlay_action_mode = 2130903060;
+			public static int abc_screen_content_include = 2130903060;
 			
 			// aapt resource value: 0x7f030015
-			public static int abc_screen_toolbar = 2130903061;
+			public static int abc_screen_simple = 2130903061;
 			
 			// aapt resource value: 0x7f030016
-			public static int abc_search_dropdown_item_icons_2line = 2130903062;
+			public static int abc_screen_simple_overlay_action_mode = 2130903062;
 			
 			// aapt resource value: 0x7f030017
-			public static int abc_search_view = 2130903063;
+			public static int abc_screen_toolbar = 2130903063;
 			
 			// aapt resource value: 0x7f030018
-			public static int abc_select_dialog_material = 2130903064;
+			public static int abc_search_dropdown_item_icons_2line = 2130903064;
 			
 			// aapt resource value: 0x7f030019
-			public static int design_bottom_sheet_dialog = 2130903065;
+			public static int abc_search_view = 2130903065;
 			
 			// aapt resource value: 0x7f03001a
-			public static int design_layout_snackbar = 2130903066;
+			public static int abc_select_dialog_material = 2130903066;
 			
 			// aapt resource value: 0x7f03001b
-			public static int design_layout_snackbar_include = 2130903067;
+			public static int design_bottom_navigation_item = 2130903067;
 			
 			// aapt resource value: 0x7f03001c
-			public static int design_layout_tab_icon = 2130903068;
+			public static int design_bottom_sheet_dialog = 2130903068;
 			
 			// aapt resource value: 0x7f03001d
-			public static int design_layout_tab_text = 2130903069;
+			public static int design_layout_snackbar = 2130903069;
 			
 			// aapt resource value: 0x7f03001e
-			public static int design_menu_item_action_area = 2130903070;
+			public static int design_layout_snackbar_include = 2130903070;
 			
 			// aapt resource value: 0x7f03001f
-			public static int design_navigation_item = 2130903071;
+			public static int design_layout_tab_icon = 2130903071;
 			
 			// aapt resource value: 0x7f030020
-			public static int design_navigation_item_header = 2130903072;
+			public static int design_layout_tab_text = 2130903072;
 			
 			// aapt resource value: 0x7f030021
-			public static int design_navigation_item_separator = 2130903073;
+			public static int design_menu_item_action_area = 2130903073;
 			
 			// aapt resource value: 0x7f030022
-			public static int design_navigation_item_subheader = 2130903074;
+			public static int design_navigation_item = 2130903074;
 			
 			// aapt resource value: 0x7f030023
-			public static int design_navigation_menu = 2130903075;
+			public static int design_navigation_item_header = 2130903075;
 			
 			// aapt resource value: 0x7f030024
-			public static int design_navigation_menu_item = 2130903076;
+			public static int design_navigation_item_separator = 2130903076;
 			
 			// aapt resource value: 0x7f030025
-			public static int mr_chooser_dialog = 2130903077;
+			public static int design_navigation_item_subheader = 2130903077;
 			
 			// aapt resource value: 0x7f030026
-			public static int mr_chooser_list_item = 2130903078;
+			public static int design_navigation_menu = 2130903078;
 			
 			// aapt resource value: 0x7f030027
-			public static int mr_controller_material_dialog_b = 2130903079;
+			public static int design_navigation_menu_item = 2130903079;
 			
 			// aapt resource value: 0x7f030028
-			public static int mr_controller_volume_item = 2130903080;
+			public static int design_text_input_password_icon = 2130903080;
 			
 			// aapt resource value: 0x7f030029
-			public static int mr_playback_control = 2130903081;
+			public static int mr_chooser_dialog = 2130903081;
 			
 			// aapt resource value: 0x7f03002a
-			public static int mr_volume_control = 2130903082;
+			public static int mr_chooser_list_item = 2130903082;
 			
 			// aapt resource value: 0x7f03002b
-			public static int notification_media_action = 2130903083;
+			public static int mr_controller_material_dialog_b = 2130903083;
 			
 			// aapt resource value: 0x7f03002c
-			public static int notification_media_cancel_action = 2130903084;
+			public static int mr_controller_volume_item = 2130903084;
 			
 			// aapt resource value: 0x7f03002d
-			public static int notification_template_big_media = 2130903085;
+			public static int mr_playback_control = 2130903085;
 			
 			// aapt resource value: 0x7f03002e
-			public static int notification_template_big_media_narrow = 2130903086;
+			public static int mr_volume_control = 2130903086;
 			
 			// aapt resource value: 0x7f03002f
-			public static int notification_template_lines = 2130903087;
+			public static int notification_action = 2130903087;
 			
 			// aapt resource value: 0x7f030030
-			public static int notification_template_media = 2130903088;
+			public static int notification_action_tombstone = 2130903088;
 			
 			// aapt resource value: 0x7f030031
-			public static int notification_template_part_chronometer = 2130903089;
+			public static int notification_media_action = 2130903089;
 			
 			// aapt resource value: 0x7f030032
-			public static int notification_template_part_time = 2130903090;
+			public static int notification_media_cancel_action = 2130903090;
 			
 			// aapt resource value: 0x7f030033
-			public static int select_dialog_item_material = 2130903091;
+			public static int notification_template_big_media = 2130903091;
 			
 			// aapt resource value: 0x7f030034
-			public static int select_dialog_multichoice_material = 2130903092;
+			public static int notification_template_big_media_custom = 2130903092;
 			
 			// aapt resource value: 0x7f030035
-			public static int select_dialog_singlechoice_material = 2130903093;
+			public static int notification_template_big_media_narrow = 2130903093;
 			
 			// aapt resource value: 0x7f030036
-			public static int support_simple_spinner_dropdown_item = 2130903094;
+			public static int notification_template_big_media_narrow_custom = 2130903094;
+			
+			// aapt resource value: 0x7f030037
+			public static int notification_template_custom_big = 2130903095;
+			
+			// aapt resource value: 0x7f030038
+			public static int notification_template_icon_group = 2130903096;
+			
+			// aapt resource value: 0x7f030039
+			public static int notification_template_lines_media = 2130903097;
+			
+			// aapt resource value: 0x7f03003a
+			public static int notification_template_media = 2130903098;
+			
+			// aapt resource value: 0x7f03003b
+			public static int notification_template_media_custom = 2130903099;
+			
+			// aapt resource value: 0x7f03003c
+			public static int notification_template_part_chronometer = 2130903100;
+			
+			// aapt resource value: 0x7f03003d
+			public static int notification_template_part_time = 2130903101;
+			
+			// aapt resource value: 0x7f03003e
+			public static int select_dialog_item_material = 2130903102;
+			
+			// aapt resource value: 0x7f03003f
+			public static int select_dialog_multichoice_material = 2130903103;
+			
+			// aapt resource value: 0x7f030040
+			public static int select_dialog_singlechoice_material = 2130903104;
+			
+			// aapt resource value: 0x7f030041
+			public static int support_simple_spinner_dropdown_item = 2130903105;
 			
 			static Layout()
 			{
@@ -2917,122 +3590,194 @@ namespace XFGloss.Droid
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f060012
-			public static int abc_action_bar_home_description = 2131099666;
+			// aapt resource value: 0x7f090015
+			public static int abc_action_bar_home_description = 2131296277;
 			
-			// aapt resource value: 0x7f060013
-			public static int abc_action_bar_home_description_format = 2131099667;
+			// aapt resource value: 0x7f090016
+			public static int abc_action_bar_home_description_format = 2131296278;
 			
-			// aapt resource value: 0x7f060014
-			public static int abc_action_bar_home_subtitle_description_format = 2131099668;
+			// aapt resource value: 0x7f090017
+			public static int abc_action_bar_home_subtitle_description_format = 2131296279;
 			
-			// aapt resource value: 0x7f060015
-			public static int abc_action_bar_up_description = 2131099669;
+			// aapt resource value: 0x7f090018
+			public static int abc_action_bar_up_description = 2131296280;
 			
-			// aapt resource value: 0x7f060016
-			public static int abc_action_menu_overflow_description = 2131099670;
+			// aapt resource value: 0x7f090019
+			public static int abc_action_menu_overflow_description = 2131296281;
 			
-			// aapt resource value: 0x7f060017
-			public static int abc_action_mode_done = 2131099671;
+			// aapt resource value: 0x7f09001a
+			public static int abc_action_mode_done = 2131296282;
 			
-			// aapt resource value: 0x7f060018
-			public static int abc_activity_chooser_view_see_all = 2131099672;
+			// aapt resource value: 0x7f09001b
+			public static int abc_activity_chooser_view_see_all = 2131296283;
 			
-			// aapt resource value: 0x7f060019
-			public static int abc_activitychooserview_choose_application = 2131099673;
+			// aapt resource value: 0x7f09001c
+			public static int abc_activitychooserview_choose_application = 2131296284;
 			
-			// aapt resource value: 0x7f06001a
-			public static int abc_capital_off = 2131099674;
+			// aapt resource value: 0x7f09001d
+			public static int abc_capital_off = 2131296285;
 			
-			// aapt resource value: 0x7f06001b
-			public static int abc_capital_on = 2131099675;
+			// aapt resource value: 0x7f09001e
+			public static int abc_capital_on = 2131296286;
 			
-			// aapt resource value: 0x7f06001c
-			public static int abc_search_hint = 2131099676;
+			// aapt resource value: 0x7f09002a
+			public static int abc_font_family_body_1_material = 2131296298;
 			
-			// aapt resource value: 0x7f06001d
-			public static int abc_searchview_description_clear = 2131099677;
+			// aapt resource value: 0x7f09002b
+			public static int abc_font_family_body_2_material = 2131296299;
 			
-			// aapt resource value: 0x7f06001e
-			public static int abc_searchview_description_query = 2131099678;
+			// aapt resource value: 0x7f09002c
+			public static int abc_font_family_button_material = 2131296300;
 			
-			// aapt resource value: 0x7f06001f
-			public static int abc_searchview_description_search = 2131099679;
+			// aapt resource value: 0x7f09002d
+			public static int abc_font_family_caption_material = 2131296301;
 			
-			// aapt resource value: 0x7f060020
-			public static int abc_searchview_description_submit = 2131099680;
+			// aapt resource value: 0x7f09002e
+			public static int abc_font_family_display_1_material = 2131296302;
 			
-			// aapt resource value: 0x7f060021
-			public static int abc_searchview_description_voice = 2131099681;
+			// aapt resource value: 0x7f09002f
+			public static int abc_font_family_display_2_material = 2131296303;
 			
-			// aapt resource value: 0x7f060022
-			public static int abc_shareactionprovider_share_with = 2131099682;
+			// aapt resource value: 0x7f090030
+			public static int abc_font_family_display_3_material = 2131296304;
 			
-			// aapt resource value: 0x7f060023
-			public static int abc_shareactionprovider_share_with_application = 2131099683;
+			// aapt resource value: 0x7f090031
+			public static int abc_font_family_display_4_material = 2131296305;
 			
-			// aapt resource value: 0x7f060024
-			public static int abc_toolbar_collapse_description = 2131099684;
+			// aapt resource value: 0x7f090032
+			public static int abc_font_family_headline_material = 2131296306;
 			
-			// aapt resource value: 0x7f06000f
-			public static int appbar_scrolling_view_behavior = 2131099663;
+			// aapt resource value: 0x7f090033
+			public static int abc_font_family_menu_material = 2131296307;
 			
-			// aapt resource value: 0x7f060010
-			public static int bottom_sheet_behavior = 2131099664;
+			// aapt resource value: 0x7f090034
+			public static int abc_font_family_subhead_material = 2131296308;
 			
-			// aapt resource value: 0x7f060011
-			public static int character_counter_pattern = 2131099665;
+			// aapt resource value: 0x7f090035
+			public static int abc_font_family_title_material = 2131296309;
 			
-			// aapt resource value: 0x7f060026
-			public static int library_name = 2131099686;
+			// aapt resource value: 0x7f09001f
+			public static int abc_search_hint = 2131296287;
 			
-			// aapt resource value: 0x7f060000
-			public static int mr_button_content_description = 2131099648;
+			// aapt resource value: 0x7f090020
+			public static int abc_searchview_description_clear = 2131296288;
 			
-			// aapt resource value: 0x7f060001
-			public static int mr_chooser_searching = 2131099649;
+			// aapt resource value: 0x7f090021
+			public static int abc_searchview_description_query = 2131296289;
 			
-			// aapt resource value: 0x7f060002
-			public static int mr_chooser_title = 2131099650;
+			// aapt resource value: 0x7f090022
+			public static int abc_searchview_description_search = 2131296290;
 			
-			// aapt resource value: 0x7f060003
-			public static int mr_controller_casting_screen = 2131099651;
+			// aapt resource value: 0x7f090023
+			public static int abc_searchview_description_submit = 2131296291;
 			
-			// aapt resource value: 0x7f060004
-			public static int mr_controller_close_description = 2131099652;
+			// aapt resource value: 0x7f090024
+			public static int abc_searchview_description_voice = 2131296292;
 			
-			// aapt resource value: 0x7f060005
-			public static int mr_controller_collapse_group = 2131099653;
+			// aapt resource value: 0x7f090025
+			public static int abc_shareactionprovider_share_with = 2131296293;
 			
-			// aapt resource value: 0x7f060006
-			public static int mr_controller_disconnect = 2131099654;
+			// aapt resource value: 0x7f090026
+			public static int abc_shareactionprovider_share_with_application = 2131296294;
 			
-			// aapt resource value: 0x7f060007
-			public static int mr_controller_expand_group = 2131099655;
+			// aapt resource value: 0x7f090027
+			public static int abc_toolbar_collapse_description = 2131296295;
 			
-			// aapt resource value: 0x7f060008
-			public static int mr_controller_no_info_available = 2131099656;
+			// aapt resource value: 0x7f090036
+			public static int appbar_scrolling_view_behavior = 2131296310;
 			
-			// aapt resource value: 0x7f060009
-			public static int mr_controller_no_media_selected = 2131099657;
+			// aapt resource value: 0x7f090037
+			public static int bottom_sheet_behavior = 2131296311;
 			
-			// aapt resource value: 0x7f06000a
-			public static int mr_controller_pause = 2131099658;
+			// aapt resource value: 0x7f090038
+			public static int character_counter_pattern = 2131296312;
 			
-			// aapt resource value: 0x7f06000b
-			public static int mr_controller_play = 2131099659;
+			// aapt resource value: 0x7f09003e
+			public static int library_name = 2131296318;
 			
-			// aapt resource value: 0x7f06000c
-			public static int mr_controller_stop = 2131099660;
+			// aapt resource value: 0x7f090000
+			public static int mr_button_content_description = 2131296256;
 			
-			// aapt resource value: 0x7f06000d
-			public static int mr_system_route_name = 2131099661;
+			// aapt resource value: 0x7f090001
+			public static int mr_cast_button_connected = 2131296257;
 			
-			// aapt resource value: 0x7f06000e
-			public static int mr_user_route_category_name = 2131099662;
+			// aapt resource value: 0x7f090002
+			public static int mr_cast_button_connecting = 2131296258;
 			
-			// aapt resource value: 0x7f060025
-			public static int status_bar_notification_info_overflow = 2131099685;
+			// aapt resource value: 0x7f090003
+			public static int mr_cast_button_disconnected = 2131296259;
+			
+			// aapt resource value: 0x7f090004
+			public static int mr_chooser_searching = 2131296260;
+			
+			// aapt resource value: 0x7f090005
+			public static int mr_chooser_title = 2131296261;
+			
+			// aapt resource value: 0x7f090006
+			public static int mr_controller_album_art = 2131296262;
+			
+			// aapt resource value: 0x7f090007
+			public static int mr_controller_casting_screen = 2131296263;
+			
+			// aapt resource value: 0x7f090008
+			public static int mr_controller_close_description = 2131296264;
+			
+			// aapt resource value: 0x7f090009
+			public static int mr_controller_collapse_group = 2131296265;
+			
+			// aapt resource value: 0x7f09000a
+			public static int mr_controller_disconnect = 2131296266;
+			
+			// aapt resource value: 0x7f09000b
+			public static int mr_controller_expand_group = 2131296267;
+			
+			// aapt resource value: 0x7f09000c
+			public static int mr_controller_no_info_available = 2131296268;
+			
+			// aapt resource value: 0x7f09000d
+			public static int mr_controller_no_media_selected = 2131296269;
+			
+			// aapt resource value: 0x7f09000e
+			public static int mr_controller_pause = 2131296270;
+			
+			// aapt resource value: 0x7f09000f
+			public static int mr_controller_play = 2131296271;
+			
+			// aapt resource value: 0x7f090014
+			public static int mr_controller_stop = 2131296276;
+			
+			// aapt resource value: 0x7f090010
+			public static int mr_controller_stop_casting = 2131296272;
+			
+			// aapt resource value: 0x7f090011
+			public static int mr_controller_volume_slider = 2131296273;
+			
+			// aapt resource value: 0x7f090012
+			public static int mr_system_route_name = 2131296274;
+			
+			// aapt resource value: 0x7f090013
+			public static int mr_user_route_category_name = 2131296275;
+			
+			// aapt resource value: 0x7f090039
+			public static int password_toggle_content_description = 2131296313;
+			
+			// aapt resource value: 0x7f09003a
+			public static int path_password_eye = 2131296314;
+			
+			// aapt resource value: 0x7f09003b
+			public static int path_password_eye_mask_strike_through = 2131296315;
+			
+			// aapt resource value: 0x7f09003c
+			public static int path_password_eye_mask_visible = 2131296316;
+			
+			// aapt resource value: 0x7f09003d
+			public static int path_password_strike_through = 2131296317;
+			
+			// aapt resource value: 0x7f090028
+			public static int search_menu_title = 2131296296;
+			
+			// aapt resource value: 0x7f090029
+			public static int status_bar_notification_info_overflow = 2131296297;
 			
 			static String()
 			{
@@ -3047,1115 +3792,1184 @@ namespace XFGloss.Droid
 		public partial class Style
 		{
 			
-			// aapt resource value: 0x7f0900ba
-			public static int AlertDialog_AppCompat = 2131296442;
+			// aapt resource value: 0x7f0b00ae
+			public static int AlertDialog_AppCompat = 2131427502;
 			
-			// aapt resource value: 0x7f0900bb
-			public static int AlertDialog_AppCompat_Light = 2131296443;
+			// aapt resource value: 0x7f0b00af
+			public static int AlertDialog_AppCompat_Light = 2131427503;
 			
-			// aapt resource value: 0x7f0900bc
-			public static int Animation_AppCompat_Dialog = 2131296444;
+			// aapt resource value: 0x7f0b00b0
+			public static int Animation_AppCompat_Dialog = 2131427504;
 			
-			// aapt resource value: 0x7f0900bd
-			public static int Animation_AppCompat_DropDownUp = 2131296445;
+			// aapt resource value: 0x7f0b00b1
+			public static int Animation_AppCompat_DropDownUp = 2131427505;
 			
-			// aapt resource value: 0x7f09001c
-			public static int Animation_Design_BottomSheetDialog = 2131296284;
+			// aapt resource value: 0x7f0b0170
+			public static int Animation_Design_BottomSheetDialog = 2131427696;
 			
-			// aapt resource value: 0x7f0900be
-			public static int Base_AlertDialog_AppCompat = 2131296446;
+			// aapt resource value: 0x7f0b00b2
+			public static int Base_AlertDialog_AppCompat = 2131427506;
 			
-			// aapt resource value: 0x7f0900bf
-			public static int Base_AlertDialog_AppCompat_Light = 2131296447;
+			// aapt resource value: 0x7f0b00b3
+			public static int Base_AlertDialog_AppCompat_Light = 2131427507;
 			
-			// aapt resource value: 0x7f0900c0
-			public static int Base_Animation_AppCompat_Dialog = 2131296448;
+			// aapt resource value: 0x7f0b00b4
+			public static int Base_Animation_AppCompat_Dialog = 2131427508;
 			
-			// aapt resource value: 0x7f0900c1
-			public static int Base_Animation_AppCompat_DropDownUp = 2131296449;
+			// aapt resource value: 0x7f0b00b5
+			public static int Base_Animation_AppCompat_DropDownUp = 2131427509;
 			
-			// aapt resource value: 0x7f090018
-			public static int Base_CardView = 2131296280;
+			// aapt resource value: 0x7f0b000c
+			public static int Base_CardView = 2131427340;
 			
-			// aapt resource value: 0x7f0900c2
-			public static int Base_DialogWindowTitle_AppCompat = 2131296450;
+			// aapt resource value: 0x7f0b00b6
+			public static int Base_DialogWindowTitle_AppCompat = 2131427510;
 			
-			// aapt resource value: 0x7f0900c3
-			public static int Base_DialogWindowTitleBackground_AppCompat = 2131296451;
+			// aapt resource value: 0x7f0b00b7
+			public static int Base_DialogWindowTitleBackground_AppCompat = 2131427511;
 			
-			// aapt resource value: 0x7f09006a
-			public static int Base_TextAppearance_AppCompat = 2131296362;
+			// aapt resource value: 0x7f0b004e
+			public static int Base_TextAppearance_AppCompat = 2131427406;
 			
-			// aapt resource value: 0x7f09006b
-			public static int Base_TextAppearance_AppCompat_Body1 = 2131296363;
+			// aapt resource value: 0x7f0b004f
+			public static int Base_TextAppearance_AppCompat_Body1 = 2131427407;
 			
-			// aapt resource value: 0x7f09006c
-			public static int Base_TextAppearance_AppCompat_Body2 = 2131296364;
+			// aapt resource value: 0x7f0b0050
+			public static int Base_TextAppearance_AppCompat_Body2 = 2131427408;
 			
-			// aapt resource value: 0x7f090054
-			public static int Base_TextAppearance_AppCompat_Button = 2131296340;
+			// aapt resource value: 0x7f0b0036
+			public static int Base_TextAppearance_AppCompat_Button = 2131427382;
 			
-			// aapt resource value: 0x7f09006d
-			public static int Base_TextAppearance_AppCompat_Caption = 2131296365;
+			// aapt resource value: 0x7f0b0051
+			public static int Base_TextAppearance_AppCompat_Caption = 2131427409;
 			
-			// aapt resource value: 0x7f09006e
-			public static int Base_TextAppearance_AppCompat_Display1 = 2131296366;
+			// aapt resource value: 0x7f0b0052
+			public static int Base_TextAppearance_AppCompat_Display1 = 2131427410;
 			
-			// aapt resource value: 0x7f09006f
-			public static int Base_TextAppearance_AppCompat_Display2 = 2131296367;
+			// aapt resource value: 0x7f0b0053
+			public static int Base_TextAppearance_AppCompat_Display2 = 2131427411;
 			
-			// aapt resource value: 0x7f090070
-			public static int Base_TextAppearance_AppCompat_Display3 = 2131296368;
+			// aapt resource value: 0x7f0b0054
+			public static int Base_TextAppearance_AppCompat_Display3 = 2131427412;
 			
-			// aapt resource value: 0x7f090071
-			public static int Base_TextAppearance_AppCompat_Display4 = 2131296369;
+			// aapt resource value: 0x7f0b0055
+			public static int Base_TextAppearance_AppCompat_Display4 = 2131427413;
 			
-			// aapt resource value: 0x7f090072
-			public static int Base_TextAppearance_AppCompat_Headline = 2131296370;
+			// aapt resource value: 0x7f0b0056
+			public static int Base_TextAppearance_AppCompat_Headline = 2131427414;
 			
-			// aapt resource value: 0x7f09003f
-			public static int Base_TextAppearance_AppCompat_Inverse = 2131296319;
+			// aapt resource value: 0x7f0b001a
+			public static int Base_TextAppearance_AppCompat_Inverse = 2131427354;
 			
-			// aapt resource value: 0x7f090073
-			public static int Base_TextAppearance_AppCompat_Large = 2131296371;
+			// aapt resource value: 0x7f0b0057
+			public static int Base_TextAppearance_AppCompat_Large = 2131427415;
 			
-			// aapt resource value: 0x7f090040
-			public static int Base_TextAppearance_AppCompat_Large_Inverse = 2131296320;
+			// aapt resource value: 0x7f0b001b
+			public static int Base_TextAppearance_AppCompat_Large_Inverse = 2131427355;
 			
-			// aapt resource value: 0x7f090074
-			public static int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131296372;
+			// aapt resource value: 0x7f0b0058
+			public static int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131427416;
 			
-			// aapt resource value: 0x7f090075
-			public static int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131296373;
+			// aapt resource value: 0x7f0b0059
+			public static int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131427417;
 			
-			// aapt resource value: 0x7f090076
-			public static int Base_TextAppearance_AppCompat_Medium = 2131296374;
+			// aapt resource value: 0x7f0b005a
+			public static int Base_TextAppearance_AppCompat_Medium = 2131427418;
 			
-			// aapt resource value: 0x7f090041
-			public static int Base_TextAppearance_AppCompat_Medium_Inverse = 2131296321;
+			// aapt resource value: 0x7f0b001c
+			public static int Base_TextAppearance_AppCompat_Medium_Inverse = 2131427356;
 			
-			// aapt resource value: 0x7f090077
-			public static int Base_TextAppearance_AppCompat_Menu = 2131296375;
+			// aapt resource value: 0x7f0b005b
+			public static int Base_TextAppearance_AppCompat_Menu = 2131427419;
 			
-			// aapt resource value: 0x7f0900c4
-			public static int Base_TextAppearance_AppCompat_SearchResult = 2131296452;
+			// aapt resource value: 0x7f0b00b8
+			public static int Base_TextAppearance_AppCompat_SearchResult = 2131427512;
 			
-			// aapt resource value: 0x7f090078
-			public static int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131296376;
+			// aapt resource value: 0x7f0b005c
+			public static int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131427420;
 			
-			// aapt resource value: 0x7f090079
-			public static int Base_TextAppearance_AppCompat_SearchResult_Title = 2131296377;
+			// aapt resource value: 0x7f0b005d
+			public static int Base_TextAppearance_AppCompat_SearchResult_Title = 2131427421;
 			
-			// aapt resource value: 0x7f09007a
-			public static int Base_TextAppearance_AppCompat_Small = 2131296378;
+			// aapt resource value: 0x7f0b005e
+			public static int Base_TextAppearance_AppCompat_Small = 2131427422;
 			
-			// aapt resource value: 0x7f090042
-			public static int Base_TextAppearance_AppCompat_Small_Inverse = 2131296322;
+			// aapt resource value: 0x7f0b001d
+			public static int Base_TextAppearance_AppCompat_Small_Inverse = 2131427357;
 			
-			// aapt resource value: 0x7f09007b
-			public static int Base_TextAppearance_AppCompat_Subhead = 2131296379;
+			// aapt resource value: 0x7f0b005f
+			public static int Base_TextAppearance_AppCompat_Subhead = 2131427423;
 			
-			// aapt resource value: 0x7f090043
-			public static int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131296323;
+			// aapt resource value: 0x7f0b001e
+			public static int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131427358;
 			
-			// aapt resource value: 0x7f09007c
-			public static int Base_TextAppearance_AppCompat_Title = 2131296380;
+			// aapt resource value: 0x7f0b0060
+			public static int Base_TextAppearance_AppCompat_Title = 2131427424;
 			
-			// aapt resource value: 0x7f090044
-			public static int Base_TextAppearance_AppCompat_Title_Inverse = 2131296324;
+			// aapt resource value: 0x7f0b001f
+			public static int Base_TextAppearance_AppCompat_Title_Inverse = 2131427359;
 			
-			// aapt resource value: 0x7f0900b3
-			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131296435;
+			// aapt resource value: 0x7f0b00a3
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131427491;
 			
-			// aapt resource value: 0x7f09007d
-			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131296381;
+			// aapt resource value: 0x7f0b0061
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131427425;
 			
-			// aapt resource value: 0x7f09007e
-			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131296382;
+			// aapt resource value: 0x7f0b0062
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131427426;
 			
-			// aapt resource value: 0x7f09007f
-			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131296383;
+			// aapt resource value: 0x7f0b0063
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131427427;
 			
-			// aapt resource value: 0x7f090080
-			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131296384;
+			// aapt resource value: 0x7f0b0064
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131427428;
 			
-			// aapt resource value: 0x7f090081
-			public static int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131296385;
+			// aapt resource value: 0x7f0b0065
+			public static int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131427429;
 			
-			// aapt resource value: 0x7f090082
-			public static int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131296386;
+			// aapt resource value: 0x7f0b0066
+			public static int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131427430;
 			
-			// aapt resource value: 0x7f090083
-			public static int Base_TextAppearance_AppCompat_Widget_Button = 2131296387;
+			// aapt resource value: 0x7f0b0067
+			public static int Base_TextAppearance_AppCompat_Widget_Button = 2131427431;
 			
-			// aapt resource value: 0x7f0900b4
-			public static int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131296436;
+			// aapt resource value: 0x7f0b00aa
+			public static int Base_TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131427498;
 			
-			// aapt resource value: 0x7f0900c5
-			public static int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131296453;
+			// aapt resource value: 0x7f0b00ab
+			public static int Base_TextAppearance_AppCompat_Widget_Button_Colored = 2131427499;
 			
-			// aapt resource value: 0x7f090084
-			public static int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131296388;
+			// aapt resource value: 0x7f0b00a4
+			public static int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131427492;
 			
-			// aapt resource value: 0x7f090085
-			public static int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131296389;
+			// aapt resource value: 0x7f0b00b9
+			public static int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131427513;
 			
-			// aapt resource value: 0x7f090086
-			public static int Base_TextAppearance_AppCompat_Widget_Switch = 2131296390;
+			// aapt resource value: 0x7f0b0068
+			public static int Base_TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131427432;
 			
-			// aapt resource value: 0x7f090087
-			public static int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131296391;
+			// aapt resource value: 0x7f0b0069
+			public static int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131427433;
 			
-			// aapt resource value: 0x7f0900c6
-			public static int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131296454;
+			// aapt resource value: 0x7f0b006a
+			public static int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131427434;
 			
-			// aapt resource value: 0x7f090088
-			public static int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131296392;
+			// aapt resource value: 0x7f0b006b
+			public static int Base_TextAppearance_AppCompat_Widget_Switch = 2131427435;
 			
-			// aapt resource value: 0x7f090089
-			public static int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131296393;
+			// aapt resource value: 0x7f0b006c
+			public static int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131427436;
 			
-			// aapt resource value: 0x7f09008a
-			public static int Base_Theme_AppCompat = 2131296394;
+			// aapt resource value: 0x7f0b00ba
+			public static int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131427514;
 			
-			// aapt resource value: 0x7f0900c7
-			public static int Base_Theme_AppCompat_CompactMenu = 2131296455;
+			// aapt resource value: 0x7f0b006d
+			public static int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131427437;
 			
-			// aapt resource value: 0x7f090045
-			public static int Base_Theme_AppCompat_Dialog = 2131296325;
+			// aapt resource value: 0x7f0b006e
+			public static int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131427438;
 			
-			// aapt resource value: 0x7f0900c8
-			public static int Base_Theme_AppCompat_Dialog_Alert = 2131296456;
+			// aapt resource value: 0x7f0b006f
+			public static int Base_Theme_AppCompat = 2131427439;
 			
-			// aapt resource value: 0x7f0900c9
-			public static int Base_Theme_AppCompat_Dialog_FixedSize = 2131296457;
+			// aapt resource value: 0x7f0b00bb
+			public static int Base_Theme_AppCompat_CompactMenu = 2131427515;
 			
-			// aapt resource value: 0x7f0900ca
-			public static int Base_Theme_AppCompat_Dialog_MinWidth = 2131296458;
+			// aapt resource value: 0x7f0b0020
+			public static int Base_Theme_AppCompat_Dialog = 2131427360;
 			
-			// aapt resource value: 0x7f090035
-			public static int Base_Theme_AppCompat_DialogWhenLarge = 2131296309;
+			// aapt resource value: 0x7f0b0021
+			public static int Base_Theme_AppCompat_Dialog_Alert = 2131427361;
 			
-			// aapt resource value: 0x7f09008b
-			public static int Base_Theme_AppCompat_Light = 2131296395;
+			// aapt resource value: 0x7f0b00bc
+			public static int Base_Theme_AppCompat_Dialog_FixedSize = 2131427516;
 			
-			// aapt resource value: 0x7f0900cb
-			public static int Base_Theme_AppCompat_Light_DarkActionBar = 2131296459;
+			// aapt resource value: 0x7f0b0022
+			public static int Base_Theme_AppCompat_Dialog_MinWidth = 2131427362;
 			
-			// aapt resource value: 0x7f090046
-			public static int Base_Theme_AppCompat_Light_Dialog = 2131296326;
+			// aapt resource value: 0x7f0b0010
+			public static int Base_Theme_AppCompat_DialogWhenLarge = 2131427344;
 			
-			// aapt resource value: 0x7f0900cc
-			public static int Base_Theme_AppCompat_Light_Dialog_Alert = 2131296460;
+			// aapt resource value: 0x7f0b0070
+			public static int Base_Theme_AppCompat_Light = 2131427440;
 			
-			// aapt resource value: 0x7f0900cd
-			public static int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131296461;
+			// aapt resource value: 0x7f0b00bd
+			public static int Base_Theme_AppCompat_Light_DarkActionBar = 2131427517;
 			
-			// aapt resource value: 0x7f0900ce
-			public static int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131296462;
+			// aapt resource value: 0x7f0b0023
+			public static int Base_Theme_AppCompat_Light_Dialog = 2131427363;
 			
-			// aapt resource value: 0x7f090036
-			public static int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131296310;
+			// aapt resource value: 0x7f0b0024
+			public static int Base_Theme_AppCompat_Light_Dialog_Alert = 2131427364;
 			
-			// aapt resource value: 0x7f0900cf
-			public static int Base_ThemeOverlay_AppCompat = 2131296463;
+			// aapt resource value: 0x7f0b00be
+			public static int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131427518;
 			
-			// aapt resource value: 0x7f0900d0
-			public static int Base_ThemeOverlay_AppCompat_ActionBar = 2131296464;
+			// aapt resource value: 0x7f0b0025
+			public static int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131427365;
 			
-			// aapt resource value: 0x7f0900d1
-			public static int Base_ThemeOverlay_AppCompat_Dark = 2131296465;
+			// aapt resource value: 0x7f0b0011
+			public static int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131427345;
 			
-			// aapt resource value: 0x7f0900d2
-			public static int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131296466;
+			// aapt resource value: 0x7f0b00bf
+			public static int Base_ThemeOverlay_AppCompat = 2131427519;
 			
-			// aapt resource value: 0x7f0900d3
-			public static int Base_ThemeOverlay_AppCompat_Light = 2131296467;
+			// aapt resource value: 0x7f0b00c0
+			public static int Base_ThemeOverlay_AppCompat_ActionBar = 2131427520;
 			
-			// aapt resource value: 0x7f090047
-			public static int Base_V11_Theme_AppCompat_Dialog = 2131296327;
+			// aapt resource value: 0x7f0b00c1
+			public static int Base_ThemeOverlay_AppCompat_Dark = 2131427521;
 			
-			// aapt resource value: 0x7f090048
-			public static int Base_V11_Theme_AppCompat_Light_Dialog = 2131296328;
+			// aapt resource value: 0x7f0b00c2
+			public static int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131427522;
 			
-			// aapt resource value: 0x7f090050
-			public static int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131296336;
+			// aapt resource value: 0x7f0b0026
+			public static int Base_ThemeOverlay_AppCompat_Dialog = 2131427366;
 			
-			// aapt resource value: 0x7f090051
-			public static int Base_V12_Widget_AppCompat_EditText = 2131296337;
+			// aapt resource value: 0x7f0b0027
+			public static int Base_ThemeOverlay_AppCompat_Dialog_Alert = 2131427367;
 			
-			// aapt resource value: 0x7f09008c
-			public static int Base_V21_Theme_AppCompat = 2131296396;
+			// aapt resource value: 0x7f0b00c3
+			public static int Base_ThemeOverlay_AppCompat_Light = 2131427523;
 			
-			// aapt resource value: 0x7f09008d
-			public static int Base_V21_Theme_AppCompat_Dialog = 2131296397;
+			// aapt resource value: 0x7f0b0028
+			public static int Base_V11_Theme_AppCompat_Dialog = 2131427368;
 			
-			// aapt resource value: 0x7f09008e
-			public static int Base_V21_Theme_AppCompat_Light = 2131296398;
+			// aapt resource value: 0x7f0b0029
+			public static int Base_V11_Theme_AppCompat_Light_Dialog = 2131427369;
 			
-			// aapt resource value: 0x7f09008f
-			public static int Base_V21_Theme_AppCompat_Light_Dialog = 2131296399;
+			// aapt resource value: 0x7f0b002a
+			public static int Base_V11_ThemeOverlay_AppCompat_Dialog = 2131427370;
 			
-			// aapt resource value: 0x7f0900b1
-			public static int Base_V22_Theme_AppCompat = 2131296433;
+			// aapt resource value: 0x7f0b0032
+			public static int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131427378;
 			
-			// aapt resource value: 0x7f0900b2
-			public static int Base_V22_Theme_AppCompat_Light = 2131296434;
+			// aapt resource value: 0x7f0b0033
+			public static int Base_V12_Widget_AppCompat_EditText = 2131427379;
 			
-			// aapt resource value: 0x7f0900b5
-			public static int Base_V23_Theme_AppCompat = 2131296437;
+			// aapt resource value: 0x7f0b0071
+			public static int Base_V21_Theme_AppCompat = 2131427441;
 			
-			// aapt resource value: 0x7f0900b6
-			public static int Base_V23_Theme_AppCompat_Light = 2131296438;
+			// aapt resource value: 0x7f0b0072
+			public static int Base_V21_Theme_AppCompat_Dialog = 2131427442;
 			
-			// aapt resource value: 0x7f0900d4
-			public static int Base_V7_Theme_AppCompat = 2131296468;
+			// aapt resource value: 0x7f0b0073
+			public static int Base_V21_Theme_AppCompat_Light = 2131427443;
 			
-			// aapt resource value: 0x7f0900d5
-			public static int Base_V7_Theme_AppCompat_Dialog = 2131296469;
+			// aapt resource value: 0x7f0b0074
+			public static int Base_V21_Theme_AppCompat_Light_Dialog = 2131427444;
 			
-			// aapt resource value: 0x7f0900d6
-			public static int Base_V7_Theme_AppCompat_Light = 2131296470;
+			// aapt resource value: 0x7f0b0075
+			public static int Base_V21_ThemeOverlay_AppCompat_Dialog = 2131427445;
 			
-			// aapt resource value: 0x7f0900d7
-			public static int Base_V7_Theme_AppCompat_Light_Dialog = 2131296471;
+			// aapt resource value: 0x7f0b00a1
+			public static int Base_V22_Theme_AppCompat = 2131427489;
 			
-			// aapt resource value: 0x7f0900d8
-			public static int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131296472;
+			// aapt resource value: 0x7f0b00a2
+			public static int Base_V22_Theme_AppCompat_Light = 2131427490;
 			
-			// aapt resource value: 0x7f0900d9
-			public static int Base_V7_Widget_AppCompat_EditText = 2131296473;
+			// aapt resource value: 0x7f0b00a5
+			public static int Base_V23_Theme_AppCompat = 2131427493;
 			
-			// aapt resource value: 0x7f0900da
-			public static int Base_Widget_AppCompat_ActionBar = 2131296474;
+			// aapt resource value: 0x7f0b00a6
+			public static int Base_V23_Theme_AppCompat_Light = 2131427494;
 			
-			// aapt resource value: 0x7f0900db
-			public static int Base_Widget_AppCompat_ActionBar_Solid = 2131296475;
+			// aapt resource value: 0x7f0b00c4
+			public static int Base_V7_Theme_AppCompat = 2131427524;
 			
-			// aapt resource value: 0x7f0900dc
-			public static int Base_Widget_AppCompat_ActionBar_TabBar = 2131296476;
+			// aapt resource value: 0x7f0b00c5
+			public static int Base_V7_Theme_AppCompat_Dialog = 2131427525;
 			
-			// aapt resource value: 0x7f090090
-			public static int Base_Widget_AppCompat_ActionBar_TabText = 2131296400;
+			// aapt resource value: 0x7f0b00c6
+			public static int Base_V7_Theme_AppCompat_Light = 2131427526;
 			
-			// aapt resource value: 0x7f090091
-			public static int Base_Widget_AppCompat_ActionBar_TabView = 2131296401;
+			// aapt resource value: 0x7f0b00c7
+			public static int Base_V7_Theme_AppCompat_Light_Dialog = 2131427527;
 			
-			// aapt resource value: 0x7f090092
-			public static int Base_Widget_AppCompat_ActionButton = 2131296402;
+			// aapt resource value: 0x7f0b00c8
+			public static int Base_V7_ThemeOverlay_AppCompat_Dialog = 2131427528;
 			
-			// aapt resource value: 0x7f090093
-			public static int Base_Widget_AppCompat_ActionButton_CloseMode = 2131296403;
+			// aapt resource value: 0x7f0b00c9
+			public static int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131427529;
 			
-			// aapt resource value: 0x7f090094
-			public static int Base_Widget_AppCompat_ActionButton_Overflow = 2131296404;
+			// aapt resource value: 0x7f0b00ca
+			public static int Base_V7_Widget_AppCompat_EditText = 2131427530;
 			
-			// aapt resource value: 0x7f0900dd
-			public static int Base_Widget_AppCompat_ActionMode = 2131296477;
+			// aapt resource value: 0x7f0b00cb
+			public static int Base_Widget_AppCompat_ActionBar = 2131427531;
 			
-			// aapt resource value: 0x7f0900de
-			public static int Base_Widget_AppCompat_ActivityChooserView = 2131296478;
+			// aapt resource value: 0x7f0b00cc
+			public static int Base_Widget_AppCompat_ActionBar_Solid = 2131427532;
 			
-			// aapt resource value: 0x7f090052
-			public static int Base_Widget_AppCompat_AutoCompleteTextView = 2131296338;
+			// aapt resource value: 0x7f0b00cd
+			public static int Base_Widget_AppCompat_ActionBar_TabBar = 2131427533;
 			
-			// aapt resource value: 0x7f090095
-			public static int Base_Widget_AppCompat_Button = 2131296405;
+			// aapt resource value: 0x7f0b0076
+			public static int Base_Widget_AppCompat_ActionBar_TabText = 2131427446;
 			
-			// aapt resource value: 0x7f090096
-			public static int Base_Widget_AppCompat_Button_Borderless = 2131296406;
+			// aapt resource value: 0x7f0b0077
+			public static int Base_Widget_AppCompat_ActionBar_TabView = 2131427447;
 			
-			// aapt resource value: 0x7f090097
-			public static int Base_Widget_AppCompat_Button_Borderless_Colored = 2131296407;
+			// aapt resource value: 0x7f0b0078
+			public static int Base_Widget_AppCompat_ActionButton = 2131427448;
 			
-			// aapt resource value: 0x7f0900df
-			public static int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131296479;
+			// aapt resource value: 0x7f0b0079
+			public static int Base_Widget_AppCompat_ActionButton_CloseMode = 2131427449;
 			
-			// aapt resource value: 0x7f0900b7
-			public static int Base_Widget_AppCompat_Button_Colored = 2131296439;
+			// aapt resource value: 0x7f0b007a
+			public static int Base_Widget_AppCompat_ActionButton_Overflow = 2131427450;
 			
-			// aapt resource value: 0x7f090098
-			public static int Base_Widget_AppCompat_Button_Small = 2131296408;
+			// aapt resource value: 0x7f0b00ce
+			public static int Base_Widget_AppCompat_ActionMode = 2131427534;
 			
-			// aapt resource value: 0x7f090099
-			public static int Base_Widget_AppCompat_ButtonBar = 2131296409;
+			// aapt resource value: 0x7f0b00cf
+			public static int Base_Widget_AppCompat_ActivityChooserView = 2131427535;
 			
-			// aapt resource value: 0x7f0900e0
-			public static int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131296480;
+			// aapt resource value: 0x7f0b0034
+			public static int Base_Widget_AppCompat_AutoCompleteTextView = 2131427380;
 			
-			// aapt resource value: 0x7f09009a
-			public static int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131296410;
+			// aapt resource value: 0x7f0b007b
+			public static int Base_Widget_AppCompat_Button = 2131427451;
 			
-			// aapt resource value: 0x7f09009b
-			public static int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131296411;
+			// aapt resource value: 0x7f0b007c
+			public static int Base_Widget_AppCompat_Button_Borderless = 2131427452;
 			
-			// aapt resource value: 0x7f0900e1
-			public static int Base_Widget_AppCompat_CompoundButton_Switch = 2131296481;
+			// aapt resource value: 0x7f0b007d
+			public static int Base_Widget_AppCompat_Button_Borderless_Colored = 2131427453;
 			
-			// aapt resource value: 0x7f090034
-			public static int Base_Widget_AppCompat_DrawerArrowToggle = 2131296308;
+			// aapt resource value: 0x7f0b00d0
+			public static int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131427536;
 			
-			// aapt resource value: 0x7f0900e2
-			public static int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131296482;
+			// aapt resource value: 0x7f0b00a7
+			public static int Base_Widget_AppCompat_Button_Colored = 2131427495;
 			
-			// aapt resource value: 0x7f09009c
-			public static int Base_Widget_AppCompat_DropDownItem_Spinner = 2131296412;
+			// aapt resource value: 0x7f0b007e
+			public static int Base_Widget_AppCompat_Button_Small = 2131427454;
 			
-			// aapt resource value: 0x7f090053
-			public static int Base_Widget_AppCompat_EditText = 2131296339;
+			// aapt resource value: 0x7f0b007f
+			public static int Base_Widget_AppCompat_ButtonBar = 2131427455;
 			
-			// aapt resource value: 0x7f09009d
-			public static int Base_Widget_AppCompat_ImageButton = 2131296413;
+			// aapt resource value: 0x7f0b00d1
+			public static int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131427537;
 			
-			// aapt resource value: 0x7f0900e3
-			public static int Base_Widget_AppCompat_Light_ActionBar = 2131296483;
+			// aapt resource value: 0x7f0b0080
+			public static int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131427456;
 			
-			// aapt resource value: 0x7f0900e4
-			public static int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131296484;
+			// aapt resource value: 0x7f0b0081
+			public static int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131427457;
 			
-			// aapt resource value: 0x7f0900e5
-			public static int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131296485;
+			// aapt resource value: 0x7f0b00d2
+			public static int Base_Widget_AppCompat_CompoundButton_Switch = 2131427538;
 			
-			// aapt resource value: 0x7f09009e
-			public static int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131296414;
+			// aapt resource value: 0x7f0b000f
+			public static int Base_Widget_AppCompat_DrawerArrowToggle = 2131427343;
 			
-			// aapt resource value: 0x7f09009f
-			public static int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131296415;
+			// aapt resource value: 0x7f0b00d3
+			public static int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131427539;
 			
-			// aapt resource value: 0x7f0900a0
-			public static int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131296416;
+			// aapt resource value: 0x7f0b0082
+			public static int Base_Widget_AppCompat_DropDownItem_Spinner = 2131427458;
 			
-			// aapt resource value: 0x7f0900a1
-			public static int Base_Widget_AppCompat_Light_PopupMenu = 2131296417;
+			// aapt resource value: 0x7f0b0035
+			public static int Base_Widget_AppCompat_EditText = 2131427381;
 			
-			// aapt resource value: 0x7f0900a2
-			public static int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131296418;
+			// aapt resource value: 0x7f0b0083
+			public static int Base_Widget_AppCompat_ImageButton = 2131427459;
 			
-			// aapt resource value: 0x7f0900a3
-			public static int Base_Widget_AppCompat_ListPopupWindow = 2131296419;
+			// aapt resource value: 0x7f0b00d4
+			public static int Base_Widget_AppCompat_Light_ActionBar = 2131427540;
 			
-			// aapt resource value: 0x7f0900a4
-			public static int Base_Widget_AppCompat_ListView = 2131296420;
+			// aapt resource value: 0x7f0b00d5
+			public static int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131427541;
 			
-			// aapt resource value: 0x7f0900a5
-			public static int Base_Widget_AppCompat_ListView_DropDown = 2131296421;
+			// aapt resource value: 0x7f0b00d6
+			public static int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131427542;
 			
-			// aapt resource value: 0x7f0900a6
-			public static int Base_Widget_AppCompat_ListView_Menu = 2131296422;
+			// aapt resource value: 0x7f0b0084
+			public static int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131427460;
 			
-			// aapt resource value: 0x7f0900a7
-			public static int Base_Widget_AppCompat_PopupMenu = 2131296423;
+			// aapt resource value: 0x7f0b0085
+			public static int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131427461;
 			
-			// aapt resource value: 0x7f0900a8
-			public static int Base_Widget_AppCompat_PopupMenu_Overflow = 2131296424;
+			// aapt resource value: 0x7f0b0086
+			public static int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131427462;
 			
-			// aapt resource value: 0x7f0900e6
-			public static int Base_Widget_AppCompat_PopupWindow = 2131296486;
+			// aapt resource value: 0x7f0b0087
+			public static int Base_Widget_AppCompat_Light_PopupMenu = 2131427463;
 			
-			// aapt resource value: 0x7f090049
-			public static int Base_Widget_AppCompat_ProgressBar = 2131296329;
+			// aapt resource value: 0x7f0b0088
+			public static int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131427464;
 			
-			// aapt resource value: 0x7f09004a
-			public static int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131296330;
+			// aapt resource value: 0x7f0b00d7
+			public static int Base_Widget_AppCompat_ListMenuView = 2131427543;
 			
-			// aapt resource value: 0x7f0900a9
-			public static int Base_Widget_AppCompat_RatingBar = 2131296425;
+			// aapt resource value: 0x7f0b0089
+			public static int Base_Widget_AppCompat_ListPopupWindow = 2131427465;
 			
-			// aapt resource value: 0x7f0900b8
-			public static int Base_Widget_AppCompat_RatingBar_Indicator = 2131296440;
+			// aapt resource value: 0x7f0b008a
+			public static int Base_Widget_AppCompat_ListView = 2131427466;
 			
-			// aapt resource value: 0x7f0900b9
-			public static int Base_Widget_AppCompat_RatingBar_Small = 2131296441;
+			// aapt resource value: 0x7f0b008b
+			public static int Base_Widget_AppCompat_ListView_DropDown = 2131427467;
 			
-			// aapt resource value: 0x7f0900e7
-			public static int Base_Widget_AppCompat_SearchView = 2131296487;
+			// aapt resource value: 0x7f0b008c
+			public static int Base_Widget_AppCompat_ListView_Menu = 2131427468;
 			
-			// aapt resource value: 0x7f0900e8
-			public static int Base_Widget_AppCompat_SearchView_ActionBar = 2131296488;
+			// aapt resource value: 0x7f0b008d
+			public static int Base_Widget_AppCompat_PopupMenu = 2131427469;
 			
-			// aapt resource value: 0x7f0900aa
-			public static int Base_Widget_AppCompat_SeekBar = 2131296426;
+			// aapt resource value: 0x7f0b008e
+			public static int Base_Widget_AppCompat_PopupMenu_Overflow = 2131427470;
 			
-			// aapt resource value: 0x7f0900ab
-			public static int Base_Widget_AppCompat_Spinner = 2131296427;
+			// aapt resource value: 0x7f0b00d8
+			public static int Base_Widget_AppCompat_PopupWindow = 2131427544;
 			
-			// aapt resource value: 0x7f090037
-			public static int Base_Widget_AppCompat_Spinner_Underlined = 2131296311;
+			// aapt resource value: 0x7f0b002b
+			public static int Base_Widget_AppCompat_ProgressBar = 2131427371;
 			
-			// aapt resource value: 0x7f0900ac
-			public static int Base_Widget_AppCompat_TextView_SpinnerItem = 2131296428;
+			// aapt resource value: 0x7f0b002c
+			public static int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131427372;
 			
-			// aapt resource value: 0x7f0900e9
-			public static int Base_Widget_AppCompat_Toolbar = 2131296489;
+			// aapt resource value: 0x7f0b008f
+			public static int Base_Widget_AppCompat_RatingBar = 2131427471;
 			
-			// aapt resource value: 0x7f0900ad
-			public static int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131296429;
+			// aapt resource value: 0x7f0b00a8
+			public static int Base_Widget_AppCompat_RatingBar_Indicator = 2131427496;
 			
-			// aapt resource value: 0x7f09001d
-			public static int Base_Widget_Design_TabLayout = 2131296285;
+			// aapt resource value: 0x7f0b00a9
+			public static int Base_Widget_AppCompat_RatingBar_Small = 2131427497;
 			
-			// aapt resource value: 0x7f090017
-			public static int CardView = 2131296279;
+			// aapt resource value: 0x7f0b00d9
+			public static int Base_Widget_AppCompat_SearchView = 2131427545;
 			
-			// aapt resource value: 0x7f090019
-			public static int CardView_Dark = 2131296281;
+			// aapt resource value: 0x7f0b00da
+			public static int Base_Widget_AppCompat_SearchView_ActionBar = 2131427546;
 			
-			// aapt resource value: 0x7f09001a
-			public static int CardView_Light = 2131296282;
+			// aapt resource value: 0x7f0b0090
+			public static int Base_Widget_AppCompat_SeekBar = 2131427472;
 			
-			// aapt resource value: 0x7f09004b
-			public static int Platform_AppCompat = 2131296331;
+			// aapt resource value: 0x7f0b00db
+			public static int Base_Widget_AppCompat_SeekBar_Discrete = 2131427547;
 			
-			// aapt resource value: 0x7f09004c
-			public static int Platform_AppCompat_Light = 2131296332;
+			// aapt resource value: 0x7f0b0091
+			public static int Base_Widget_AppCompat_Spinner = 2131427473;
 			
-			// aapt resource value: 0x7f0900ae
-			public static int Platform_ThemeOverlay_AppCompat = 2131296430;
+			// aapt resource value: 0x7f0b0012
+			public static int Base_Widget_AppCompat_Spinner_Underlined = 2131427346;
 			
-			// aapt resource value: 0x7f0900af
-			public static int Platform_ThemeOverlay_AppCompat_Dark = 2131296431;
+			// aapt resource value: 0x7f0b0092
+			public static int Base_Widget_AppCompat_TextView_SpinnerItem = 2131427474;
 			
-			// aapt resource value: 0x7f0900b0
-			public static int Platform_ThemeOverlay_AppCompat_Light = 2131296432;
+			// aapt resource value: 0x7f0b00dc
+			public static int Base_Widget_AppCompat_Toolbar = 2131427548;
 			
-			// aapt resource value: 0x7f09004d
-			public static int Platform_V11_AppCompat = 2131296333;
+			// aapt resource value: 0x7f0b0093
+			public static int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131427475;
 			
-			// aapt resource value: 0x7f09004e
-			public static int Platform_V11_AppCompat_Light = 2131296334;
+			// aapt resource value: 0x7f0b0171
+			public static int Base_Widget_Design_AppBarLayout = 2131427697;
 			
-			// aapt resource value: 0x7f090055
-			public static int Platform_V14_AppCompat = 2131296341;
+			// aapt resource value: 0x7f0b0172
+			public static int Base_Widget_Design_TabLayout = 2131427698;
 			
-			// aapt resource value: 0x7f090056
-			public static int Platform_V14_AppCompat_Light = 2131296342;
+			// aapt resource value: 0x7f0b000b
+			public static int CardView = 2131427339;
 			
-			// aapt resource value: 0x7f09004f
-			public static int Platform_Widget_AppCompat_Spinner = 2131296335;
+			// aapt resource value: 0x7f0b000d
+			public static int CardView_Dark = 2131427341;
 			
-			// aapt resource value: 0x7f09005c
-			public static int RtlOverlay_DialogWindowTitle_AppCompat = 2131296348;
+			// aapt resource value: 0x7f0b000e
+			public static int CardView_Light = 2131427342;
 			
-			// aapt resource value: 0x7f09005d
-			public static int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131296349;
+			// aapt resource value: 0x7f0b002d
+			public static int Platform_AppCompat = 2131427373;
 			
-			// aapt resource value: 0x7f09005e
-			public static int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131296350;
+			// aapt resource value: 0x7f0b002e
+			public static int Platform_AppCompat_Light = 2131427374;
 			
-			// aapt resource value: 0x7f09005f
-			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131296351;
+			// aapt resource value: 0x7f0b0094
+			public static int Platform_ThemeOverlay_AppCompat = 2131427476;
 			
-			// aapt resource value: 0x7f090060
-			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131296352;
+			// aapt resource value: 0x7f0b0095
+			public static int Platform_ThemeOverlay_AppCompat_Dark = 2131427477;
 			
-			// aapt resource value: 0x7f090061
-			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131296353;
+			// aapt resource value: 0x7f0b0096
+			public static int Platform_ThemeOverlay_AppCompat_Light = 2131427478;
 			
-			// aapt resource value: 0x7f090062
-			public static int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131296354;
+			// aapt resource value: 0x7f0b002f
+			public static int Platform_V11_AppCompat = 2131427375;
 			
-			// aapt resource value: 0x7f090063
-			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131296355;
+			// aapt resource value: 0x7f0b0030
+			public static int Platform_V11_AppCompat_Light = 2131427376;
 			
-			// aapt resource value: 0x7f090064
-			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131296356;
+			// aapt resource value: 0x7f0b0037
+			public static int Platform_V14_AppCompat = 2131427383;
 			
-			// aapt resource value: 0x7f090065
-			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131296357;
+			// aapt resource value: 0x7f0b0038
+			public static int Platform_V14_AppCompat_Light = 2131427384;
 			
-			// aapt resource value: 0x7f090066
-			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131296358;
+			// aapt resource value: 0x7f0b0097
+			public static int Platform_V21_AppCompat = 2131427479;
 			
-			// aapt resource value: 0x7f090067
-			public static int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131296359;
+			// aapt resource value: 0x7f0b0098
+			public static int Platform_V21_AppCompat_Light = 2131427480;
 			
-			// aapt resource value: 0x7f090068
-			public static int RtlUnderlay_Widget_AppCompat_ActionButton = 2131296360;
+			// aapt resource value: 0x7f0b00ac
+			public static int Platform_V25_AppCompat = 2131427500;
 			
-			// aapt resource value: 0x7f090069
-			public static int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131296361;
+			// aapt resource value: 0x7f0b00ad
+			public static int Platform_V25_AppCompat_Light = 2131427501;
 			
-			// aapt resource value: 0x7f0900ea
-			public static int TextAppearance_AppCompat = 2131296490;
+			// aapt resource value: 0x7f0b0031
+			public static int Platform_Widget_AppCompat_Spinner = 2131427377;
 			
-			// aapt resource value: 0x7f0900eb
-			public static int TextAppearance_AppCompat_Body1 = 2131296491;
+			// aapt resource value: 0x7f0b0040
+			public static int RtlOverlay_DialogWindowTitle_AppCompat = 2131427392;
 			
-			// aapt resource value: 0x7f0900ec
-			public static int TextAppearance_AppCompat_Body2 = 2131296492;
+			// aapt resource value: 0x7f0b0041
+			public static int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131427393;
 			
-			// aapt resource value: 0x7f0900ed
-			public static int TextAppearance_AppCompat_Button = 2131296493;
+			// aapt resource value: 0x7f0b0042
+			public static int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131427394;
 			
-			// aapt resource value: 0x7f0900ee
-			public static int TextAppearance_AppCompat_Caption = 2131296494;
+			// aapt resource value: 0x7f0b0043
+			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131427395;
 			
-			// aapt resource value: 0x7f0900ef
-			public static int TextAppearance_AppCompat_Display1 = 2131296495;
+			// aapt resource value: 0x7f0b0044
+			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131427396;
 			
-			// aapt resource value: 0x7f0900f0
-			public static int TextAppearance_AppCompat_Display2 = 2131296496;
+			// aapt resource value: 0x7f0b0045
+			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131427397;
 			
-			// aapt resource value: 0x7f0900f1
-			public static int TextAppearance_AppCompat_Display3 = 2131296497;
+			// aapt resource value: 0x7f0b0046
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131427398;
 			
-			// aapt resource value: 0x7f0900f2
-			public static int TextAppearance_AppCompat_Display4 = 2131296498;
+			// aapt resource value: 0x7f0b0047
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131427399;
 			
-			// aapt resource value: 0x7f0900f3
-			public static int TextAppearance_AppCompat_Headline = 2131296499;
+			// aapt resource value: 0x7f0b0048
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131427400;
 			
-			// aapt resource value: 0x7f0900f4
-			public static int TextAppearance_AppCompat_Inverse = 2131296500;
+			// aapt resource value: 0x7f0b0049
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131427401;
 			
-			// aapt resource value: 0x7f0900f5
-			public static int TextAppearance_AppCompat_Large = 2131296501;
+			// aapt resource value: 0x7f0b004a
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131427402;
 			
-			// aapt resource value: 0x7f0900f6
-			public static int TextAppearance_AppCompat_Large_Inverse = 2131296502;
+			// aapt resource value: 0x7f0b004b
+			public static int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131427403;
 			
-			// aapt resource value: 0x7f0900f7
-			public static int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131296503;
+			// aapt resource value: 0x7f0b004c
+			public static int RtlUnderlay_Widget_AppCompat_ActionButton = 2131427404;
 			
-			// aapt resource value: 0x7f0900f8
-			public static int TextAppearance_AppCompat_Light_SearchResult_Title = 2131296504;
+			// aapt resource value: 0x7f0b004d
+			public static int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131427405;
 			
-			// aapt resource value: 0x7f0900f9
-			public static int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131296505;
+			// aapt resource value: 0x7f0b00dd
+			public static int TextAppearance_AppCompat = 2131427549;
 			
-			// aapt resource value: 0x7f0900fa
-			public static int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131296506;
+			// aapt resource value: 0x7f0b00de
+			public static int TextAppearance_AppCompat_Body1 = 2131427550;
 			
-			// aapt resource value: 0x7f0900fb
-			public static int TextAppearance_AppCompat_Medium = 2131296507;
+			// aapt resource value: 0x7f0b00df
+			public static int TextAppearance_AppCompat_Body2 = 2131427551;
 			
-			// aapt resource value: 0x7f0900fc
-			public static int TextAppearance_AppCompat_Medium_Inverse = 2131296508;
+			// aapt resource value: 0x7f0b00e0
+			public static int TextAppearance_AppCompat_Button = 2131427552;
 			
-			// aapt resource value: 0x7f0900fd
-			public static int TextAppearance_AppCompat_Menu = 2131296509;
+			// aapt resource value: 0x7f0b00e1
+			public static int TextAppearance_AppCompat_Caption = 2131427553;
 			
-			// aapt resource value: 0x7f0900fe
-			public static int TextAppearance_AppCompat_SearchResult_Subtitle = 2131296510;
+			// aapt resource value: 0x7f0b00e2
+			public static int TextAppearance_AppCompat_Display1 = 2131427554;
 			
-			// aapt resource value: 0x7f0900ff
-			public static int TextAppearance_AppCompat_SearchResult_Title = 2131296511;
+			// aapt resource value: 0x7f0b00e3
+			public static int TextAppearance_AppCompat_Display2 = 2131427555;
 			
-			// aapt resource value: 0x7f090100
-			public static int TextAppearance_AppCompat_Small = 2131296512;
+			// aapt resource value: 0x7f0b00e4
+			public static int TextAppearance_AppCompat_Display3 = 2131427556;
 			
-			// aapt resource value: 0x7f090101
-			public static int TextAppearance_AppCompat_Small_Inverse = 2131296513;
+			// aapt resource value: 0x7f0b00e5
+			public static int TextAppearance_AppCompat_Display4 = 2131427557;
 			
-			// aapt resource value: 0x7f090102
-			public static int TextAppearance_AppCompat_Subhead = 2131296514;
+			// aapt resource value: 0x7f0b00e6
+			public static int TextAppearance_AppCompat_Headline = 2131427558;
 			
-			// aapt resource value: 0x7f090103
-			public static int TextAppearance_AppCompat_Subhead_Inverse = 2131296515;
+			// aapt resource value: 0x7f0b00e7
+			public static int TextAppearance_AppCompat_Inverse = 2131427559;
 			
-			// aapt resource value: 0x7f090104
-			public static int TextAppearance_AppCompat_Title = 2131296516;
+			// aapt resource value: 0x7f0b00e8
+			public static int TextAppearance_AppCompat_Large = 2131427560;
 			
-			// aapt resource value: 0x7f090105
-			public static int TextAppearance_AppCompat_Title_Inverse = 2131296517;
+			// aapt resource value: 0x7f0b00e9
+			public static int TextAppearance_AppCompat_Large_Inverse = 2131427561;
 			
-			// aapt resource value: 0x7f090106
-			public static int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131296518;
+			// aapt resource value: 0x7f0b00ea
+			public static int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131427562;
 			
-			// aapt resource value: 0x7f090107
-			public static int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131296519;
+			// aapt resource value: 0x7f0b00eb
+			public static int TextAppearance_AppCompat_Light_SearchResult_Title = 2131427563;
 			
-			// aapt resource value: 0x7f090108
-			public static int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131296520;
+			// aapt resource value: 0x7f0b00ec
+			public static int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131427564;
 			
-			// aapt resource value: 0x7f090109
-			public static int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131296521;
+			// aapt resource value: 0x7f0b00ed
+			public static int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131427565;
 			
-			// aapt resource value: 0x7f09010a
-			public static int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131296522;
+			// aapt resource value: 0x7f0b00ee
+			public static int TextAppearance_AppCompat_Medium = 2131427566;
 			
-			// aapt resource value: 0x7f09010b
-			public static int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131296523;
+			// aapt resource value: 0x7f0b00ef
+			public static int TextAppearance_AppCompat_Medium_Inverse = 2131427567;
 			
-			// aapt resource value: 0x7f09010c
-			public static int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131296524;
+			// aapt resource value: 0x7f0b00f0
+			public static int TextAppearance_AppCompat_Menu = 2131427568;
 			
-			// aapt resource value: 0x7f09010d
-			public static int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131296525;
+			// aapt resource value: 0x7f0b0039
+			public static int TextAppearance_AppCompat_Notification = 2131427385;
 			
-			// aapt resource value: 0x7f09010e
-			public static int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131296526;
+			// aapt resource value: 0x7f0b0099
+			public static int TextAppearance_AppCompat_Notification_Info = 2131427481;
 			
-			// aapt resource value: 0x7f09010f
-			public static int TextAppearance_AppCompat_Widget_Button = 2131296527;
+			// aapt resource value: 0x7f0b009a
+			public static int TextAppearance_AppCompat_Notification_Info_Media = 2131427482;
 			
-			// aapt resource value: 0x7f090110
-			public static int TextAppearance_AppCompat_Widget_Button_Inverse = 2131296528;
+			// aapt resource value: 0x7f0b00f1
+			public static int TextAppearance_AppCompat_Notification_Line2 = 2131427569;
 			
-			// aapt resource value: 0x7f090111
-			public static int TextAppearance_AppCompat_Widget_DropDownItem = 2131296529;
+			// aapt resource value: 0x7f0b00f2
+			public static int TextAppearance_AppCompat_Notification_Line2_Media = 2131427570;
 			
-			// aapt resource value: 0x7f090112
-			public static int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131296530;
+			// aapt resource value: 0x7f0b009b
+			public static int TextAppearance_AppCompat_Notification_Media = 2131427483;
 			
-			// aapt resource value: 0x7f090113
-			public static int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131296531;
+			// aapt resource value: 0x7f0b009c
+			public static int TextAppearance_AppCompat_Notification_Time = 2131427484;
 			
-			// aapt resource value: 0x7f090114
-			public static int TextAppearance_AppCompat_Widget_Switch = 2131296532;
+			// aapt resource value: 0x7f0b009d
+			public static int TextAppearance_AppCompat_Notification_Time_Media = 2131427485;
 			
-			// aapt resource value: 0x7f090115
-			public static int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131296533;
+			// aapt resource value: 0x7f0b003a
+			public static int TextAppearance_AppCompat_Notification_Title = 2131427386;
 			
-			// aapt resource value: 0x7f09001e
-			public static int TextAppearance_Design_CollapsingToolbar_Expanded = 2131296286;
+			// aapt resource value: 0x7f0b009e
+			public static int TextAppearance_AppCompat_Notification_Title_Media = 2131427486;
 			
-			// aapt resource value: 0x7f09001f
-			public static int TextAppearance_Design_Counter = 2131296287;
+			// aapt resource value: 0x7f0b00f3
+			public static int TextAppearance_AppCompat_SearchResult_Subtitle = 2131427571;
 			
-			// aapt resource value: 0x7f090020
-			public static int TextAppearance_Design_Counter_Overflow = 2131296288;
+			// aapt resource value: 0x7f0b00f4
+			public static int TextAppearance_AppCompat_SearchResult_Title = 2131427572;
 			
-			// aapt resource value: 0x7f090021
-			public static int TextAppearance_Design_Error = 2131296289;
+			// aapt resource value: 0x7f0b00f5
+			public static int TextAppearance_AppCompat_Small = 2131427573;
 			
-			// aapt resource value: 0x7f090022
-			public static int TextAppearance_Design_Hint = 2131296290;
+			// aapt resource value: 0x7f0b00f6
+			public static int TextAppearance_AppCompat_Small_Inverse = 2131427574;
 			
-			// aapt resource value: 0x7f090023
-			public static int TextAppearance_Design_Snackbar_Message = 2131296291;
+			// aapt resource value: 0x7f0b00f7
+			public static int TextAppearance_AppCompat_Subhead = 2131427575;
 			
-			// aapt resource value: 0x7f090024
-			public static int TextAppearance_Design_Tab = 2131296292;
+			// aapt resource value: 0x7f0b00f8
+			public static int TextAppearance_AppCompat_Subhead_Inverse = 2131427576;
 			
-			// aapt resource value: 0x7f090057
-			public static int TextAppearance_StatusBar_EventContent = 2131296343;
+			// aapt resource value: 0x7f0b00f9
+			public static int TextAppearance_AppCompat_Title = 2131427577;
 			
-			// aapt resource value: 0x7f090058
-			public static int TextAppearance_StatusBar_EventContent_Info = 2131296344;
+			// aapt resource value: 0x7f0b00fa
+			public static int TextAppearance_AppCompat_Title_Inverse = 2131427578;
 			
-			// aapt resource value: 0x7f090059
-			public static int TextAppearance_StatusBar_EventContent_Line2 = 2131296345;
+			// aapt resource value: 0x7f0b00fb
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131427579;
 			
-			// aapt resource value: 0x7f09005a
-			public static int TextAppearance_StatusBar_EventContent_Time = 2131296346;
+			// aapt resource value: 0x7f0b00fc
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131427580;
 			
-			// aapt resource value: 0x7f09005b
-			public static int TextAppearance_StatusBar_EventContent_Title = 2131296347;
+			// aapt resource value: 0x7f0b00fd
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131427581;
 			
-			// aapt resource value: 0x7f090116
-			public static int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131296534;
+			// aapt resource value: 0x7f0b00fe
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131427582;
 			
-			// aapt resource value: 0x7f090117
-			public static int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131296535;
+			// aapt resource value: 0x7f0b00ff
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131427583;
 			
-			// aapt resource value: 0x7f090118
-			public static int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131296536;
+			// aapt resource value: 0x7f0b0100
+			public static int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131427584;
 			
-			// aapt resource value: 0x7f090119
-			public static int Theme_AppCompat = 2131296537;
+			// aapt resource value: 0x7f0b0101
+			public static int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131427585;
 			
-			// aapt resource value: 0x7f09011a
-			public static int Theme_AppCompat_CompactMenu = 2131296538;
+			// aapt resource value: 0x7f0b0102
+			public static int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131427586;
 			
-			// aapt resource value: 0x7f090038
-			public static int Theme_AppCompat_DayNight = 2131296312;
+			// aapt resource value: 0x7f0b0103
+			public static int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131427587;
 			
-			// aapt resource value: 0x7f090039
-			public static int Theme_AppCompat_DayNight_DarkActionBar = 2131296313;
+			// aapt resource value: 0x7f0b0104
+			public static int TextAppearance_AppCompat_Widget_Button = 2131427588;
 			
-			// aapt resource value: 0x7f09003a
-			public static int Theme_AppCompat_DayNight_Dialog = 2131296314;
+			// aapt resource value: 0x7f0b0105
+			public static int TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131427589;
 			
-			// aapt resource value: 0x7f09003b
-			public static int Theme_AppCompat_DayNight_Dialog_Alert = 2131296315;
+			// aapt resource value: 0x7f0b0106
+			public static int TextAppearance_AppCompat_Widget_Button_Colored = 2131427590;
 			
-			// aapt resource value: 0x7f09003c
-			public static int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131296316;
+			// aapt resource value: 0x7f0b0107
+			public static int TextAppearance_AppCompat_Widget_Button_Inverse = 2131427591;
 			
-			// aapt resource value: 0x7f09003d
-			public static int Theme_AppCompat_DayNight_DialogWhenLarge = 2131296317;
+			// aapt resource value: 0x7f0b0108
+			public static int TextAppearance_AppCompat_Widget_DropDownItem = 2131427592;
 			
-			// aapt resource value: 0x7f09003e
-			public static int Theme_AppCompat_DayNight_NoActionBar = 2131296318;
+			// aapt resource value: 0x7f0b0109
+			public static int TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131427593;
 			
-			// aapt resource value: 0x7f09011b
-			public static int Theme_AppCompat_Dialog = 2131296539;
+			// aapt resource value: 0x7f0b010a
+			public static int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131427594;
 			
-			// aapt resource value: 0x7f09011c
-			public static int Theme_AppCompat_Dialog_Alert = 2131296540;
+			// aapt resource value: 0x7f0b010b
+			public static int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131427595;
 			
-			// aapt resource value: 0x7f09011d
-			public static int Theme_AppCompat_Dialog_MinWidth = 2131296541;
+			// aapt resource value: 0x7f0b010c
+			public static int TextAppearance_AppCompat_Widget_Switch = 2131427596;
 			
-			// aapt resource value: 0x7f09011e
-			public static int Theme_AppCompat_DialogWhenLarge = 2131296542;
+			// aapt resource value: 0x7f0b010d
+			public static int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131427597;
 			
-			// aapt resource value: 0x7f09011f
-			public static int Theme_AppCompat_Light = 2131296543;
+			// aapt resource value: 0x7f0b0173
+			public static int TextAppearance_Design_CollapsingToolbar_Expanded = 2131427699;
 			
-			// aapt resource value: 0x7f090120
-			public static int Theme_AppCompat_Light_DarkActionBar = 2131296544;
+			// aapt resource value: 0x7f0b0174
+			public static int TextAppearance_Design_Counter = 2131427700;
 			
-			// aapt resource value: 0x7f090121
-			public static int Theme_AppCompat_Light_Dialog = 2131296545;
+			// aapt resource value: 0x7f0b0175
+			public static int TextAppearance_Design_Counter_Overflow = 2131427701;
 			
-			// aapt resource value: 0x7f090122
-			public static int Theme_AppCompat_Light_Dialog_Alert = 2131296546;
+			// aapt resource value: 0x7f0b0176
+			public static int TextAppearance_Design_Error = 2131427702;
 			
-			// aapt resource value: 0x7f090123
-			public static int Theme_AppCompat_Light_Dialog_MinWidth = 2131296547;
+			// aapt resource value: 0x7f0b0177
+			public static int TextAppearance_Design_Hint = 2131427703;
 			
-			// aapt resource value: 0x7f090124
-			public static int Theme_AppCompat_Light_DialogWhenLarge = 2131296548;
+			// aapt resource value: 0x7f0b0178
+			public static int TextAppearance_Design_Snackbar_Message = 2131427704;
 			
-			// aapt resource value: 0x7f090125
-			public static int Theme_AppCompat_Light_NoActionBar = 2131296549;
+			// aapt resource value: 0x7f0b0179
+			public static int TextAppearance_Design_Tab = 2131427705;
 			
-			// aapt resource value: 0x7f090126
-			public static int Theme_AppCompat_NoActionBar = 2131296550;
+			// aapt resource value: 0x7f0b0000
+			public static int TextAppearance_MediaRouter_PrimaryText = 2131427328;
 			
-			// aapt resource value: 0x7f090025
-			public static int Theme_Design = 2131296293;
+			// aapt resource value: 0x7f0b0001
+			public static int TextAppearance_MediaRouter_SecondaryText = 2131427329;
 			
-			// aapt resource value: 0x7f090026
-			public static int Theme_Design_BottomSheetDialog = 2131296294;
+			// aapt resource value: 0x7f0b0002
+			public static int TextAppearance_MediaRouter_Title = 2131427330;
 			
-			// aapt resource value: 0x7f090027
-			public static int Theme_Design_Light = 2131296295;
+			// aapt resource value: 0x7f0b003b
+			public static int TextAppearance_StatusBar_EventContent = 2131427387;
 			
-			// aapt resource value: 0x7f090028
-			public static int Theme_Design_Light_BottomSheetDialog = 2131296296;
+			// aapt resource value: 0x7f0b003c
+			public static int TextAppearance_StatusBar_EventContent_Info = 2131427388;
 			
-			// aapt resource value: 0x7f090029
-			public static int Theme_Design_Light_NoActionBar = 2131296297;
+			// aapt resource value: 0x7f0b003d
+			public static int TextAppearance_StatusBar_EventContent_Line2 = 2131427389;
 			
-			// aapt resource value: 0x7f09002a
-			public static int Theme_Design_NoActionBar = 2131296298;
+			// aapt resource value: 0x7f0b003e
+			public static int TextAppearance_StatusBar_EventContent_Time = 2131427390;
 			
-			// aapt resource value: 0x7f090000
-			public static int Theme_MediaRouter = 2131296256;
+			// aapt resource value: 0x7f0b003f
+			public static int TextAppearance_StatusBar_EventContent_Title = 2131427391;
 			
-			// aapt resource value: 0x7f090001
-			public static int Theme_MediaRouter_Light = 2131296257;
+			// aapt resource value: 0x7f0b010e
+			public static int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131427598;
 			
-			// aapt resource value: 0x7f090002
-			public static int Theme_MediaRouter_Light_DarkControlPanel = 2131296258;
+			// aapt resource value: 0x7f0b010f
+			public static int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131427599;
 			
-			// aapt resource value: 0x7f090003
-			public static int Theme_MediaRouter_LightControlPanel = 2131296259;
+			// aapt resource value: 0x7f0b0110
+			public static int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131427600;
 			
-			// aapt resource value: 0x7f090127
-			public static int ThemeOverlay_AppCompat = 2131296551;
+			// aapt resource value: 0x7f0b0111
+			public static int Theme_AppCompat = 2131427601;
 			
-			// aapt resource value: 0x7f090128
-			public static int ThemeOverlay_AppCompat_ActionBar = 2131296552;
+			// aapt resource value: 0x7f0b0112
+			public static int Theme_AppCompat_CompactMenu = 2131427602;
 			
-			// aapt resource value: 0x7f090129
-			public static int ThemeOverlay_AppCompat_Dark = 2131296553;
+			// aapt resource value: 0x7f0b0013
+			public static int Theme_AppCompat_DayNight = 2131427347;
 			
-			// aapt resource value: 0x7f09012a
-			public static int ThemeOverlay_AppCompat_Dark_ActionBar = 2131296554;
+			// aapt resource value: 0x7f0b0014
+			public static int Theme_AppCompat_DayNight_DarkActionBar = 2131427348;
 			
-			// aapt resource value: 0x7f09012b
-			public static int ThemeOverlay_AppCompat_Light = 2131296555;
+			// aapt resource value: 0x7f0b0015
+			public static int Theme_AppCompat_DayNight_Dialog = 2131427349;
 			
-			// aapt resource value: 0x7f09012c
-			public static int Widget_AppCompat_ActionBar = 2131296556;
+			// aapt resource value: 0x7f0b0016
+			public static int Theme_AppCompat_DayNight_Dialog_Alert = 2131427350;
 			
-			// aapt resource value: 0x7f09012d
-			public static int Widget_AppCompat_ActionBar_Solid = 2131296557;
+			// aapt resource value: 0x7f0b0017
+			public static int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131427351;
 			
-			// aapt resource value: 0x7f09012e
-			public static int Widget_AppCompat_ActionBar_TabBar = 2131296558;
+			// aapt resource value: 0x7f0b0018
+			public static int Theme_AppCompat_DayNight_DialogWhenLarge = 2131427352;
 			
-			// aapt resource value: 0x7f09012f
-			public static int Widget_AppCompat_ActionBar_TabText = 2131296559;
+			// aapt resource value: 0x7f0b0019
+			public static int Theme_AppCompat_DayNight_NoActionBar = 2131427353;
 			
-			// aapt resource value: 0x7f090130
-			public static int Widget_AppCompat_ActionBar_TabView = 2131296560;
+			// aapt resource value: 0x7f0b0113
+			public static int Theme_AppCompat_Dialog = 2131427603;
 			
-			// aapt resource value: 0x7f090131
-			public static int Widget_AppCompat_ActionButton = 2131296561;
+			// aapt resource value: 0x7f0b0114
+			public static int Theme_AppCompat_Dialog_Alert = 2131427604;
 			
-			// aapt resource value: 0x7f090132
-			public static int Widget_AppCompat_ActionButton_CloseMode = 2131296562;
+			// aapt resource value: 0x7f0b0115
+			public static int Theme_AppCompat_Dialog_MinWidth = 2131427605;
 			
-			// aapt resource value: 0x7f090133
-			public static int Widget_AppCompat_ActionButton_Overflow = 2131296563;
+			// aapt resource value: 0x7f0b0116
+			public static int Theme_AppCompat_DialogWhenLarge = 2131427606;
 			
-			// aapt resource value: 0x7f090134
-			public static int Widget_AppCompat_ActionMode = 2131296564;
+			// aapt resource value: 0x7f0b0117
+			public static int Theme_AppCompat_Light = 2131427607;
 			
-			// aapt resource value: 0x7f090135
-			public static int Widget_AppCompat_ActivityChooserView = 2131296565;
+			// aapt resource value: 0x7f0b0118
+			public static int Theme_AppCompat_Light_DarkActionBar = 2131427608;
 			
-			// aapt resource value: 0x7f090136
-			public static int Widget_AppCompat_AutoCompleteTextView = 2131296566;
+			// aapt resource value: 0x7f0b0119
+			public static int Theme_AppCompat_Light_Dialog = 2131427609;
 			
-			// aapt resource value: 0x7f090137
-			public static int Widget_AppCompat_Button = 2131296567;
+			// aapt resource value: 0x7f0b011a
+			public static int Theme_AppCompat_Light_Dialog_Alert = 2131427610;
 			
-			// aapt resource value: 0x7f090138
-			public static int Widget_AppCompat_Button_Borderless = 2131296568;
+			// aapt resource value: 0x7f0b011b
+			public static int Theme_AppCompat_Light_Dialog_MinWidth = 2131427611;
 			
-			// aapt resource value: 0x7f090139
-			public static int Widget_AppCompat_Button_Borderless_Colored = 2131296569;
+			// aapt resource value: 0x7f0b011c
+			public static int Theme_AppCompat_Light_DialogWhenLarge = 2131427612;
 			
-			// aapt resource value: 0x7f09013a
-			public static int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131296570;
+			// aapt resource value: 0x7f0b011d
+			public static int Theme_AppCompat_Light_NoActionBar = 2131427613;
 			
-			// aapt resource value: 0x7f09013b
-			public static int Widget_AppCompat_Button_Colored = 2131296571;
+			// aapt resource value: 0x7f0b011e
+			public static int Theme_AppCompat_NoActionBar = 2131427614;
 			
-			// aapt resource value: 0x7f09013c
-			public static int Widget_AppCompat_Button_Small = 2131296572;
+			// aapt resource value: 0x7f0b017a
+			public static int Theme_Design = 2131427706;
 			
-			// aapt resource value: 0x7f09013d
-			public static int Widget_AppCompat_ButtonBar = 2131296573;
+			// aapt resource value: 0x7f0b017b
+			public static int Theme_Design_BottomSheetDialog = 2131427707;
 			
-			// aapt resource value: 0x7f09013e
-			public static int Widget_AppCompat_ButtonBar_AlertDialog = 2131296574;
+			// aapt resource value: 0x7f0b017c
+			public static int Theme_Design_Light = 2131427708;
 			
-			// aapt resource value: 0x7f09013f
-			public static int Widget_AppCompat_CompoundButton_CheckBox = 2131296575;
+			// aapt resource value: 0x7f0b017d
+			public static int Theme_Design_Light_BottomSheetDialog = 2131427709;
 			
-			// aapt resource value: 0x7f090140
-			public static int Widget_AppCompat_CompoundButton_RadioButton = 2131296576;
+			// aapt resource value: 0x7f0b017e
+			public static int Theme_Design_Light_NoActionBar = 2131427710;
 			
-			// aapt resource value: 0x7f090141
-			public static int Widget_AppCompat_CompoundButton_Switch = 2131296577;
+			// aapt resource value: 0x7f0b017f
+			public static int Theme_Design_NoActionBar = 2131427711;
 			
-			// aapt resource value: 0x7f090142
-			public static int Widget_AppCompat_DrawerArrowToggle = 2131296578;
+			// aapt resource value: 0x7f0b0003
+			public static int Theme_MediaRouter = 2131427331;
 			
-			// aapt resource value: 0x7f090143
-			public static int Widget_AppCompat_DropDownItem_Spinner = 2131296579;
+			// aapt resource value: 0x7f0b0004
+			public static int Theme_MediaRouter_Light = 2131427332;
 			
-			// aapt resource value: 0x7f090144
-			public static int Widget_AppCompat_EditText = 2131296580;
+			// aapt resource value: 0x7f0b0005
+			public static int Theme_MediaRouter_Light_DarkControlPanel = 2131427333;
 			
-			// aapt resource value: 0x7f090145
-			public static int Widget_AppCompat_ImageButton = 2131296581;
+			// aapt resource value: 0x7f0b0006
+			public static int Theme_MediaRouter_LightControlPanel = 2131427334;
 			
-			// aapt resource value: 0x7f090146
-			public static int Widget_AppCompat_Light_ActionBar = 2131296582;
+			// aapt resource value: 0x7f0b011f
+			public static int ThemeOverlay_AppCompat = 2131427615;
 			
-			// aapt resource value: 0x7f090147
-			public static int Widget_AppCompat_Light_ActionBar_Solid = 2131296583;
+			// aapt resource value: 0x7f0b0120
+			public static int ThemeOverlay_AppCompat_ActionBar = 2131427616;
 			
-			// aapt resource value: 0x7f090148
-			public static int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131296584;
+			// aapt resource value: 0x7f0b0121
+			public static int ThemeOverlay_AppCompat_Dark = 2131427617;
 			
-			// aapt resource value: 0x7f090149
-			public static int Widget_AppCompat_Light_ActionBar_TabBar = 2131296585;
+			// aapt resource value: 0x7f0b0122
+			public static int ThemeOverlay_AppCompat_Dark_ActionBar = 2131427618;
 			
-			// aapt resource value: 0x7f09014a
-			public static int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131296586;
+			// aapt resource value: 0x7f0b0123
+			public static int ThemeOverlay_AppCompat_Dialog = 2131427619;
 			
-			// aapt resource value: 0x7f09014b
-			public static int Widget_AppCompat_Light_ActionBar_TabText = 2131296587;
+			// aapt resource value: 0x7f0b0124
+			public static int ThemeOverlay_AppCompat_Dialog_Alert = 2131427620;
 			
-			// aapt resource value: 0x7f09014c
-			public static int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131296588;
+			// aapt resource value: 0x7f0b0125
+			public static int ThemeOverlay_AppCompat_Light = 2131427621;
 			
-			// aapt resource value: 0x7f09014d
-			public static int Widget_AppCompat_Light_ActionBar_TabView = 2131296589;
+			// aapt resource value: 0x7f0b0007
+			public static int ThemeOverlay_MediaRouter_Dark = 2131427335;
 			
-			// aapt resource value: 0x7f09014e
-			public static int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131296590;
+			// aapt resource value: 0x7f0b0008
+			public static int ThemeOverlay_MediaRouter_Light = 2131427336;
 			
-			// aapt resource value: 0x7f09014f
-			public static int Widget_AppCompat_Light_ActionButton = 2131296591;
+			// aapt resource value: 0x7f0b0126
+			public static int Widget_AppCompat_ActionBar = 2131427622;
 			
-			// aapt resource value: 0x7f090150
-			public static int Widget_AppCompat_Light_ActionButton_CloseMode = 2131296592;
+			// aapt resource value: 0x7f0b0127
+			public static int Widget_AppCompat_ActionBar_Solid = 2131427623;
 			
-			// aapt resource value: 0x7f090151
-			public static int Widget_AppCompat_Light_ActionButton_Overflow = 2131296593;
+			// aapt resource value: 0x7f0b0128
+			public static int Widget_AppCompat_ActionBar_TabBar = 2131427624;
 			
-			// aapt resource value: 0x7f090152
-			public static int Widget_AppCompat_Light_ActionMode_Inverse = 2131296594;
+			// aapt resource value: 0x7f0b0129
+			public static int Widget_AppCompat_ActionBar_TabText = 2131427625;
 			
-			// aapt resource value: 0x7f090153
-			public static int Widget_AppCompat_Light_ActivityChooserView = 2131296595;
+			// aapt resource value: 0x7f0b012a
+			public static int Widget_AppCompat_ActionBar_TabView = 2131427626;
 			
-			// aapt resource value: 0x7f090154
-			public static int Widget_AppCompat_Light_AutoCompleteTextView = 2131296596;
+			// aapt resource value: 0x7f0b012b
+			public static int Widget_AppCompat_ActionButton = 2131427627;
 			
-			// aapt resource value: 0x7f090155
-			public static int Widget_AppCompat_Light_DropDownItem_Spinner = 2131296597;
+			// aapt resource value: 0x7f0b012c
+			public static int Widget_AppCompat_ActionButton_CloseMode = 2131427628;
 			
-			// aapt resource value: 0x7f090156
-			public static int Widget_AppCompat_Light_ListPopupWindow = 2131296598;
+			// aapt resource value: 0x7f0b012d
+			public static int Widget_AppCompat_ActionButton_Overflow = 2131427629;
 			
-			// aapt resource value: 0x7f090157
-			public static int Widget_AppCompat_Light_ListView_DropDown = 2131296599;
+			// aapt resource value: 0x7f0b012e
+			public static int Widget_AppCompat_ActionMode = 2131427630;
 			
-			// aapt resource value: 0x7f090158
-			public static int Widget_AppCompat_Light_PopupMenu = 2131296600;
+			// aapt resource value: 0x7f0b012f
+			public static int Widget_AppCompat_ActivityChooserView = 2131427631;
 			
-			// aapt resource value: 0x7f090159
-			public static int Widget_AppCompat_Light_PopupMenu_Overflow = 2131296601;
+			// aapt resource value: 0x7f0b0130
+			public static int Widget_AppCompat_AutoCompleteTextView = 2131427632;
 			
-			// aapt resource value: 0x7f09015a
-			public static int Widget_AppCompat_Light_SearchView = 2131296602;
+			// aapt resource value: 0x7f0b0131
+			public static int Widget_AppCompat_Button = 2131427633;
 			
-			// aapt resource value: 0x7f09015b
-			public static int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131296603;
+			// aapt resource value: 0x7f0b0132
+			public static int Widget_AppCompat_Button_Borderless = 2131427634;
 			
-			// aapt resource value: 0x7f09015c
-			public static int Widget_AppCompat_ListPopupWindow = 2131296604;
+			// aapt resource value: 0x7f0b0133
+			public static int Widget_AppCompat_Button_Borderless_Colored = 2131427635;
 			
-			// aapt resource value: 0x7f09015d
-			public static int Widget_AppCompat_ListView = 2131296605;
+			// aapt resource value: 0x7f0b0134
+			public static int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131427636;
 			
-			// aapt resource value: 0x7f09015e
-			public static int Widget_AppCompat_ListView_DropDown = 2131296606;
+			// aapt resource value: 0x7f0b0135
+			public static int Widget_AppCompat_Button_Colored = 2131427637;
 			
-			// aapt resource value: 0x7f09015f
-			public static int Widget_AppCompat_ListView_Menu = 2131296607;
+			// aapt resource value: 0x7f0b0136
+			public static int Widget_AppCompat_Button_Small = 2131427638;
 			
-			// aapt resource value: 0x7f090160
-			public static int Widget_AppCompat_PopupMenu = 2131296608;
+			// aapt resource value: 0x7f0b0137
+			public static int Widget_AppCompat_ButtonBar = 2131427639;
 			
-			// aapt resource value: 0x7f090161
-			public static int Widget_AppCompat_PopupMenu_Overflow = 2131296609;
+			// aapt resource value: 0x7f0b0138
+			public static int Widget_AppCompat_ButtonBar_AlertDialog = 2131427640;
 			
-			// aapt resource value: 0x7f090162
-			public static int Widget_AppCompat_PopupWindow = 2131296610;
+			// aapt resource value: 0x7f0b0139
+			public static int Widget_AppCompat_CompoundButton_CheckBox = 2131427641;
 			
-			// aapt resource value: 0x7f090163
-			public static int Widget_AppCompat_ProgressBar = 2131296611;
+			// aapt resource value: 0x7f0b013a
+			public static int Widget_AppCompat_CompoundButton_RadioButton = 2131427642;
 			
-			// aapt resource value: 0x7f090164
-			public static int Widget_AppCompat_ProgressBar_Horizontal = 2131296612;
+			// aapt resource value: 0x7f0b013b
+			public static int Widget_AppCompat_CompoundButton_Switch = 2131427643;
 			
-			// aapt resource value: 0x7f090165
-			public static int Widget_AppCompat_RatingBar = 2131296613;
+			// aapt resource value: 0x7f0b013c
+			public static int Widget_AppCompat_DrawerArrowToggle = 2131427644;
 			
-			// aapt resource value: 0x7f090166
-			public static int Widget_AppCompat_RatingBar_Indicator = 2131296614;
+			// aapt resource value: 0x7f0b013d
+			public static int Widget_AppCompat_DropDownItem_Spinner = 2131427645;
 			
-			// aapt resource value: 0x7f090167
-			public static int Widget_AppCompat_RatingBar_Small = 2131296615;
+			// aapt resource value: 0x7f0b013e
+			public static int Widget_AppCompat_EditText = 2131427646;
 			
-			// aapt resource value: 0x7f090168
-			public static int Widget_AppCompat_SearchView = 2131296616;
+			// aapt resource value: 0x7f0b013f
+			public static int Widget_AppCompat_ImageButton = 2131427647;
 			
-			// aapt resource value: 0x7f090169
-			public static int Widget_AppCompat_SearchView_ActionBar = 2131296617;
+			// aapt resource value: 0x7f0b0140
+			public static int Widget_AppCompat_Light_ActionBar = 2131427648;
 			
-			// aapt resource value: 0x7f09016a
-			public static int Widget_AppCompat_SeekBar = 2131296618;
+			// aapt resource value: 0x7f0b0141
+			public static int Widget_AppCompat_Light_ActionBar_Solid = 2131427649;
 			
-			// aapt resource value: 0x7f09016b
-			public static int Widget_AppCompat_Spinner = 2131296619;
+			// aapt resource value: 0x7f0b0142
+			public static int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131427650;
 			
-			// aapt resource value: 0x7f09016c
-			public static int Widget_AppCompat_Spinner_DropDown = 2131296620;
+			// aapt resource value: 0x7f0b0143
+			public static int Widget_AppCompat_Light_ActionBar_TabBar = 2131427651;
 			
-			// aapt resource value: 0x7f09016d
-			public static int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131296621;
+			// aapt resource value: 0x7f0b0144
+			public static int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131427652;
 			
-			// aapt resource value: 0x7f09016e
-			public static int Widget_AppCompat_Spinner_Underlined = 2131296622;
+			// aapt resource value: 0x7f0b0145
+			public static int Widget_AppCompat_Light_ActionBar_TabText = 2131427653;
 			
-			// aapt resource value: 0x7f09016f
-			public static int Widget_AppCompat_TextView_SpinnerItem = 2131296623;
+			// aapt resource value: 0x7f0b0146
+			public static int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131427654;
 			
-			// aapt resource value: 0x7f090170
-			public static int Widget_AppCompat_Toolbar = 2131296624;
+			// aapt resource value: 0x7f0b0147
+			public static int Widget_AppCompat_Light_ActionBar_TabView = 2131427655;
 			
-			// aapt resource value: 0x7f090171
-			public static int Widget_AppCompat_Toolbar_Button_Navigation = 2131296625;
+			// aapt resource value: 0x7f0b0148
+			public static int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131427656;
 			
-			// aapt resource value: 0x7f09002b
-			public static int Widget_Design_AppBarLayout = 2131296299;
+			// aapt resource value: 0x7f0b0149
+			public static int Widget_AppCompat_Light_ActionButton = 2131427657;
 			
-			// aapt resource value: 0x7f09002c
-			public static int Widget_Design_BottomSheet_Modal = 2131296300;
+			// aapt resource value: 0x7f0b014a
+			public static int Widget_AppCompat_Light_ActionButton_CloseMode = 2131427658;
 			
-			// aapt resource value: 0x7f09002d
-			public static int Widget_Design_CollapsingToolbar = 2131296301;
+			// aapt resource value: 0x7f0b014b
+			public static int Widget_AppCompat_Light_ActionButton_Overflow = 2131427659;
 			
-			// aapt resource value: 0x7f09002e
-			public static int Widget_Design_CoordinatorLayout = 2131296302;
+			// aapt resource value: 0x7f0b014c
+			public static int Widget_AppCompat_Light_ActionMode_Inverse = 2131427660;
 			
-			// aapt resource value: 0x7f09002f
-			public static int Widget_Design_FloatingActionButton = 2131296303;
+			// aapt resource value: 0x7f0b014d
+			public static int Widget_AppCompat_Light_ActivityChooserView = 2131427661;
 			
-			// aapt resource value: 0x7f090030
-			public static int Widget_Design_NavigationView = 2131296304;
+			// aapt resource value: 0x7f0b014e
+			public static int Widget_AppCompat_Light_AutoCompleteTextView = 2131427662;
 			
-			// aapt resource value: 0x7f090031
-			public static int Widget_Design_ScrimInsetsFrameLayout = 2131296305;
+			// aapt resource value: 0x7f0b014f
+			public static int Widget_AppCompat_Light_DropDownItem_Spinner = 2131427663;
 			
-			// aapt resource value: 0x7f090032
-			public static int Widget_Design_Snackbar = 2131296306;
+			// aapt resource value: 0x7f0b0150
+			public static int Widget_AppCompat_Light_ListPopupWindow = 2131427664;
 			
-			// aapt resource value: 0x7f09001b
-			public static int Widget_Design_TabLayout = 2131296283;
+			// aapt resource value: 0x7f0b0151
+			public static int Widget_AppCompat_Light_ListView_DropDown = 2131427665;
 			
-			// aapt resource value: 0x7f090033
-			public static int Widget_Design_TextInputLayout = 2131296307;
+			// aapt resource value: 0x7f0b0152
+			public static int Widget_AppCompat_Light_PopupMenu = 2131427666;
 			
-			// aapt resource value: 0x7f090004
-			public static int Widget_MediaRouter_ChooserText = 2131296260;
+			// aapt resource value: 0x7f0b0153
+			public static int Widget_AppCompat_Light_PopupMenu_Overflow = 2131427667;
 			
-			// aapt resource value: 0x7f090005
-			public static int Widget_MediaRouter_ChooserText_Primary = 2131296261;
+			// aapt resource value: 0x7f0b0154
+			public static int Widget_AppCompat_Light_SearchView = 2131427668;
 			
-			// aapt resource value: 0x7f090006
-			public static int Widget_MediaRouter_ChooserText_Primary_Dark = 2131296262;
+			// aapt resource value: 0x7f0b0155
+			public static int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131427669;
 			
-			// aapt resource value: 0x7f090007
-			public static int Widget_MediaRouter_ChooserText_Primary_Light = 2131296263;
+			// aapt resource value: 0x7f0b0156
+			public static int Widget_AppCompat_ListMenuView = 2131427670;
 			
-			// aapt resource value: 0x7f090008
-			public static int Widget_MediaRouter_ChooserText_Secondary = 2131296264;
+			// aapt resource value: 0x7f0b0157
+			public static int Widget_AppCompat_ListPopupWindow = 2131427671;
 			
-			// aapt resource value: 0x7f090009
-			public static int Widget_MediaRouter_ChooserText_Secondary_Dark = 2131296265;
+			// aapt resource value: 0x7f0b0158
+			public static int Widget_AppCompat_ListView = 2131427672;
 			
-			// aapt resource value: 0x7f09000a
-			public static int Widget_MediaRouter_ChooserText_Secondary_Light = 2131296266;
+			// aapt resource value: 0x7f0b0159
+			public static int Widget_AppCompat_ListView_DropDown = 2131427673;
 			
-			// aapt resource value: 0x7f09000b
-			public static int Widget_MediaRouter_ControllerText = 2131296267;
+			// aapt resource value: 0x7f0b015a
+			public static int Widget_AppCompat_ListView_Menu = 2131427674;
 			
-			// aapt resource value: 0x7f09000c
-			public static int Widget_MediaRouter_ControllerText_Primary = 2131296268;
+			// aapt resource value: 0x7f0b009f
+			public static int Widget_AppCompat_NotificationActionContainer = 2131427487;
 			
-			// aapt resource value: 0x7f09000d
-			public static int Widget_MediaRouter_ControllerText_Primary_Dark = 2131296269;
+			// aapt resource value: 0x7f0b00a0
+			public static int Widget_AppCompat_NotificationActionText = 2131427488;
 			
-			// aapt resource value: 0x7f09000e
-			public static int Widget_MediaRouter_ControllerText_Primary_Light = 2131296270;
+			// aapt resource value: 0x7f0b015b
+			public static int Widget_AppCompat_PopupMenu = 2131427675;
 			
-			// aapt resource value: 0x7f09000f
-			public static int Widget_MediaRouter_ControllerText_Secondary = 2131296271;
+			// aapt resource value: 0x7f0b015c
+			public static int Widget_AppCompat_PopupMenu_Overflow = 2131427676;
 			
-			// aapt resource value: 0x7f090010
-			public static int Widget_MediaRouter_ControllerText_Secondary_Dark = 2131296272;
+			// aapt resource value: 0x7f0b015d
+			public static int Widget_AppCompat_PopupWindow = 2131427677;
 			
-			// aapt resource value: 0x7f090011
-			public static int Widget_MediaRouter_ControllerText_Secondary_Light = 2131296273;
+			// aapt resource value: 0x7f0b015e
+			public static int Widget_AppCompat_ProgressBar = 2131427678;
 			
-			// aapt resource value: 0x7f090012
-			public static int Widget_MediaRouter_ControllerText_Title = 2131296274;
+			// aapt resource value: 0x7f0b015f
+			public static int Widget_AppCompat_ProgressBar_Horizontal = 2131427679;
 			
-			// aapt resource value: 0x7f090013
-			public static int Widget_MediaRouter_ControllerText_Title_Dark = 2131296275;
+			// aapt resource value: 0x7f0b0160
+			public static int Widget_AppCompat_RatingBar = 2131427680;
 			
-			// aapt resource value: 0x7f090014
-			public static int Widget_MediaRouter_ControllerText_Title_Light = 2131296276;
+			// aapt resource value: 0x7f0b0161
+			public static int Widget_AppCompat_RatingBar_Indicator = 2131427681;
 			
-			// aapt resource value: 0x7f090015
-			public static int Widget_MediaRouter_Light_MediaRouteButton = 2131296277;
+			// aapt resource value: 0x7f0b0162
+			public static int Widget_AppCompat_RatingBar_Small = 2131427682;
 			
-			// aapt resource value: 0x7f090016
-			public static int Widget_MediaRouter_MediaRouteButton = 2131296278;
+			// aapt resource value: 0x7f0b0163
+			public static int Widget_AppCompat_SearchView = 2131427683;
+			
+			// aapt resource value: 0x7f0b0164
+			public static int Widget_AppCompat_SearchView_ActionBar = 2131427684;
+			
+			// aapt resource value: 0x7f0b0165
+			public static int Widget_AppCompat_SeekBar = 2131427685;
+			
+			// aapt resource value: 0x7f0b0166
+			public static int Widget_AppCompat_SeekBar_Discrete = 2131427686;
+			
+			// aapt resource value: 0x7f0b0167
+			public static int Widget_AppCompat_Spinner = 2131427687;
+			
+			// aapt resource value: 0x7f0b0168
+			public static int Widget_AppCompat_Spinner_DropDown = 2131427688;
+			
+			// aapt resource value: 0x7f0b0169
+			public static int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131427689;
+			
+			// aapt resource value: 0x7f0b016a
+			public static int Widget_AppCompat_Spinner_Underlined = 2131427690;
+			
+			// aapt resource value: 0x7f0b016b
+			public static int Widget_AppCompat_TextView_SpinnerItem = 2131427691;
+			
+			// aapt resource value: 0x7f0b016c
+			public static int Widget_AppCompat_Toolbar = 2131427692;
+			
+			// aapt resource value: 0x7f0b016d
+			public static int Widget_AppCompat_Toolbar_Button_Navigation = 2131427693;
+			
+			// aapt resource value: 0x7f0b016f
+			public static int Widget_Design_AppBarLayout = 2131427695;
+			
+			// aapt resource value: 0x7f0b0180
+			public static int Widget_Design_BottomNavigationView = 2131427712;
+			
+			// aapt resource value: 0x7f0b0181
+			public static int Widget_Design_BottomSheet_Modal = 2131427713;
+			
+			// aapt resource value: 0x7f0b0182
+			public static int Widget_Design_CollapsingToolbar = 2131427714;
+			
+			// aapt resource value: 0x7f0b0183
+			public static int Widget_Design_CoordinatorLayout = 2131427715;
+			
+			// aapt resource value: 0x7f0b0184
+			public static int Widget_Design_FloatingActionButton = 2131427716;
+			
+			// aapt resource value: 0x7f0b0185
+			public static int Widget_Design_NavigationView = 2131427717;
+			
+			// aapt resource value: 0x7f0b0186
+			public static int Widget_Design_ScrimInsetsFrameLayout = 2131427718;
+			
+			// aapt resource value: 0x7f0b0187
+			public static int Widget_Design_Snackbar = 2131427719;
+			
+			// aapt resource value: 0x7f0b016e
+			public static int Widget_Design_TabLayout = 2131427694;
+			
+			// aapt resource value: 0x7f0b0188
+			public static int Widget_Design_TextInputLayout = 2131427720;
+			
+			// aapt resource value: 0x7f0b0009
+			public static int Widget_MediaRouter_Light_MediaRouteButton = 2131427337;
+			
+			// aapt resource value: 0x7f0b000a
+			public static int Widget_MediaRouter_MediaRouteButton = 2131427338;
 			
 			static Style()
 			{
@@ -4172,33 +4986,35 @@ namespace XFGloss.Droid
 			
 			public static int[] ActionBar = new int[]
 			{
-					2130772076,
-					2130772078,
-					2130772079,
-					2130772080,
-					2130772081,
-					2130772082,
-					2130772083,
-					2130772084,
-					2130772085,
-					2130772086,
-					2130772087,
-					2130772088,
-					2130772089,
-					2130772090,
-					2130772091,
-					2130772092,
-					2130772093,
-					2130772094,
-					2130772095,
-					2130772096,
-					2130772097,
-					2130772098,
-					2130772099,
-					2130772100,
-					2130772101,
-					2130772102,
-					2130772159};
+					2130771997,
+					2130771999,
+					2130772000,
+					2130772001,
+					2130772002,
+					2130772003,
+					2130772004,
+					2130772005,
+					2130772006,
+					2130772007,
+					2130772008,
+					2130772009,
+					2130772010,
+					2130772011,
+					2130772012,
+					2130772013,
+					2130772014,
+					2130772015,
+					2130772016,
+					2130772017,
+					2130772018,
+					2130772019,
+					2130772020,
+					2130772021,
+					2130772022,
+					2130772023,
+					2130772024,
+					2130772025,
+					2130772087};
 			
 			// aapt resource value: 10
 			public static int ActionBar_background = 10;
@@ -4212,6 +5028,9 @@ namespace XFGloss.Droid
 			// aapt resource value: 21
 			public static int ActionBar_contentInsetEnd = 21;
 			
+			// aapt resource value: 25
+			public static int ActionBar_contentInsetEndWithActions = 25;
+			
 			// aapt resource value: 22
 			public static int ActionBar_contentInsetLeft = 22;
 			
@@ -4220,6 +5039,9 @@ namespace XFGloss.Droid
 			
 			// aapt resource value: 20
 			public static int ActionBar_contentInsetStart = 20;
+			
+			// aapt resource value: 24
+			public static int ActionBar_contentInsetStartWithNavigation = 24;
 			
 			// aapt resource value: 13
 			public static int ActionBar_customNavigationLayout = 13;
@@ -4230,8 +5052,8 @@ namespace XFGloss.Droid
 			// aapt resource value: 9
 			public static int ActionBar_divider = 9;
 			
-			// aapt resource value: 24
-			public static int ActionBar_elevation = 24;
+			// aapt resource value: 26
+			public static int ActionBar_elevation = 26;
 			
 			// aapt resource value: 0
 			public static int ActionBar_height = 0;
@@ -4239,8 +5061,8 @@ namespace XFGloss.Droid
 			// aapt resource value: 19
 			public static int ActionBar_hideOnContentScroll = 19;
 			
-			// aapt resource value: 26
-			public static int ActionBar_homeAsUpIndicator = 26;
+			// aapt resource value: 28
+			public static int ActionBar_homeAsUpIndicator = 28;
 			
 			// aapt resource value: 14
 			public static int ActionBar_homeLayout = 14;
@@ -4260,8 +5082,8 @@ namespace XFGloss.Droid
 			// aapt resource value: 2
 			public static int ActionBar_navigationMode = 2;
 			
-			// aapt resource value: 25
-			public static int ActionBar_popupTheme = 25;
+			// aapt resource value: 27
+			public static int ActionBar_popupTheme = 27;
 			
 			// aapt resource value: 17
 			public static int ActionBar_progressBarPadding = 17;
@@ -4299,12 +5121,12 @@ namespace XFGloss.Droid
 			
 			public static int[] ActionMode = new int[]
 			{
-					2130772076,
-					2130772082,
-					2130772083,
-					2130772087,
-					2130772089,
-					2130772103};
+					2130771997,
+					2130772003,
+					2130772004,
+					2130772008,
+					2130772010,
+					2130772026};
 			
 			// aapt resource value: 3
 			public static int ActionMode_background = 3;
@@ -4326,8 +5148,8 @@ namespace XFGloss.Droid
 			
 			public static int[] ActivityChooserView = new int[]
 			{
-					2130772104,
-					2130772105};
+					2130772027,
+					2130772028};
 			
 			// aapt resource value: 1
 			public static int ActivityChooserView_expandActivityOverflowButtonDrawable = 1;
@@ -4338,11 +5160,12 @@ namespace XFGloss.Droid
 			public static int[] AlertDialog = new int[]
 			{
 					16842994,
-					2130772106,
-					2130772107,
-					2130772108,
-					2130772109,
-					2130772110};
+					2130772029,
+					2130772030,
+					2130772031,
+					2130772032,
+					2130772033,
+					2130772034};
 			
 			// aapt resource value: 0
 			public static int AlertDialog_android_layout = 0;
@@ -4359,39 +5182,53 @@ namespace XFGloss.Droid
 			// aapt resource value: 3
 			public static int AlertDialog_multiChoiceItemLayout = 3;
 			
+			// aapt resource value: 6
+			public static int AlertDialog_showTitle = 6;
+			
 			// aapt resource value: 4
 			public static int AlertDialog_singleChoiceItemLayout = 4;
 			
 			public static int[] AppBarLayout = new int[]
 			{
 					16842964,
-					2130772002,
-					2130772101};
+					2130772024,
+					2130772224};
 			
 			// aapt resource value: 0
 			public static int AppBarLayout_android_background = 0;
 			
-			// aapt resource value: 2
-			public static int AppBarLayout_elevation = 2;
-			
 			// aapt resource value: 1
-			public static int AppBarLayout_expanded = 1;
+			public static int AppBarLayout_elevation = 1;
 			
-			public static int[] AppBarLayout_LayoutParams = new int[]
+			// aapt resource value: 2
+			public static int AppBarLayout_expanded = 2;
+			
+			public static int[] AppBarLayoutStates = new int[]
 			{
-					2130772003,
-					2130772004};
+					2130772225,
+					2130772226};
 			
 			// aapt resource value: 0
-			public static int AppBarLayout_LayoutParams_layout_scrollFlags = 0;
+			public static int AppBarLayoutStates_state_collapsed = 0;
 			
 			// aapt resource value: 1
-			public static int AppBarLayout_LayoutParams_layout_scrollInterpolator = 1;
+			public static int AppBarLayoutStates_state_collapsible = 1;
+			
+			public static int[] AppBarLayout_Layout = new int[]
+			{
+					2130772227,
+					2130772228};
+			
+			// aapt resource value: 0
+			public static int AppBarLayout_Layout_layout_scrollFlags = 0;
+			
+			// aapt resource value: 1
+			public static int AppBarLayout_Layout_layout_scrollInterpolator = 1;
 			
 			public static int[] AppCompatImageView = new int[]
 			{
 					16843033,
-					2130772111};
+					2130772035};
 			
 			// aapt resource value: 0
 			public static int AppCompatImageView_android_src = 0;
@@ -4399,10 +5236,60 @@ namespace XFGloss.Droid
 			// aapt resource value: 1
 			public static int AppCompatImageView_srcCompat = 1;
 			
+			public static int[] AppCompatSeekBar = new int[]
+			{
+					16843074,
+					2130772036,
+					2130772037,
+					2130772038};
+			
+			// aapt resource value: 0
+			public static int AppCompatSeekBar_android_thumb = 0;
+			
+			// aapt resource value: 1
+			public static int AppCompatSeekBar_tickMark = 1;
+			
+			// aapt resource value: 2
+			public static int AppCompatSeekBar_tickMarkTint = 2;
+			
+			// aapt resource value: 3
+			public static int AppCompatSeekBar_tickMarkTintMode = 3;
+			
+			public static int[] AppCompatTextHelper = new int[]
+			{
+					16842804,
+					16843117,
+					16843118,
+					16843119,
+					16843120,
+					16843666,
+					16843667};
+			
+			// aapt resource value: 2
+			public static int AppCompatTextHelper_android_drawableBottom = 2;
+			
+			// aapt resource value: 6
+			public static int AppCompatTextHelper_android_drawableEnd = 6;
+			
+			// aapt resource value: 3
+			public static int AppCompatTextHelper_android_drawableLeft = 3;
+			
+			// aapt resource value: 4
+			public static int AppCompatTextHelper_android_drawableRight = 4;
+			
+			// aapt resource value: 5
+			public static int AppCompatTextHelper_android_drawableStart = 5;
+			
+			// aapt resource value: 1
+			public static int AppCompatTextHelper_android_drawableTop = 1;
+			
+			// aapt resource value: 0
+			public static int AppCompatTextHelper_android_textAppearance = 0;
+			
 			public static int[] AppCompatTextView = new int[]
 			{
 					16842804,
-					2130772112};
+					2130772039};
 			
 			// aapt resource value: 0
 			public static int AppCompatTextView_android_textAppearance = 0;
@@ -4414,6 +5301,79 @@ namespace XFGloss.Droid
 			{
 					16842839,
 					16842926,
+					2130772040,
+					2130772041,
+					2130772042,
+					2130772043,
+					2130772044,
+					2130772045,
+					2130772046,
+					2130772047,
+					2130772048,
+					2130772049,
+					2130772050,
+					2130772051,
+					2130772052,
+					2130772053,
+					2130772054,
+					2130772055,
+					2130772056,
+					2130772057,
+					2130772058,
+					2130772059,
+					2130772060,
+					2130772061,
+					2130772062,
+					2130772063,
+					2130772064,
+					2130772065,
+					2130772066,
+					2130772067,
+					2130772068,
+					2130772069,
+					2130772070,
+					2130772071,
+					2130772072,
+					2130772073,
+					2130772074,
+					2130772075,
+					2130772076,
+					2130772077,
+					2130772078,
+					2130772079,
+					2130772080,
+					2130772081,
+					2130772082,
+					2130772083,
+					2130772084,
+					2130772085,
+					2130772086,
+					2130772087,
+					2130772088,
+					2130772089,
+					2130772090,
+					2130772091,
+					2130772092,
+					2130772093,
+					2130772094,
+					2130772095,
+					2130772096,
+					2130772097,
+					2130772098,
+					2130772099,
+					2130772100,
+					2130772101,
+					2130772102,
+					2130772103,
+					2130772104,
+					2130772105,
+					2130772106,
+					2130772107,
+					2130772108,
+					2130772109,
+					2130772110,
+					2130772111,
+					2130772112,
 					2130772113,
 					2130772114,
 					2130772115,
@@ -4453,77 +5413,7 @@ namespace XFGloss.Droid
 					2130772149,
 					2130772150,
 					2130772151,
-					2130772152,
-					2130772153,
-					2130772154,
-					2130772155,
-					2130772156,
-					2130772157,
-					2130772158,
-					2130772159,
-					2130772160,
-					2130772161,
-					2130772162,
-					2130772163,
-					2130772164,
-					2130772165,
-					2130772166,
-					2130772167,
-					2130772168,
-					2130772169,
-					2130772170,
-					2130772171,
-					2130772172,
-					2130772173,
-					2130772174,
-					2130772175,
-					2130772176,
-					2130772177,
-					2130772178,
-					2130772179,
-					2130772180,
-					2130772181,
-					2130772182,
-					2130772183,
-					2130772184,
-					2130772185,
-					2130772186,
-					2130772187,
-					2130772188,
-					2130772189,
-					2130772190,
-					2130772191,
-					2130772192,
-					2130772193,
-					2130772194,
-					2130772195,
-					2130772196,
-					2130772197,
-					2130772198,
-					2130772199,
-					2130772200,
-					2130772201,
-					2130772202,
-					2130772203,
-					2130772204,
-					2130772205,
-					2130772206,
-					2130772207,
-					2130772208,
-					2130772209,
-					2130772210,
-					2130772211,
-					2130772212,
-					2130772213,
-					2130772214,
-					2130772215,
-					2130772216,
-					2130772217,
-					2130772218,
-					2130772219,
-					2130772220,
-					2130772221,
-					2130772222};
+					2130772152};
 			
 			// aapt resource value: 23
 			public static int AppCompatTheme_actionBarDivider = 23;
@@ -4558,11 +5448,11 @@ namespace XFGloss.Droid
 			// aapt resource value: 21
 			public static int AppCompatTheme_actionBarWidgetTheme = 21;
 			
-			// aapt resource value: 49
-			public static int AppCompatTheme_actionButtonStyle = 49;
+			// aapt resource value: 50
+			public static int AppCompatTheme_actionButtonStyle = 50;
 			
-			// aapt resource value: 45
-			public static int AppCompatTheme_actionDropDownStyle = 45;
+			// aapt resource value: 46
+			public static int AppCompatTheme_actionDropDownStyle = 46;
 			
 			// aapt resource value: 25
 			public static int AppCompatTheme_actionMenuTextAppearance = 25;
@@ -4615,20 +5505,20 @@ namespace XFGloss.Droid
 			// aapt resource value: 16
 			public static int AppCompatTheme_actionOverflowMenuStyle = 16;
 			
-			// aapt resource value: 57
-			public static int AppCompatTheme_activityChooserViewStyle = 57;
-			
-			// aapt resource value: 92
-			public static int AppCompatTheme_alertDialogButtonGroupStyle = 92;
-			
-			// aapt resource value: 93
-			public static int AppCompatTheme_alertDialogCenterButtons = 93;
-			
-			// aapt resource value: 91
-			public static int AppCompatTheme_alertDialogStyle = 91;
+			// aapt resource value: 58
+			public static int AppCompatTheme_activityChooserViewStyle = 58;
 			
 			// aapt resource value: 94
-			public static int AppCompatTheme_alertDialogTheme = 94;
+			public static int AppCompatTheme_alertDialogButtonGroupStyle = 94;
+			
+			// aapt resource value: 95
+			public static int AppCompatTheme_alertDialogCenterButtons = 95;
+			
+			// aapt resource value: 93
+			public static int AppCompatTheme_alertDialogStyle = 93;
+			
+			// aapt resource value: 96
+			public static int AppCompatTheme_alertDialogTheme = 96;
 			
 			// aapt resource value: 1
 			public static int AppCompatTheme_android_windowAnimationStyle = 1;
@@ -4636,200 +5526,209 @@ namespace XFGloss.Droid
 			// aapt resource value: 0
 			public static int AppCompatTheme_android_windowIsFloating = 0;
 			
-			// aapt resource value: 99
-			public static int AppCompatTheme_autoCompleteTextViewStyle = 99;
-			
-			// aapt resource value: 54
-			public static int AppCompatTheme_borderlessButtonStyle = 54;
-			
-			// aapt resource value: 51
-			public static int AppCompatTheme_buttonBarButtonStyle = 51;
-			
-			// aapt resource value: 97
-			public static int AppCompatTheme_buttonBarNegativeButtonStyle = 97;
-			
-			// aapt resource value: 98
-			public static int AppCompatTheme_buttonBarNeutralButtonStyle = 98;
-			
-			// aapt resource value: 96
-			public static int AppCompatTheme_buttonBarPositiveButtonStyle = 96;
-			
-			// aapt resource value: 50
-			public static int AppCompatTheme_buttonBarStyle = 50;
-			
-			// aapt resource value: 100
-			public static int AppCompatTheme_buttonStyle = 100;
-			
 			// aapt resource value: 101
-			public static int AppCompatTheme_buttonStyleSmall = 101;
-			
-			// aapt resource value: 102
-			public static int AppCompatTheme_checkboxStyle = 102;
-			
-			// aapt resource value: 103
-			public static int AppCompatTheme_checkedTextViewStyle = 103;
-			
-			// aapt resource value: 84
-			public static int AppCompatTheme_colorAccent = 84;
-			
-			// aapt resource value: 88
-			public static int AppCompatTheme_colorButtonNormal = 88;
-			
-			// aapt resource value: 86
-			public static int AppCompatTheme_colorControlActivated = 86;
-			
-			// aapt resource value: 87
-			public static int AppCompatTheme_colorControlHighlight = 87;
-			
-			// aapt resource value: 85
-			public static int AppCompatTheme_colorControlNormal = 85;
-			
-			// aapt resource value: 82
-			public static int AppCompatTheme_colorPrimary = 82;
-			
-			// aapt resource value: 83
-			public static int AppCompatTheme_colorPrimaryDark = 83;
-			
-			// aapt resource value: 89
-			public static int AppCompatTheme_colorSwitchThumbNormal = 89;
-			
-			// aapt resource value: 90
-			public static int AppCompatTheme_controlBackground = 90;
-			
-			// aapt resource value: 43
-			public static int AppCompatTheme_dialogPreferredPadding = 43;
-			
-			// aapt resource value: 42
-			public static int AppCompatTheme_dialogTheme = 42;
-			
-			// aapt resource value: 56
-			public static int AppCompatTheme_dividerHorizontal = 56;
+			public static int AppCompatTheme_autoCompleteTextViewStyle = 101;
 			
 			// aapt resource value: 55
-			public static int AppCompatTheme_dividerVertical = 55;
-			
-			// aapt resource value: 74
-			public static int AppCompatTheme_dropDownListViewStyle = 74;
-			
-			// aapt resource value: 46
-			public static int AppCompatTheme_dropdownListPreferredItemHeight = 46;
-			
-			// aapt resource value: 63
-			public static int AppCompatTheme_editTextBackground = 63;
-			
-			// aapt resource value: 62
-			public static int AppCompatTheme_editTextColor = 62;
-			
-			// aapt resource value: 104
-			public static int AppCompatTheme_editTextStyle = 104;
-			
-			// aapt resource value: 48
-			public static int AppCompatTheme_homeAsUpIndicator = 48;
-			
-			// aapt resource value: 64
-			public static int AppCompatTheme_imageButtonStyle = 64;
-			
-			// aapt resource value: 81
-			public static int AppCompatTheme_listChoiceBackgroundIndicator = 81;
-			
-			// aapt resource value: 44
-			public static int AppCompatTheme_listDividerAlertDialog = 44;
-			
-			// aapt resource value: 75
-			public static int AppCompatTheme_listPopupWindowStyle = 75;
-			
-			// aapt resource value: 69
-			public static int AppCompatTheme_listPreferredItemHeight = 69;
-			
-			// aapt resource value: 71
-			public static int AppCompatTheme_listPreferredItemHeightLarge = 71;
-			
-			// aapt resource value: 70
-			public static int AppCompatTheme_listPreferredItemHeightSmall = 70;
-			
-			// aapt resource value: 72
-			public static int AppCompatTheme_listPreferredItemPaddingLeft = 72;
-			
-			// aapt resource value: 73
-			public static int AppCompatTheme_listPreferredItemPaddingRight = 73;
-			
-			// aapt resource value: 78
-			public static int AppCompatTheme_panelBackground = 78;
-			
-			// aapt resource value: 80
-			public static int AppCompatTheme_panelMenuListTheme = 80;
-			
-			// aapt resource value: 79
-			public static int AppCompatTheme_panelMenuListWidth = 79;
-			
-			// aapt resource value: 60
-			public static int AppCompatTheme_popupMenuStyle = 60;
-			
-			// aapt resource value: 61
-			public static int AppCompatTheme_popupWindowStyle = 61;
-			
-			// aapt resource value: 105
-			public static int AppCompatTheme_radioButtonStyle = 105;
-			
-			// aapt resource value: 106
-			public static int AppCompatTheme_ratingBarStyle = 106;
-			
-			// aapt resource value: 107
-			public static int AppCompatTheme_ratingBarStyleIndicator = 107;
-			
-			// aapt resource value: 108
-			public static int AppCompatTheme_ratingBarStyleSmall = 108;
-			
-			// aapt resource value: 68
-			public static int AppCompatTheme_searchViewStyle = 68;
-			
-			// aapt resource value: 109
-			public static int AppCompatTheme_seekBarStyle = 109;
+			public static int AppCompatTheme_borderlessButtonStyle = 55;
 			
 			// aapt resource value: 52
-			public static int AppCompatTheme_selectableItemBackground = 52;
+			public static int AppCompatTheme_buttonBarButtonStyle = 52;
 			
-			// aapt resource value: 53
-			public static int AppCompatTheme_selectableItemBackgroundBorderless = 53;
+			// aapt resource value: 99
+			public static int AppCompatTheme_buttonBarNegativeButtonStyle = 99;
+			
+			// aapt resource value: 100
+			public static int AppCompatTheme_buttonBarNeutralButtonStyle = 100;
+			
+			// aapt resource value: 98
+			public static int AppCompatTheme_buttonBarPositiveButtonStyle = 98;
+			
+			// aapt resource value: 51
+			public static int AppCompatTheme_buttonBarStyle = 51;
+			
+			// aapt resource value: 102
+			public static int AppCompatTheme_buttonStyle = 102;
+			
+			// aapt resource value: 103
+			public static int AppCompatTheme_buttonStyleSmall = 103;
+			
+			// aapt resource value: 104
+			public static int AppCompatTheme_checkboxStyle = 104;
+			
+			// aapt resource value: 105
+			public static int AppCompatTheme_checkedTextViewStyle = 105;
+			
+			// aapt resource value: 85
+			public static int AppCompatTheme_colorAccent = 85;
+			
+			// aapt resource value: 92
+			public static int AppCompatTheme_colorBackgroundFloating = 92;
+			
+			// aapt resource value: 89
+			public static int AppCompatTheme_colorButtonNormal = 89;
+			
+			// aapt resource value: 87
+			public static int AppCompatTheme_colorControlActivated = 87;
+			
+			// aapt resource value: 88
+			public static int AppCompatTheme_colorControlHighlight = 88;
+			
+			// aapt resource value: 86
+			public static int AppCompatTheme_colorControlNormal = 86;
+			
+			// aapt resource value: 83
+			public static int AppCompatTheme_colorPrimary = 83;
+			
+			// aapt resource value: 84
+			public static int AppCompatTheme_colorPrimaryDark = 84;
+			
+			// aapt resource value: 90
+			public static int AppCompatTheme_colorSwitchThumbNormal = 90;
+			
+			// aapt resource value: 91
+			public static int AppCompatTheme_controlBackground = 91;
+			
+			// aapt resource value: 44
+			public static int AppCompatTheme_dialogPreferredPadding = 44;
+			
+			// aapt resource value: 43
+			public static int AppCompatTheme_dialogTheme = 43;
+			
+			// aapt resource value: 57
+			public static int AppCompatTheme_dividerHorizontal = 57;
+			
+			// aapt resource value: 56
+			public static int AppCompatTheme_dividerVertical = 56;
+			
+			// aapt resource value: 75
+			public static int AppCompatTheme_dropDownListViewStyle = 75;
 			
 			// aapt resource value: 47
-			public static int AppCompatTheme_spinnerDropDownItemStyle = 47;
+			public static int AppCompatTheme_dropdownListPreferredItemHeight = 47;
+			
+			// aapt resource value: 64
+			public static int AppCompatTheme_editTextBackground = 64;
+			
+			// aapt resource value: 63
+			public static int AppCompatTheme_editTextColor = 63;
+			
+			// aapt resource value: 106
+			public static int AppCompatTheme_editTextStyle = 106;
+			
+			// aapt resource value: 49
+			public static int AppCompatTheme_homeAsUpIndicator = 49;
+			
+			// aapt resource value: 65
+			public static int AppCompatTheme_imageButtonStyle = 65;
+			
+			// aapt resource value: 82
+			public static int AppCompatTheme_listChoiceBackgroundIndicator = 82;
+			
+			// aapt resource value: 45
+			public static int AppCompatTheme_listDividerAlertDialog = 45;
+			
+			// aapt resource value: 114
+			public static int AppCompatTheme_listMenuViewStyle = 114;
+			
+			// aapt resource value: 76
+			public static int AppCompatTheme_listPopupWindowStyle = 76;
+			
+			// aapt resource value: 70
+			public static int AppCompatTheme_listPreferredItemHeight = 70;
+			
+			// aapt resource value: 72
+			public static int AppCompatTheme_listPreferredItemHeightLarge = 72;
+			
+			// aapt resource value: 71
+			public static int AppCompatTheme_listPreferredItemHeightSmall = 71;
+			
+			// aapt resource value: 73
+			public static int AppCompatTheme_listPreferredItemPaddingLeft = 73;
+			
+			// aapt resource value: 74
+			public static int AppCompatTheme_listPreferredItemPaddingRight = 74;
+			
+			// aapt resource value: 79
+			public static int AppCompatTheme_panelBackground = 79;
+			
+			// aapt resource value: 81
+			public static int AppCompatTheme_panelMenuListTheme = 81;
+			
+			// aapt resource value: 80
+			public static int AppCompatTheme_panelMenuListWidth = 80;
+			
+			// aapt resource value: 61
+			public static int AppCompatTheme_popupMenuStyle = 61;
+			
+			// aapt resource value: 62
+			public static int AppCompatTheme_popupWindowStyle = 62;
+			
+			// aapt resource value: 107
+			public static int AppCompatTheme_radioButtonStyle = 107;
+			
+			// aapt resource value: 108
+			public static int AppCompatTheme_ratingBarStyle = 108;
+			
+			// aapt resource value: 109
+			public static int AppCompatTheme_ratingBarStyleIndicator = 109;
 			
 			// aapt resource value: 110
-			public static int AppCompatTheme_spinnerStyle = 110;
+			public static int AppCompatTheme_ratingBarStyleSmall = 110;
+			
+			// aapt resource value: 69
+			public static int AppCompatTheme_searchViewStyle = 69;
 			
 			// aapt resource value: 111
-			public static int AppCompatTheme_switchStyle = 111;
+			public static int AppCompatTheme_seekBarStyle = 111;
+			
+			// aapt resource value: 53
+			public static int AppCompatTheme_selectableItemBackground = 53;
+			
+			// aapt resource value: 54
+			public static int AppCompatTheme_selectableItemBackgroundBorderless = 54;
+			
+			// aapt resource value: 48
+			public static int AppCompatTheme_spinnerDropDownItemStyle = 48;
+			
+			// aapt resource value: 112
+			public static int AppCompatTheme_spinnerStyle = 112;
+			
+			// aapt resource value: 113
+			public static int AppCompatTheme_switchStyle = 113;
 			
 			// aapt resource value: 40
 			public static int AppCompatTheme_textAppearanceLargePopupMenu = 40;
 			
-			// aapt resource value: 76
-			public static int AppCompatTheme_textAppearanceListItem = 76;
-			
 			// aapt resource value: 77
-			public static int AppCompatTheme_textAppearanceListItemSmall = 77;
+			public static int AppCompatTheme_textAppearanceListItem = 77;
+			
+			// aapt resource value: 78
+			public static int AppCompatTheme_textAppearanceListItemSmall = 78;
+			
+			// aapt resource value: 42
+			public static int AppCompatTheme_textAppearancePopupMenuHeader = 42;
+			
+			// aapt resource value: 67
+			public static int AppCompatTheme_textAppearanceSearchResultSubtitle = 67;
 			
 			// aapt resource value: 66
-			public static int AppCompatTheme_textAppearanceSearchResultSubtitle = 66;
-			
-			// aapt resource value: 65
-			public static int AppCompatTheme_textAppearanceSearchResultTitle = 65;
+			public static int AppCompatTheme_textAppearanceSearchResultTitle = 66;
 			
 			// aapt resource value: 41
 			public static int AppCompatTheme_textAppearanceSmallPopupMenu = 41;
 			
-			// aapt resource value: 95
-			public static int AppCompatTheme_textColorAlertDialogListItem = 95;
+			// aapt resource value: 97
+			public static int AppCompatTheme_textColorAlertDialogListItem = 97;
 			
-			// aapt resource value: 67
-			public static int AppCompatTheme_textColorSearchUrl = 67;
+			// aapt resource value: 68
+			public static int AppCompatTheme_textColorSearchUrl = 68;
+			
+			// aapt resource value: 60
+			public static int AppCompatTheme_toolbarNavigationButtonStyle = 60;
 			
 			// aapt resource value: 59
-			public static int AppCompatTheme_toolbarNavigationButtonStyle = 59;
-			
-			// aapt resource value: 58
-			public static int AppCompatTheme_toolbarStyle = 58;
+			public static int AppCompatTheme_toolbarStyle = 59;
 			
 			// aapt resource value: 2
 			public static int AppCompatTheme_windowActionBar = 2;
@@ -4861,20 +5760,47 @@ namespace XFGloss.Droid
 			// aapt resource value: 3
 			public static int AppCompatTheme_windowNoTitle = 3;
 			
-			public static int[] BottomSheetBehavior_Params = new int[]
+			public static int[] BottomNavigationView = new int[]
 			{
-					2130772005,
-					2130772006};
-			
-			// aapt resource value: 1
-			public static int BottomSheetBehavior_Params_behavior_hideable = 1;
+					2130772024,
+					2130772267,
+					2130772268,
+					2130772269,
+					2130772270};
 			
 			// aapt resource value: 0
-			public static int BottomSheetBehavior_Params_behavior_peekHeight = 0;
+			public static int BottomNavigationView_elevation = 0;
+			
+			// aapt resource value: 4
+			public static int BottomNavigationView_itemBackground = 4;
+			
+			// aapt resource value: 2
+			public static int BottomNavigationView_itemIconTint = 2;
+			
+			// aapt resource value: 3
+			public static int BottomNavigationView_itemTextColor = 3;
+			
+			// aapt resource value: 1
+			public static int BottomNavigationView_menu = 1;
+			
+			public static int[] BottomSheetBehavior_Layout = new int[]
+			{
+					2130772229,
+					2130772230,
+					2130772231};
+			
+			// aapt resource value: 1
+			public static int BottomSheetBehavior_Layout_behavior_hideable = 1;
+			
+			// aapt resource value: 0
+			public static int BottomSheetBehavior_Layout_behavior_peekHeight = 0;
+			
+			// aapt resource value: 2
+			public static int BottomSheetBehavior_Layout_behavior_skipCollapsed = 2;
 			
 			public static int[] ButtonBarLayout = new int[]
 			{
-					2130772223};
+					2130772153};
 			
 			// aapt resource value: 0
 			public static int ButtonBarLayout_allowStacking = 0;
@@ -4883,17 +5809,17 @@ namespace XFGloss.Droid
 			{
 					16843071,
 					16843072,
+					2130771985,
+					2130771986,
+					2130771987,
+					2130771988,
+					2130771989,
+					2130771990,
 					2130771991,
 					2130771992,
 					2130771993,
 					2130771994,
-					2130771995,
-					2130771996,
-					2130771997,
-					2130771998,
-					2130771999,
-					2130772000,
-					2130772001};
+					2130771995};
 			
 			// aapt resource value: 1
 			public static int CardView_android_minHeight = 1;
@@ -4934,81 +5860,104 @@ namespace XFGloss.Droid
 			// aapt resource value: 11
 			public static int CardView_contentPaddingTop = 11;
 			
-			public static int[] CollapsingAppBarLayout_LayoutParams = new int[]
-			{
-					2130772007,
-					2130772008};
-			
-			// aapt resource value: 0
-			public static int CollapsingAppBarLayout_LayoutParams_layout_collapseMode = 0;
-			
-			// aapt resource value: 1
-			public static int CollapsingAppBarLayout_LayoutParams_layout_collapseParallaxMultiplier = 1;
-			
 			public static int[] CollapsingToolbarLayout = new int[]
 			{
-					2130772009,
-					2130772010,
-					2130772011,
-					2130772012,
-					2130772013,
-					2130772014,
-					2130772015,
-					2130772016,
-					2130772017,
-					2130772018,
-					2130772019,
-					2130772020,
-					2130772021,
-					2130772078};
-			
-			// aapt resource value: 10
-			public static int CollapsingToolbarLayout_collapsedTitleGravity = 10;
-			
-			// aapt resource value: 6
-			public static int CollapsingToolbarLayout_collapsedTitleTextAppearance = 6;
-			
-			// aapt resource value: 7
-			public static int CollapsingToolbarLayout_contentScrim = 7;
-			
-			// aapt resource value: 11
-			public static int CollapsingToolbarLayout_expandedTitleGravity = 11;
-			
-			// aapt resource value: 0
-			public static int CollapsingToolbarLayout_expandedTitleMargin = 0;
-			
-			// aapt resource value: 4
-			public static int CollapsingToolbarLayout_expandedTitleMarginBottom = 4;
-			
-			// aapt resource value: 3
-			public static int CollapsingToolbarLayout_expandedTitleMarginEnd = 3;
-			
-			// aapt resource value: 1
-			public static int CollapsingToolbarLayout_expandedTitleMarginStart = 1;
-			
-			// aapt resource value: 2
-			public static int CollapsingToolbarLayout_expandedTitleMarginTop = 2;
-			
-			// aapt resource value: 5
-			public static int CollapsingToolbarLayout_expandedTitleTextAppearance = 5;
-			
-			// aapt resource value: 8
-			public static int CollapsingToolbarLayout_statusBarScrim = 8;
+					2130771999,
+					2130772232,
+					2130772233,
+					2130772234,
+					2130772235,
+					2130772236,
+					2130772237,
+					2130772238,
+					2130772239,
+					2130772240,
+					2130772241,
+					2130772242,
+					2130772243,
+					2130772244,
+					2130772245,
+					2130772246};
 			
 			// aapt resource value: 13
-			public static int CollapsingToolbarLayout_title = 13;
+			public static int CollapsingToolbarLayout_collapsedTitleGravity = 13;
+			
+			// aapt resource value: 7
+			public static int CollapsingToolbarLayout_collapsedTitleTextAppearance = 7;
+			
+			// aapt resource value: 8
+			public static int CollapsingToolbarLayout_contentScrim = 8;
+			
+			// aapt resource value: 14
+			public static int CollapsingToolbarLayout_expandedTitleGravity = 14;
+			
+			// aapt resource value: 1
+			public static int CollapsingToolbarLayout_expandedTitleMargin = 1;
+			
+			// aapt resource value: 5
+			public static int CollapsingToolbarLayout_expandedTitleMarginBottom = 5;
+			
+			// aapt resource value: 4
+			public static int CollapsingToolbarLayout_expandedTitleMarginEnd = 4;
+			
+			// aapt resource value: 2
+			public static int CollapsingToolbarLayout_expandedTitleMarginStart = 2;
+			
+			// aapt resource value: 3
+			public static int CollapsingToolbarLayout_expandedTitleMarginTop = 3;
+			
+			// aapt resource value: 6
+			public static int CollapsingToolbarLayout_expandedTitleTextAppearance = 6;
 			
 			// aapt resource value: 12
-			public static int CollapsingToolbarLayout_titleEnabled = 12;
+			public static int CollapsingToolbarLayout_scrimAnimationDuration = 12;
+			
+			// aapt resource value: 11
+			public static int CollapsingToolbarLayout_scrimVisibleHeightTrigger = 11;
 			
 			// aapt resource value: 9
-			public static int CollapsingToolbarLayout_toolbarId = 9;
+			public static int CollapsingToolbarLayout_statusBarScrim = 9;
+			
+			// aapt resource value: 0
+			public static int CollapsingToolbarLayout_title = 0;
+			
+			// aapt resource value: 15
+			public static int CollapsingToolbarLayout_titleEnabled = 15;
+			
+			// aapt resource value: 10
+			public static int CollapsingToolbarLayout_toolbarId = 10;
+			
+			public static int[] CollapsingToolbarLayout_Layout = new int[]
+			{
+					2130772247,
+					2130772248};
+			
+			// aapt resource value: 0
+			public static int CollapsingToolbarLayout_Layout_layout_collapseMode = 0;
+			
+			// aapt resource value: 1
+			public static int CollapsingToolbarLayout_Layout_layout_collapseParallaxMultiplier = 1;
+			
+			public static int[] ColorStateListItem = new int[]
+			{
+					16843173,
+					16843551,
+					2130772154};
+			
+			// aapt resource value: 2
+			public static int ColorStateListItem_alpha = 2;
+			
+			// aapt resource value: 1
+			public static int ColorStateListItem_android_alpha = 1;
+			
+			// aapt resource value: 0
+			public static int ColorStateListItem_android_color = 0;
 			
 			public static int[] CompoundButton = new int[]
 			{
 					16843015,
-					2130772224,
-					2130772225};
+					2130772155,
+					2130772156};
 			
 			// aapt resource value: 0
 			public static int CompoundButton_android_button = 0;
@@ -5021,8 +5970,8 @@ namespace XFGloss.Droid
 			
 			public static int[] CoordinatorLayout = new int[]
 			{
-					2130772022,
-					2130772023};
+					2130772249,
+					2130772250};
 			
 			// aapt resource value: 0
 			public static int CoordinatorLayout_keylines = 0;
@@ -5030,34 +5979,42 @@ namespace XFGloss.Droid
 			// aapt resource value: 1
 			public static int CoordinatorLayout_statusBarBackground = 1;
 			
-			public static int[] CoordinatorLayout_LayoutParams = new int[]
+			public static int[] CoordinatorLayout_Layout = new int[]
 			{
 					16842931,
-					2130772024,
-					2130772025,
-					2130772026,
-					2130772027};
+					2130772251,
+					2130772252,
+					2130772253,
+					2130772254,
+					2130772255,
+					2130772256};
 			
 			// aapt resource value: 0
-			public static int CoordinatorLayout_LayoutParams_android_layout_gravity = 0;
+			public static int CoordinatorLayout_Layout_android_layout_gravity = 0;
 			
 			// aapt resource value: 2
-			public static int CoordinatorLayout_LayoutParams_layout_anchor = 2;
+			public static int CoordinatorLayout_Layout_layout_anchor = 2;
 			
 			// aapt resource value: 4
-			public static int CoordinatorLayout_LayoutParams_layout_anchorGravity = 4;
+			public static int CoordinatorLayout_Layout_layout_anchorGravity = 4;
 			
 			// aapt resource value: 1
-			public static int CoordinatorLayout_LayoutParams_layout_behavior = 1;
+			public static int CoordinatorLayout_Layout_layout_behavior = 1;
+			
+			// aapt resource value: 6
+			public static int CoordinatorLayout_Layout_layout_dodgeInsetEdges = 6;
+			
+			// aapt resource value: 5
+			public static int CoordinatorLayout_Layout_layout_insetEdge = 5;
 			
 			// aapt resource value: 3
-			public static int CoordinatorLayout_LayoutParams_layout_keyline = 3;
+			public static int CoordinatorLayout_Layout_layout_keyline = 3;
 			
 			public static int[] DesignTheme = new int[]
 			{
-					2130772028,
-					2130772029,
-					2130772030};
+					2130772257,
+					2130772258,
+					2130772259};
 			
 			// aapt resource value: 0
 			public static int DesignTheme_bottomSheetDialogTheme = 0;
@@ -5070,14 +6027,14 @@ namespace XFGloss.Droid
 			
 			public static int[] DrawerArrowToggle = new int[]
 			{
-					2130772226,
-					2130772227,
-					2130772228,
-					2130772229,
-					2130772230,
-					2130772231,
-					2130772232,
-					2130772233};
+					2130772157,
+					2130772158,
+					2130772159,
+					2130772160,
+					2130772161,
+					2130772162,
+					2130772163,
+					2130772164};
 			
 			// aapt resource value: 4
 			public static int DrawerArrowToggle_arrowHeadLength = 4;
@@ -5105,44 +6062,51 @@ namespace XFGloss.Droid
 			
 			public static int[] FloatingActionButton = new int[]
 			{
-					2130772031,
-					2130772032,
-					2130772033,
-					2130772034,
-					2130772035,
-					2130772101,
-					2130772282,
-					2130772283};
-			
-			// aapt resource value: 6
-			public static int FloatingActionButton_backgroundTint = 6;
-			
-			// aapt resource value: 7
-			public static int FloatingActionButton_backgroundTintMode = 7;
-			
-			// aapt resource value: 3
-			public static int FloatingActionButton_borderWidth = 3;
-			
-			// aapt resource value: 5
-			public static int FloatingActionButton_elevation = 5;
+					2130772024,
+					2130772222,
+					2130772223,
+					2130772260,
+					2130772261,
+					2130772262,
+					2130772263,
+					2130772264};
 			
 			// aapt resource value: 1
-			public static int FloatingActionButton_fabSize = 1;
+			public static int FloatingActionButton_backgroundTint = 1;
 			
 			// aapt resource value: 2
-			public static int FloatingActionButton_pressedTranslationZ = 2;
+			public static int FloatingActionButton_backgroundTintMode = 2;
+			
+			// aapt resource value: 6
+			public static int FloatingActionButton_borderWidth = 6;
 			
 			// aapt resource value: 0
-			public static int FloatingActionButton_rippleColor = 0;
+			public static int FloatingActionButton_elevation = 0;
 			
 			// aapt resource value: 4
-			public static int FloatingActionButton_useCompatPadding = 4;
+			public static int FloatingActionButton_fabSize = 4;
+			
+			// aapt resource value: 5
+			public static int FloatingActionButton_pressedTranslationZ = 5;
+			
+			// aapt resource value: 3
+			public static int FloatingActionButton_rippleColor = 3;
+			
+			// aapt resource value: 7
+			public static int FloatingActionButton_useCompatPadding = 7;
+			
+			public static int[] FloatingActionButton_Behavior_Layout = new int[]
+			{
+					2130772265};
+			
+			// aapt resource value: 0
+			public static int FloatingActionButton_Behavior_Layout_behavior_autoHide = 0;
 			
 			public static int[] ForegroundLinearLayout = new int[]
 			{
 					16843017,
 					16843264,
-					2130772036};
+					2130772266};
 			
 			// aapt resource value: 0
 			public static int ForegroundLinearLayout_android_foreground = 0;
@@ -5160,10 +6124,10 @@ namespace XFGloss.Droid
 					16843046,
 					16843047,
 					16843048,
-					2130772086,
-					2130772234,
-					2130772235,
-					2130772236};
+					2130772007,
+					2130772165,
+					2130772166,
+					2130772167};
 			
 			// aapt resource value: 2
 			public static int LinearLayoutCompat_android_baselineAligned = 2;
@@ -5226,13 +6190,17 @@ namespace XFGloss.Droid
 			{
 					16843071,
 					16843072,
-					2130771990};
+					2130771984,
+					2130772155};
 			
 			// aapt resource value: 1
 			public static int MediaRouteButton_android_minHeight = 1;
 			
 			// aapt resource value: 0
 			public static int MediaRouteButton_android_minWidth = 0;
+			
+			// aapt resource value: 3
+			public static int MediaRouteButton_buttonTint = 3;
 			
 			// aapt resource value: 2
 			public static int MediaRouteButton_externalRouteEnabledDrawable = 2;
@@ -5279,10 +6247,10 @@ namespace XFGloss.Droid
 					16843236,
 					16843237,
 					16843375,
-					2130772237,
-					2130772238,
-					2130772239,
-					2130772240};
+					2130772168,
+					2130772169,
+					2130772170,
+					2130772171};
 			
 			// aapt resource value: 14
 			public static int MenuItem_actionLayout = 14;
@@ -5344,7 +6312,8 @@ namespace XFGloss.Droid
 					16843055,
 					16843056,
 					16843057,
-					2130772241};
+					2130772172,
+					2130772173};
 			
 			// aapt resource value: 4
 			public static int MenuView_android_headerBackground = 4;
@@ -5370,18 +6339,21 @@ namespace XFGloss.Droid
 			// aapt resource value: 7
 			public static int MenuView_preserveIconSpacing = 7;
 			
+			// aapt resource value: 8
+			public static int MenuView_subMenuArrow = 8;
+			
 			public static int[] NavigationView = new int[]
 			{
 					16842964,
 					16842973,
 					16843039,
-					2130772037,
-					2130772038,
-					2130772039,
-					2130772040,
-					2130772041,
-					2130772042,
-					2130772101};
+					2130772024,
+					2130772267,
+					2130772268,
+					2130772269,
+					2130772270,
+					2130772271,
+					2130772272};
 			
 			// aapt resource value: 0
 			public static int NavigationView_android_background = 0;
@@ -5392,81 +6364,100 @@ namespace XFGloss.Droid
 			// aapt resource value: 2
 			public static int NavigationView_android_maxWidth = 2;
 			
+			// aapt resource value: 3
+			public static int NavigationView_elevation = 3;
+			
 			// aapt resource value: 9
-			public static int NavigationView_elevation = 9;
-			
-			// aapt resource value: 8
-			public static int NavigationView_headerLayout = 8;
-			
-			// aapt resource value: 6
-			public static int NavigationView_itemBackground = 6;
-			
-			// aapt resource value: 4
-			public static int NavigationView_itemIconTint = 4;
+			public static int NavigationView_headerLayout = 9;
 			
 			// aapt resource value: 7
-			public static int NavigationView_itemTextAppearance = 7;
+			public static int NavigationView_itemBackground = 7;
 			
 			// aapt resource value: 5
-			public static int NavigationView_itemTextColor = 5;
+			public static int NavigationView_itemIconTint = 5;
 			
-			// aapt resource value: 3
-			public static int NavigationView_menu = 3;
+			// aapt resource value: 8
+			public static int NavigationView_itemTextAppearance = 8;
+			
+			// aapt resource value: 6
+			public static int NavigationView_itemTextColor = 6;
+			
+			// aapt resource value: 4
+			public static int NavigationView_menu = 4;
 			
 			public static int[] PopupWindow = new int[]
 			{
 					16843126,
-					2130772242};
+					16843465,
+					2130772174};
+			
+			// aapt resource value: 1
+			public static int PopupWindow_android_popupAnimationStyle = 1;
 			
 			// aapt resource value: 0
 			public static int PopupWindow_android_popupBackground = 0;
 			
-			// aapt resource value: 1
-			public static int PopupWindow_overlapAnchor = 1;
+			// aapt resource value: 2
+			public static int PopupWindow_overlapAnchor = 2;
 			
 			public static int[] PopupWindowBackgroundState = new int[]
 			{
-					2130772243};
+					2130772175};
 			
 			// aapt resource value: 0
 			public static int PopupWindowBackgroundState_state_above_anchor = 0;
 			
+			public static int[] RecycleListView = new int[]
+			{
+					2130772176,
+					2130772177};
+			
+			// aapt resource value: 0
+			public static int RecycleListView_paddingBottomNoButtons = 0;
+			
+			// aapt resource value: 1
+			public static int RecycleListView_paddingTopNoTitle = 1;
+			
 			public static int[] RecyclerView = new int[]
 			{
 					16842948,
-					2130772071,
-					2130772072,
-					2130772073,
-					2130772074};
+					16842993,
+					2130771968,
+					2130771969,
+					2130771970,
+					2130771971};
+			
+			// aapt resource value: 1
+			public static int RecyclerView_android_descendantFocusability = 1;
 			
 			// aapt resource value: 0
 			public static int RecyclerView_android_orientation = 0;
 			
-			// aapt resource value: 1
-			public static int RecyclerView_layoutManager = 1;
-			
-			// aapt resource value: 3
-			public static int RecyclerView_reverseLayout = 3;
-			
 			// aapt resource value: 2
-			public static int RecyclerView_spanCount = 2;
+			public static int RecyclerView_layoutManager = 2;
 			
 			// aapt resource value: 4
-			public static int RecyclerView_stackFromEnd = 4;
+			public static int RecyclerView_reverseLayout = 4;
+			
+			// aapt resource value: 3
+			public static int RecyclerView_spanCount = 3;
+			
+			// aapt resource value: 5
+			public static int RecyclerView_stackFromEnd = 5;
 			
 			public static int[] ScrimInsetsFrameLayout = new int[]
 			{
-					2130772043};
+					2130772273};
 			
 			// aapt resource value: 0
 			public static int ScrimInsetsFrameLayout_insetForeground = 0;
 			
-			public static int[] ScrollingViewBehavior_Params = new int[]
+			public static int[] ScrollingViewBehavior_Layout = new int[]
 			{
-					2130772044};
+					2130772274};
 			
 			// aapt resource value: 0
-			public static int ScrollingViewBehavior_Params_behavior_overlapTop = 0;
+			public static int ScrollingViewBehavior_Layout_behavior_overlapTop = 0;
 			
 			public static int[] SearchView = new int[]
 			{
@@ -5474,19 +6465,19 @@ namespace XFGloss.Droid
 					16843039,
 					16843296,
 					16843364,
-					2130772244,
-					2130772245,
-					2130772246,
-					2130772247,
-					2130772248,
-					2130772249,
-					2130772250,
-					2130772251,
-					2130772252,
-					2130772253,
-					2130772254,
-					2130772255,
-					2130772256};
+					2130772178,
+					2130772179,
+					2130772180,
+					2130772181,
+					2130772182,
+					2130772183,
+					2130772184,
+					2130772185,
+					2130772186,
+					2130772187,
+					2130772188,
+					2130772189,
+					2130772190};
 			
 			// aapt resource value: 0
 			public static int SearchView_android_focusable = 0;
@@ -5542,17 +6533,17 @@ namespace XFGloss.Droid
 			public static int[] SnackbarLayout = new int[]
 			{
 					16843039,
-					2130772045,
-					2130772101};
+					2130772024,
+					2130772275};
 			
 			// aapt resource value: 0
 			public static int SnackbarLayout_android_maxWidth = 0;
 			
-			// aapt resource value: 2
-			public static int SnackbarLayout_elevation = 2;
-			
 			// aapt resource value: 1
-			public static int SnackbarLayout_maxActionInlineWidth = 1;
+			public static int SnackbarLayout_elevation = 1;
+			
+			// aapt resource value: 2
+			public static int SnackbarLayout_maxActionInlineWidth = 2;
 			
 			public static int[] Spinner = new int[]
 			{
@@ -5560,7 +6551,7 @@ namespace XFGloss.Droid
 					16843126,
 					16843131,
 					16843362,
-					2130772102};
+					2130772025};
 			
 			// aapt resource value: 3
 			public static int Spinner_android_dropDownWidth = 3;
@@ -5582,13 +6573,17 @@ namespace XFGloss.Droid
 					16843044,
 					16843045,
 					16843074,
-					2130772257,
-					2130772258,
-					2130772259,
-					2130772260,
-					2130772261,
-					2130772262,
-					2130772263};
+					2130772191,
+					2130772192,
+					2130772193,
+					2130772194,
+					2130772195,
+					2130772196,
+					2130772197,
+					2130772198,
+					2130772199,
+					2130772200,
+					2130772201};
 			
 			// aapt resource value: 1
 			public static int SwitchCompat_android_textOff = 1;
@@ -5599,26 +6594,38 @@ namespace XFGloss.Droid
 			// aapt resource value: 2
 			public static int SwitchCompat_android_thumb = 2;
 			
+			// aapt resource value: 13
+			public static int SwitchCompat_showText = 13;
+			
+			// aapt resource value: 12
+			public static int SwitchCompat_splitTrack = 12;
+			
+			// aapt resource value: 10
+			public static int SwitchCompat_switchMinWidth = 10;
+			
+			// aapt resource value: 11
+			public static int SwitchCompat_switchPadding = 11;
+			
 			// aapt resource value: 9
-			public static int SwitchCompat_showText = 9;
+			public static int SwitchCompat_switchTextAppearance = 9;
 			
 			// aapt resource value: 8
-			public static int SwitchCompat_splitTrack = 8;
-			
-			// aapt resource value: 6
-			public static int SwitchCompat_switchMinWidth = 6;
-			
-			// aapt resource value: 7
-			public static int SwitchCompat_switchPadding = 7;
-			
-			// aapt resource value: 5
-			public static int SwitchCompat_switchTextAppearance = 5;
-			
-			// aapt resource value: 4
-			public static int SwitchCompat_thumbTextPadding = 4;
+			public static int SwitchCompat_thumbTextPadding = 8;
 			
 			// aapt resource value: 3
-			public static int SwitchCompat_track = 3;
+			public static int SwitchCompat_thumbTint = 3;
+			
+			// aapt resource value: 4
+			public static int SwitchCompat_thumbTintMode = 4;
+			
+			// aapt resource value: 5
+			public static int SwitchCompat_track = 5;
+			
+			// aapt resource value: 6
+			public static int SwitchCompat_trackTint = 6;
+			
+			// aapt resource value: 7
+			public static int SwitchCompat_trackTintMode = 7;
 			
 			public static int[] TabItem = new int[]
 			{
@@ -5637,22 +6644,22 @@ namespace XFGloss.Droid
 			
 			public static int[] TabLayout = new int[]
 			{
-					2130772046,
-					2130772047,
-					2130772048,
-					2130772049,
-					2130772050,
-					2130772051,
-					2130772052,
-					2130772053,
-					2130772054,
-					2130772055,
-					2130772056,
-					2130772057,
-					2130772058,
-					2130772059,
-					2130772060,
-					2130772061};
+					2130772276,
+					2130772277,
+					2130772278,
+					2130772279,
+					2130772280,
+					2130772281,
+					2130772282,
+					2130772283,
+					2130772284,
+					2130772285,
+					2130772286,
+					2130772287,
+					2130772288,
+					2130772289,
+					2130772290,
+					2130772291};
 			
 			// aapt resource value: 3
 			public static int TabLayout_tabBackground = 3;
@@ -5708,26 +6715,30 @@ namespace XFGloss.Droid
 					16842902,
 					16842903,
 					16842904,
+					16842906,
 					16843105,
 					16843106,
 					16843107,
 					16843108,
-					2130772112};
-			
-			// aapt resource value: 4
-			public static int TextAppearance_android_shadowColor = 4;
+					2130772039};
 			
 			// aapt resource value: 5
-			public static int TextAppearance_android_shadowDx = 5;
+			public static int TextAppearance_android_shadowColor = 5;
 			
 			// aapt resource value: 6
-			public static int TextAppearance_android_shadowDy = 6;
+			public static int TextAppearance_android_shadowDx = 6;
 			
 			// aapt resource value: 7
-			public static int TextAppearance_android_shadowRadius = 7;
+			public static int TextAppearance_android_shadowDy = 7;
+			
+			// aapt resource value: 8
+			public static int TextAppearance_android_shadowRadius = 8;
 			
 			// aapt resource value: 3
 			public static int TextAppearance_android_textColor = 3;
+			
+			// aapt resource value: 4
+			public static int TextAppearance_android_textColorHint = 4;
 			
 			// aapt resource value: 0
 			public static int TextAppearance_android_textSize = 0;
@@ -5738,22 +6749,27 @@ namespace XFGloss.Droid
 			// aapt resource value: 1
 			public static int TextAppearance_android_typeface = 1;
 			
-			// aapt resource value: 8
-			public static int TextAppearance_textAllCaps = 8;
+			// aapt resource value: 9
+			public static int TextAppearance_textAllCaps = 9;
 			
 			public static int[] TextInputLayout = new int[]
 			{
 					16842906,
 					16843088,
-					2130772062,
-					2130772063,
-					2130772064,
-					2130772065,
-					2130772066,
-					2130772067,
-					2130772068,
-					2130772069,
-					2130772070};
+					2130772292,
+					2130772293,
+					2130772294,
+					2130772295,
+					2130772296,
+					2130772297,
+					2130772298,
+					2130772299,
+					2130772300,
+					2130772301,
+					2130772302,
+					2130772303,
+					2130772304,
+					2130772305};
 			
 			// aapt resource value: 1
 			public static int TextInputLayout_android_hint = 1;
@@ -5788,33 +6804,52 @@ namespace XFGloss.Droid
 			// aapt resource value: 2
 			public static int TextInputLayout_hintTextAppearance = 2;
 			
+			// aapt resource value: 13
+			public static int TextInputLayout_passwordToggleContentDescription = 13;
+			
+			// aapt resource value: 12
+			public static int TextInputLayout_passwordToggleDrawable = 12;
+			
+			// aapt resource value: 11
+			public static int TextInputLayout_passwordToggleEnabled = 11;
+			
+			// aapt resource value: 14
+			public static int TextInputLayout_passwordToggleTint = 14;
+			
+			// aapt resource value: 15
+			public static int TextInputLayout_passwordToggleTintMode = 15;
+			
 			public static int[] Toolbar = new int[]
 			{
 					16842927,
 					16843072,
-					2130772078,
-					2130772081,
-					2130772085,
-					2130772097,
-					2130772098,
-					2130772099,
-					2130772100,
-					2130772102,
-					2130772264,
-					2130772265,
-					2130772266,
-					2130772267,
-					2130772268,
-					2130772269,
-					2130772270,
-					2130772271,
-					2130772272,
-					2130772273,
-					2130772274,
-					2130772275,
-					2130772276,
-					2130772277,
-					2130772278};
+					2130771999,
+					2130772002,
+					2130772006,
+					2130772018,
+					2130772019,
+					2130772020,
+					2130772021,
+					2130772022,
+					2130772023,
+					2130772025,
+					2130772202,
+					2130772203,
+					2130772204,
+					2130772205,
+					2130772206,
+					2130772207,
+					2130772208,
+					2130772209,
+					2130772210,
+					2130772211,
+					2130772212,
+					2130772213,
+					2130772214,
+					2130772215,
+					2130772216,
+					2130772217,
+					2130772218};
 			
 			// aapt resource value: 0
 			public static int Toolbar_android_gravity = 0;
@@ -5822,14 +6857,20 @@ namespace XFGloss.Droid
 			// aapt resource value: 1
 			public static int Toolbar_android_minHeight = 1;
 			
-			// aapt resource value: 19
-			public static int Toolbar_collapseContentDescription = 19;
+			// aapt resource value: 21
+			public static int Toolbar_buttonGravity = 21;
 			
-			// aapt resource value: 18
-			public static int Toolbar_collapseIcon = 18;
+			// aapt resource value: 23
+			public static int Toolbar_collapseContentDescription = 23;
+			
+			// aapt resource value: 22
+			public static int Toolbar_collapseIcon = 22;
 			
 			// aapt resource value: 6
 			public static int Toolbar_contentInsetEnd = 6;
+			
+			// aapt resource value: 10
+			public static int Toolbar_contentInsetEndWithActions = 10;
 			
 			// aapt resource value: 7
 			public static int Toolbar_contentInsetLeft = 7;
@@ -5840,64 +6881,70 @@ namespace XFGloss.Droid
 			// aapt resource value: 5
 			public static int Toolbar_contentInsetStart = 5;
 			
+			// aapt resource value: 9
+			public static int Toolbar_contentInsetStartWithNavigation = 9;
+			
 			// aapt resource value: 4
 			public static int Toolbar_logo = 4;
 			
-			// aapt resource value: 22
-			public static int Toolbar_logoDescription = 22;
-			
-			// aapt resource value: 17
-			public static int Toolbar_maxButtonHeight = 17;
-			
-			// aapt resource value: 21
-			public static int Toolbar_navigationContentDescription = 21;
+			// aapt resource value: 26
+			public static int Toolbar_logoDescription = 26;
 			
 			// aapt resource value: 20
-			public static int Toolbar_navigationIcon = 20;
+			public static int Toolbar_maxButtonHeight = 20;
 			
-			// aapt resource value: 9
-			public static int Toolbar_popupTheme = 9;
+			// aapt resource value: 25
+			public static int Toolbar_navigationContentDescription = 25;
+			
+			// aapt resource value: 24
+			public static int Toolbar_navigationIcon = 24;
+			
+			// aapt resource value: 11
+			public static int Toolbar_popupTheme = 11;
 			
 			// aapt resource value: 3
 			public static int Toolbar_subtitle = 3;
 			
-			// aapt resource value: 11
-			public static int Toolbar_subtitleTextAppearance = 11;
+			// aapt resource value: 13
+			public static int Toolbar_subtitleTextAppearance = 13;
 			
-			// aapt resource value: 24
-			public static int Toolbar_subtitleTextColor = 24;
+			// aapt resource value: 28
+			public static int Toolbar_subtitleTextColor = 28;
 			
 			// aapt resource value: 2
 			public static int Toolbar_title = 2;
 			
-			// aapt resource value: 16
-			public static int Toolbar_titleMarginBottom = 16;
-			
 			// aapt resource value: 14
-			public static int Toolbar_titleMarginEnd = 14;
+			public static int Toolbar_titleMargin = 14;
 			
-			// aapt resource value: 13
-			public static int Toolbar_titleMarginStart = 13;
+			// aapt resource value: 18
+			public static int Toolbar_titleMarginBottom = 18;
+			
+			// aapt resource value: 16
+			public static int Toolbar_titleMarginEnd = 16;
 			
 			// aapt resource value: 15
-			public static int Toolbar_titleMarginTop = 15;
+			public static int Toolbar_titleMarginStart = 15;
+			
+			// aapt resource value: 17
+			public static int Toolbar_titleMarginTop = 17;
+			
+			// aapt resource value: 19
+			public static int Toolbar_titleMargins = 19;
 			
 			// aapt resource value: 12
-			public static int Toolbar_titleMargins = 12;
+			public static int Toolbar_titleTextAppearance = 12;
 			
-			// aapt resource value: 10
-			public static int Toolbar_titleTextAppearance = 10;
-			
-			// aapt resource value: 23
-			public static int Toolbar_titleTextColor = 23;
+			// aapt resource value: 27
+			public static int Toolbar_titleTextColor = 27;
 			
 			public static int[] View = new int[]
 			{
 					16842752,
 					16842970,
-					2130772279,
-					2130772280,
-					2130772281};
+					2130772219,
+					2130772220,
+					2130772221};
 			
 			// aapt resource value: 1
 			public static int View_android_focusable = 1;
@@ -5917,8 +6964,8 @@ namespace XFGloss.Droid
 			public static int[] ViewBackgroundHelper = new int[]
 			{
 					16842964,
-					2130772282,
-					2130772283};
+					2130772222,
+					2130772223};
 			
 			// aapt resource value: 0
 			public static int ViewBackgroundHelper_android_background = 0;

--- a/XFGloss.Droid/XFGloss.Droid.csproj
+++ b/XFGloss.Droid/XFGloss.Droid.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.props" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.props')" />
+  <Import Project="..\packages\Xamarin.Build.Download.0.4.4\build\Xamarin.Build.Download.props" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.4\build\Xamarin.Build.Download.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -136,7 +136,6 @@
   <ItemGroup />
   <Import Project="..\XFGloss.Shared\XFGloss.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.targets" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.targets')" />
   <Import Project="..\packages\Xamarin.Android.Support.Annotations.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Annotations.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Annotations.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Annotations.targets')" />
   <Import Project="..\packages\Xamarin.Android.Support.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Compat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Compat.targets')" />
   <Import Project="..\packages\Xamarin.Android.Support.Core.UI.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.UI.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Core.UI.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.UI.targets')" />
@@ -154,4 +153,5 @@
   <Import Project="..\packages\Xamarin.Android.Support.Design.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Design.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Design.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Design.targets')" />
   <Import Project="..\packages\Xamarin.Android.Support.v7.MediaRouter.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.MediaRouter.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.MediaRouter.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.MediaRouter.targets')" />
   <Import Project="..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\packages\Xamarin.Build.Download.0.4.4\build\Xamarin.Build.Download.targets" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.4\build\Xamarin.Build.Download.targets')" />
 </Project>

--- a/XFGloss.Droid/XFGloss.Droid.csproj
+++ b/XFGloss.Droid/XFGloss.Droid.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.props" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -8,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>XFGloss.Droid</RootNamespace>
     <AssemblyName>XFGloss.Droid</AssemblyName>
-    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
@@ -26,7 +27,6 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <AndroidLinkMode>None</AndroidLinkMode>
-    <AndroidSupportedAbis>arm64-v8a;armeabi;armeabi-v7a;x86</AndroidSupportedAbis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -42,44 +42,68 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
+    <Reference Include="Xamarin.Android.Support.Annotations">
+      <HintPath>..\packages\Xamarin.Android.Support.Annotations.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Compat">
+      <HintPath>..\packages\Xamarin.Android.Support.Compat.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Compat.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Core.UI">
+      <HintPath>..\packages\Xamarin.Android.Support.Core.UI.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Core.UI.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Core.Utils">
+      <HintPath>..\packages\Xamarin.Android.Support.Core.Utils.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Core.Utils.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Media.Compat">
+      <HintPath>..\packages\Xamarin.Android.Support.Media.Compat.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Media.Compat.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Fragment">
+      <HintPath>..\packages\Xamarin.Android.Support.Fragment.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Fragment.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Transition">
+      <HintPath>..\packages\Xamarin.Android.Support.Transition.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Transition.dll</HintPath>
+    </Reference>
     <Reference Include="Xamarin.Android.Support.v4">
-      <HintPath>..\packages\Xamarin.Android.Support.v4.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Android.Support.Vector.Drawable">
-      <HintPath>..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.Vector.Drawable.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Android.Support.Animated.Vector.Drawable">
-      <HintPath>..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.Animated.Vector.Drawable.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Android.Support.v7.AppCompat">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.AppCompat.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Android.Support.v7.RecyclerView">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.RecyclerView.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.RecyclerView.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Android.Support.Design">
-      <HintPath>..\packages\Xamarin.Android.Support.Design.23.3.0\lib\MonoAndroid43\Xamarin.Android.Support.Design.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v4.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v4.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.CardView">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.CardView.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.CardView.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v7.CardView.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.CardView.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v7.Palette">
+      <HintPath>..\packages\Xamarin.Android.Support.v7.Palette.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.Palette.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v7.RecyclerView">
+      <HintPath>..\packages\Xamarin.Android.Support.v7.RecyclerView.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.RecyclerView.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Vector.Drawable">
+      <HintPath>..\packages\Xamarin.Android.Support.Vector.Drawable.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Vector.Drawable.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Animated.Vector.Drawable">
+      <HintPath>..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Animated.Vector.Drawable.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v7.AppCompat">
+      <HintPath>..\packages\Xamarin.Android.Support.v7.AppCompat.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Design">
+      <HintPath>..\packages\Xamarin.Android.Support.Design.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Design.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.MediaRouter">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.MediaRouter.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.MediaRouter.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v7.MediaRouter.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.MediaRouter.dll</HintPath>
     </Reference>
     <Reference Include="FormsViewGroup">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.Android">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -112,6 +136,22 @@
   <ItemGroup />
   <Import Project="..\XFGloss.Shared\XFGloss.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets')" />
-  <Import Project="..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.targets" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Annotations.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Annotations.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Annotations.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Annotations.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Compat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Compat.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Core.UI.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.UI.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Core.UI.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.UI.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Core.Utils.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.Utils.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Core.Utils.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.Utils.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Media.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Media.Compat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Media.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Media.Compat.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Fragment.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Fragment.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Fragment.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Fragment.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Transition.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Transition.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Transition.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Transition.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v4.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v4.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v4.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v4.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v7.CardView.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.CardView.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.CardView.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.CardView.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v7.Palette.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.Palette.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.Palette.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.Palette.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v7.RecyclerView.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.RecyclerView.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.RecyclerView.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.RecyclerView.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Vector.Drawable.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Vector.Drawable.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Vector.Drawable.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Animated.Vector.Drawable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Animated.Vector.Drawable.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v7.AppCompat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.AppCompat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.AppCompat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.AppCompat.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Design.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Design.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Design.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Design.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v7.MediaRouter.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.MediaRouter.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.MediaRouter.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.MediaRouter.targets')" />
+  <Import Project="..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/XFGloss.Droid/packages.config
+++ b/XFGloss.Droid/packages.config
@@ -16,6 +16,6 @@
   <package id="Xamarin.Android.Support.v7.Palette" version="25.3.1" targetFramework="monoandroid71" />
   <package id="Xamarin.Android.Support.v7.RecyclerView" version="25.3.1" targetFramework="monoandroid71" />
   <package id="Xamarin.Android.Support.Vector.Drawable" version="25.3.1" targetFramework="monoandroid71" />
-  <package id="Xamarin.Build.Download" version="0.4.3" targetFramework="monoandroid71" />
+  <package id="Xamarin.Build.Download" version="0.4.4" targetFramework="monoandroid71" />
   <package id="Xamarin.Forms" version="2.3.4.231" targetFramework="monoandroid71" />
 </packages>

--- a/XFGloss.Droid/packages.config
+++ b/XFGloss.Droid/packages.config
@@ -1,12 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="23.3.0" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.Android.Support.Design" version="23.3.0" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.Android.Support.v4" version="23.3.0" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.Android.Support.v7.AppCompat" version="23.3.0" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.Android.Support.v7.CardView" version="23.3.0" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.Android.Support.v7.MediaRouter" version="23.3.0" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.Android.Support.v7.RecyclerView" version="23.3.0" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.Android.Support.Vector.Drawable" version="23.3.0" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.Forms" version="2.3.3.193" targetFramework="monoandroid70" />
+  <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Annotations" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Compat" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Core.UI" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Core.Utils" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Design" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Fragment" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Media.Compat" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Transition" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v4" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.AppCompat" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.CardView" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.MediaRouter" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.Palette" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.RecyclerView" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Vector.Drawable" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Build.Download" version="0.4.3" targetFramework="monoandroid71" />
+  <package id="Xamarin.Forms" version="2.3.4.231" targetFramework="monoandroid71" />
 </packages>

--- a/XFGloss.iOS/XFGloss.iOS.csproj
+++ b/XFGloss.iOS/XFGloss.iOS.csproj
@@ -19,8 +19,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <MtouchUseSGen>true</MtouchUseSGen>
-    <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchLink>
     </MtouchLink>
     <MtouchHttpClientHandler>
@@ -37,8 +35,6 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\XFGloss.iOS.xml</DocumentationFile>
     <ConsolePause>false</ConsolePause>
-    <MtouchUseSGen>true</MtouchUseSGen>
-    <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchLink>
     </MtouchLink>
     <MtouchHttpClientHandler>
@@ -52,16 +48,16 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.iOS">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup />
@@ -89,5 +85,5 @@
   </ItemGroup>
   <Import Project="..\XFGloss.Shared\XFGloss.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/XFGloss.iOS/packages.config
+++ b/XFGloss.iOS/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.3.3.193" targetFramework="xamarinios10" />
+  <package id="Xamarin.Forms" version="2.3.4.231" targetFramework="xamarinios10" />
 </packages>

--- a/XFGloss.nuspec
+++ b/XFGloss.nuspec
@@ -16,7 +16,7 @@
        <summary>Visual enhancements for Xamarin.Forms</summary>
        <tags>xamarin.forms, gloss, style, styling, xamarin, pcl, xam.pcl, plugin, plugin for xamarin.forms, android, ios</tags>
        <dependencies>
-         <dependency id="Xamarin.Forms" version="2.3.1.114" />
+         <dependency id="Xamarin.Forms" version="2.3.4.231" />
        </dependencies>
        <releaseNotes>
        </releaseNotes>

--- a/XFGloss/Events/WeakEvent.cs
+++ b/XFGloss/Events/WeakEvent.cs
@@ -132,13 +132,14 @@ namespace XFGloss
             RegisteredWeakEvents.Add(new WeakEventRegistration(null, eventInfo, handler));
         }
 
-        /// <summary>Removes a weak event registration from the given source object.</summary>
-        /// <typeparam name="TEventSource">The type of the source object.</typeparam>
-        /// <param name="source">The source object to register the event from. </param>
-        /// <param name="eventName">The event name to remove the registration from.</param>
-        /// <param name="handler">The handler to remove.</param>
-        /// <returns>True if the event registration could be found and was removed. </returns>
-        public static bool DeregisterEvent<TEventSource, TEventArgs>(TEventSource source, string eventName, EventHandler<TEventArgs> handler)
+		/// <summary>Removes a weak event registration from the given source object.</summary>
+		/// <typeparam name="TEventSource">The type of the source object.</typeparam>
+		/// <typeparam name="TEventArgs">The type of the event arguments.</typeparam>
+		/// <param name="source">The source object to register the event from. </param>
+		/// <param name="eventName">The event name to remove the registration from.</param>
+		/// <param name="handler">The handler to remove.</param>
+		/// <returns>True if the event registration could be found and was removed. </returns>
+		public static bool DeregisterEvent<TEventSource, TEventArgs>(TEventSource source, string eventName, EventHandler<TEventArgs> handler)
         {
             var eventInfo = typeof(TEventSource).GetRuntimeEvent(eventName);
             return DeregisterEvent(source, handler, eventInfo);

--- a/XFGloss/XFGloss.csproj
+++ b/XFGloss/XFGloss.csproj
@@ -51,24 +51,24 @@
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
+    <Folder Include="Attributes\" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Attributes\" />
-  </ItemGroup>
   <Import Project="..\XFGloss.Shared\XFGloss.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\packages\Xamarin.Forms.2.3.1.114\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.1.114\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
-  <Import Project="..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/XFGloss/packages.config
+++ b/XFGloss/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.3.3.193" targetFramework="portable45-net45+win8+wp8" />
+  <package id="Xamarin.Forms" version="2.3.4.231" targetFramework="portable45-net45+win8+wp8" />
 </packages>

--- a/XFGlossSample.Droid/Resources/Resource.designer.cs
+++ b/XFGlossSample.Droid/Resources/Resource.designer.cs
@@ -43,7 +43,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Animation.design_fab_out = global::XFGlossSample.Droid.Resource.Animation.design_fab_out;
 			global::XFGloss.Droid.Resource.Animation.design_snackbar_in = global::XFGlossSample.Droid.Resource.Animation.design_snackbar_in;
 			global::XFGloss.Droid.Resource.Animation.design_snackbar_out = global::XFGlossSample.Droid.Resource.Animation.design_snackbar_out;
-			global::XFGloss.Droid.Resource.Attribute.MediaRouteControllerWindowBackground = global::XFGlossSample.Droid.Resource.Attribute.MediaRouteControllerWindowBackground;
+			global::XFGloss.Droid.Resource.Animator.design_appbar_state_list_animator = global::XFGlossSample.Droid.Resource.Animator.design_appbar_state_list_animator;
 			global::XFGloss.Droid.Resource.Attribute.actionBarDivider = global::XFGlossSample.Droid.Resource.Attribute.actionBarDivider;
 			global::XFGloss.Droid.Resource.Attribute.actionBarItemBackground = global::XFGlossSample.Droid.Resource.Attribute.actionBarItemBackground;
 			global::XFGloss.Droid.Resource.Attribute.actionBarPopupTheme = global::XFGlossSample.Droid.Resource.Attribute.actionBarPopupTheme;
@@ -83,6 +83,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Attribute.alertDialogStyle = global::XFGlossSample.Droid.Resource.Attribute.alertDialogStyle;
 			global::XFGloss.Droid.Resource.Attribute.alertDialogTheme = global::XFGlossSample.Droid.Resource.Attribute.alertDialogTheme;
 			global::XFGloss.Droid.Resource.Attribute.allowStacking = global::XFGlossSample.Droid.Resource.Attribute.allowStacking;
+			global::XFGloss.Droid.Resource.Attribute.alpha = global::XFGlossSample.Droid.Resource.Attribute.alpha;
 			global::XFGloss.Droid.Resource.Attribute.arrowHeadLength = global::XFGlossSample.Droid.Resource.Attribute.arrowHeadLength;
 			global::XFGloss.Droid.Resource.Attribute.arrowShaftLength = global::XFGlossSample.Droid.Resource.Attribute.arrowShaftLength;
 			global::XFGloss.Droid.Resource.Attribute.autoCompleteTextViewStyle = global::XFGlossSample.Droid.Resource.Attribute.autoCompleteTextViewStyle;
@@ -92,9 +93,11 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Attribute.backgroundTint = global::XFGlossSample.Droid.Resource.Attribute.backgroundTint;
 			global::XFGloss.Droid.Resource.Attribute.backgroundTintMode = global::XFGlossSample.Droid.Resource.Attribute.backgroundTintMode;
 			global::XFGloss.Droid.Resource.Attribute.barLength = global::XFGlossSample.Droid.Resource.Attribute.barLength;
+			global::XFGloss.Droid.Resource.Attribute.behavior_autoHide = global::XFGlossSample.Droid.Resource.Attribute.behavior_autoHide;
 			global::XFGloss.Droid.Resource.Attribute.behavior_hideable = global::XFGlossSample.Droid.Resource.Attribute.behavior_hideable;
 			global::XFGloss.Droid.Resource.Attribute.behavior_overlapTop = global::XFGlossSample.Droid.Resource.Attribute.behavior_overlapTop;
 			global::XFGloss.Droid.Resource.Attribute.behavior_peekHeight = global::XFGlossSample.Droid.Resource.Attribute.behavior_peekHeight;
+			global::XFGloss.Droid.Resource.Attribute.behavior_skipCollapsed = global::XFGlossSample.Droid.Resource.Attribute.behavior_skipCollapsed;
 			global::XFGloss.Droid.Resource.Attribute.borderWidth = global::XFGlossSample.Droid.Resource.Attribute.borderWidth;
 			global::XFGloss.Droid.Resource.Attribute.borderlessButtonStyle = global::XFGlossSample.Droid.Resource.Attribute.borderlessButtonStyle;
 			global::XFGloss.Droid.Resource.Attribute.bottomSheetDialogTheme = global::XFGlossSample.Droid.Resource.Attribute.bottomSheetDialogTheme;
@@ -104,6 +107,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Attribute.buttonBarNeutralButtonStyle = global::XFGlossSample.Droid.Resource.Attribute.buttonBarNeutralButtonStyle;
 			global::XFGloss.Droid.Resource.Attribute.buttonBarPositiveButtonStyle = global::XFGlossSample.Droid.Resource.Attribute.buttonBarPositiveButtonStyle;
 			global::XFGloss.Droid.Resource.Attribute.buttonBarStyle = global::XFGlossSample.Droid.Resource.Attribute.buttonBarStyle;
+			global::XFGloss.Droid.Resource.Attribute.buttonGravity = global::XFGlossSample.Droid.Resource.Attribute.buttonGravity;
 			global::XFGloss.Droid.Resource.Attribute.buttonPanelSideLayout = global::XFGlossSample.Droid.Resource.Attribute.buttonPanelSideLayout;
 			global::XFGloss.Droid.Resource.Attribute.buttonStyle = global::XFGlossSample.Droid.Resource.Attribute.buttonStyle;
 			global::XFGloss.Droid.Resource.Attribute.buttonStyleSmall = global::XFGlossSample.Droid.Resource.Attribute.buttonStyleSmall;
@@ -125,6 +129,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Attribute.collapsedTitleTextAppearance = global::XFGlossSample.Droid.Resource.Attribute.collapsedTitleTextAppearance;
 			global::XFGloss.Droid.Resource.Attribute.color = global::XFGlossSample.Droid.Resource.Attribute.color;
 			global::XFGloss.Droid.Resource.Attribute.colorAccent = global::XFGlossSample.Droid.Resource.Attribute.colorAccent;
+			global::XFGloss.Droid.Resource.Attribute.colorBackgroundFloating = global::XFGlossSample.Droid.Resource.Attribute.colorBackgroundFloating;
 			global::XFGloss.Droid.Resource.Attribute.colorButtonNormal = global::XFGlossSample.Droid.Resource.Attribute.colorButtonNormal;
 			global::XFGloss.Droid.Resource.Attribute.colorControlActivated = global::XFGlossSample.Droid.Resource.Attribute.colorControlActivated;
 			global::XFGloss.Droid.Resource.Attribute.colorControlHighlight = global::XFGlossSample.Droid.Resource.Attribute.colorControlHighlight;
@@ -134,9 +139,11 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Attribute.colorSwitchThumbNormal = global::XFGlossSample.Droid.Resource.Attribute.colorSwitchThumbNormal;
 			global::XFGloss.Droid.Resource.Attribute.commitIcon = global::XFGlossSample.Droid.Resource.Attribute.commitIcon;
 			global::XFGloss.Droid.Resource.Attribute.contentInsetEnd = global::XFGlossSample.Droid.Resource.Attribute.contentInsetEnd;
+			global::XFGloss.Droid.Resource.Attribute.contentInsetEndWithActions = global::XFGlossSample.Droid.Resource.Attribute.contentInsetEndWithActions;
 			global::XFGloss.Droid.Resource.Attribute.contentInsetLeft = global::XFGlossSample.Droid.Resource.Attribute.contentInsetLeft;
 			global::XFGloss.Droid.Resource.Attribute.contentInsetRight = global::XFGlossSample.Droid.Resource.Attribute.contentInsetRight;
 			global::XFGloss.Droid.Resource.Attribute.contentInsetStart = global::XFGlossSample.Droid.Resource.Attribute.contentInsetStart;
+			global::XFGloss.Droid.Resource.Attribute.contentInsetStartWithNavigation = global::XFGlossSample.Droid.Resource.Attribute.contentInsetStartWithNavigation;
 			global::XFGloss.Droid.Resource.Attribute.contentPadding = global::XFGlossSample.Droid.Resource.Attribute.contentPadding;
 			global::XFGloss.Droid.Resource.Attribute.contentPaddingBottom = global::XFGlossSample.Droid.Resource.Attribute.contentPaddingBottom;
 			global::XFGloss.Droid.Resource.Attribute.contentPaddingLeft = global::XFGlossSample.Droid.Resource.Attribute.contentPaddingLeft;
@@ -209,6 +216,8 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Attribute.layout_behavior = global::XFGlossSample.Droid.Resource.Attribute.layout_behavior;
 			global::XFGloss.Droid.Resource.Attribute.layout_collapseMode = global::XFGlossSample.Droid.Resource.Attribute.layout_collapseMode;
 			global::XFGloss.Droid.Resource.Attribute.layout_collapseParallaxMultiplier = global::XFGlossSample.Droid.Resource.Attribute.layout_collapseParallaxMultiplier;
+			global::XFGloss.Droid.Resource.Attribute.layout_dodgeInsetEdges = global::XFGlossSample.Droid.Resource.Attribute.layout_dodgeInsetEdges;
+			global::XFGloss.Droid.Resource.Attribute.layout_insetEdge = global::XFGlossSample.Droid.Resource.Attribute.layout_insetEdge;
 			global::XFGloss.Droid.Resource.Attribute.layout_keyline = global::XFGlossSample.Droid.Resource.Attribute.layout_keyline;
 			global::XFGloss.Droid.Resource.Attribute.layout_scrollFlags = global::XFGlossSample.Droid.Resource.Attribute.layout_scrollFlags;
 			global::XFGloss.Droid.Resource.Attribute.layout_scrollInterpolator = global::XFGlossSample.Droid.Resource.Attribute.layout_scrollInterpolator;
@@ -216,6 +225,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Attribute.listDividerAlertDialog = global::XFGlossSample.Droid.Resource.Attribute.listDividerAlertDialog;
 			global::XFGloss.Droid.Resource.Attribute.listItemLayout = global::XFGlossSample.Droid.Resource.Attribute.listItemLayout;
 			global::XFGloss.Droid.Resource.Attribute.listLayout = global::XFGlossSample.Droid.Resource.Attribute.listLayout;
+			global::XFGloss.Droid.Resource.Attribute.listMenuViewStyle = global::XFGlossSample.Droid.Resource.Attribute.listMenuViewStyle;
 			global::XFGloss.Droid.Resource.Attribute.listPopupWindowStyle = global::XFGlossSample.Droid.Resource.Attribute.listPopupWindowStyle;
 			global::XFGloss.Droid.Resource.Attribute.listPreferredItemHeight = global::XFGlossSample.Droid.Resource.Attribute.listPreferredItemHeight;
 			global::XFGloss.Droid.Resource.Attribute.listPreferredItemHeightLarge = global::XFGlossSample.Droid.Resource.Attribute.listPreferredItemHeightLarge;
@@ -228,25 +238,16 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Attribute.maxButtonHeight = global::XFGlossSample.Droid.Resource.Attribute.maxButtonHeight;
 			global::XFGloss.Droid.Resource.Attribute.measureWithLargestChild = global::XFGlossSample.Droid.Resource.Attribute.measureWithLargestChild;
 			global::XFGloss.Droid.Resource.Attribute.mediaRouteAudioTrackDrawable = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteAudioTrackDrawable;
-			global::XFGloss.Droid.Resource.Attribute.mediaRouteBluetoothIconDrawable = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteBluetoothIconDrawable;
 			global::XFGloss.Droid.Resource.Attribute.mediaRouteButtonStyle = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteButtonStyle;
-			global::XFGloss.Droid.Resource.Attribute.mediaRouteCastDrawable = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteCastDrawable;
-			global::XFGloss.Droid.Resource.Attribute.mediaRouteChooserPrimaryTextStyle = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteChooserPrimaryTextStyle;
-			global::XFGloss.Droid.Resource.Attribute.mediaRouteChooserSecondaryTextStyle = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteChooserSecondaryTextStyle;
 			global::XFGloss.Droid.Resource.Attribute.mediaRouteCloseDrawable = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteCloseDrawable;
-			global::XFGloss.Droid.Resource.Attribute.mediaRouteCollapseGroupDrawable = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteCollapseGroupDrawable;
-			global::XFGloss.Droid.Resource.Attribute.mediaRouteConnectingDrawable = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteConnectingDrawable;
-			global::XFGloss.Droid.Resource.Attribute.mediaRouteControllerPrimaryTextStyle = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteControllerPrimaryTextStyle;
-			global::XFGloss.Droid.Resource.Attribute.mediaRouteControllerSecondaryTextStyle = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteControllerSecondaryTextStyle;
-			global::XFGloss.Droid.Resource.Attribute.mediaRouteControllerTitleTextStyle = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteControllerTitleTextStyle;
+			global::XFGloss.Droid.Resource.Attribute.mediaRouteControlPanelThemeOverlay = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteControlPanelThemeOverlay;
 			global::XFGloss.Droid.Resource.Attribute.mediaRouteDefaultIconDrawable = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteDefaultIconDrawable;
-			global::XFGloss.Droid.Resource.Attribute.mediaRouteExpandGroupDrawable = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteExpandGroupDrawable;
-			global::XFGloss.Droid.Resource.Attribute.mediaRouteOffDrawable = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteOffDrawable;
-			global::XFGloss.Droid.Resource.Attribute.mediaRouteOnDrawable = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteOnDrawable;
 			global::XFGloss.Droid.Resource.Attribute.mediaRoutePauseDrawable = global::XFGlossSample.Droid.Resource.Attribute.mediaRoutePauseDrawable;
 			global::XFGloss.Droid.Resource.Attribute.mediaRoutePlayDrawable = global::XFGlossSample.Droid.Resource.Attribute.mediaRoutePlayDrawable;
 			global::XFGloss.Droid.Resource.Attribute.mediaRouteSpeakerGroupIconDrawable = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteSpeakerGroupIconDrawable;
 			global::XFGloss.Droid.Resource.Attribute.mediaRouteSpeakerIconDrawable = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteSpeakerIconDrawable;
+			global::XFGloss.Droid.Resource.Attribute.mediaRouteStopDrawable = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteStopDrawable;
+			global::XFGloss.Droid.Resource.Attribute.mediaRouteTheme = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteTheme;
 			global::XFGloss.Droid.Resource.Attribute.mediaRouteTvIconDrawable = global::XFGlossSample.Droid.Resource.Attribute.mediaRouteTvIconDrawable;
 			global::XFGloss.Droid.Resource.Attribute.menu = global::XFGlossSample.Droid.Resource.Attribute.menu;
 			global::XFGloss.Droid.Resource.Attribute.multiChoiceItemLayout = global::XFGlossSample.Droid.Resource.Attribute.multiChoiceItemLayout;
@@ -254,11 +255,18 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Attribute.navigationIcon = global::XFGlossSample.Droid.Resource.Attribute.navigationIcon;
 			global::XFGloss.Droid.Resource.Attribute.navigationMode = global::XFGlossSample.Droid.Resource.Attribute.navigationMode;
 			global::XFGloss.Droid.Resource.Attribute.overlapAnchor = global::XFGlossSample.Droid.Resource.Attribute.overlapAnchor;
+			global::XFGloss.Droid.Resource.Attribute.paddingBottomNoButtons = global::XFGlossSample.Droid.Resource.Attribute.paddingBottomNoButtons;
 			global::XFGloss.Droid.Resource.Attribute.paddingEnd = global::XFGlossSample.Droid.Resource.Attribute.paddingEnd;
 			global::XFGloss.Droid.Resource.Attribute.paddingStart = global::XFGlossSample.Droid.Resource.Attribute.paddingStart;
+			global::XFGloss.Droid.Resource.Attribute.paddingTopNoTitle = global::XFGlossSample.Droid.Resource.Attribute.paddingTopNoTitle;
 			global::XFGloss.Droid.Resource.Attribute.panelBackground = global::XFGlossSample.Droid.Resource.Attribute.panelBackground;
 			global::XFGloss.Droid.Resource.Attribute.panelMenuListTheme = global::XFGlossSample.Droid.Resource.Attribute.panelMenuListTheme;
 			global::XFGloss.Droid.Resource.Attribute.panelMenuListWidth = global::XFGlossSample.Droid.Resource.Attribute.panelMenuListWidth;
+			global::XFGloss.Droid.Resource.Attribute.passwordToggleContentDescription = global::XFGlossSample.Droid.Resource.Attribute.passwordToggleContentDescription;
+			global::XFGloss.Droid.Resource.Attribute.passwordToggleDrawable = global::XFGlossSample.Droid.Resource.Attribute.passwordToggleDrawable;
+			global::XFGloss.Droid.Resource.Attribute.passwordToggleEnabled = global::XFGlossSample.Droid.Resource.Attribute.passwordToggleEnabled;
+			global::XFGloss.Droid.Resource.Attribute.passwordToggleTint = global::XFGlossSample.Droid.Resource.Attribute.passwordToggleTint;
+			global::XFGloss.Droid.Resource.Attribute.passwordToggleTintMode = global::XFGlossSample.Droid.Resource.Attribute.passwordToggleTintMode;
 			global::XFGloss.Droid.Resource.Attribute.popupMenuStyle = global::XFGlossSample.Droid.Resource.Attribute.popupMenuStyle;
 			global::XFGloss.Droid.Resource.Attribute.popupTheme = global::XFGlossSample.Droid.Resource.Attribute.popupTheme;
 			global::XFGloss.Droid.Resource.Attribute.popupWindowStyle = global::XFGlossSample.Droid.Resource.Attribute.popupWindowStyle;
@@ -274,6 +282,8 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Attribute.ratingBarStyleSmall = global::XFGlossSample.Droid.Resource.Attribute.ratingBarStyleSmall;
 			global::XFGloss.Droid.Resource.Attribute.reverseLayout = global::XFGlossSample.Droid.Resource.Attribute.reverseLayout;
 			global::XFGloss.Droid.Resource.Attribute.rippleColor = global::XFGlossSample.Droid.Resource.Attribute.rippleColor;
+			global::XFGloss.Droid.Resource.Attribute.scrimAnimationDuration = global::XFGlossSample.Droid.Resource.Attribute.scrimAnimationDuration;
+			global::XFGloss.Droid.Resource.Attribute.scrimVisibleHeightTrigger = global::XFGlossSample.Droid.Resource.Attribute.scrimVisibleHeightTrigger;
 			global::XFGloss.Droid.Resource.Attribute.searchHintIcon = global::XFGlossSample.Droid.Resource.Attribute.searchHintIcon;
 			global::XFGloss.Droid.Resource.Attribute.searchIcon = global::XFGlossSample.Droid.Resource.Attribute.searchIcon;
 			global::XFGloss.Droid.Resource.Attribute.searchViewStyle = global::XFGlossSample.Droid.Resource.Attribute.searchViewStyle;
@@ -283,6 +293,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Attribute.showAsAction = global::XFGlossSample.Droid.Resource.Attribute.showAsAction;
 			global::XFGloss.Droid.Resource.Attribute.showDividers = global::XFGlossSample.Droid.Resource.Attribute.showDividers;
 			global::XFGloss.Droid.Resource.Attribute.showText = global::XFGlossSample.Droid.Resource.Attribute.showText;
+			global::XFGloss.Droid.Resource.Attribute.showTitle = global::XFGlossSample.Droid.Resource.Attribute.showTitle;
 			global::XFGloss.Droid.Resource.Attribute.singleChoiceItemLayout = global::XFGlossSample.Droid.Resource.Attribute.singleChoiceItemLayout;
 			global::XFGloss.Droid.Resource.Attribute.spanCount = global::XFGlossSample.Droid.Resource.Attribute.spanCount;
 			global::XFGloss.Droid.Resource.Attribute.spinBars = global::XFGlossSample.Droid.Resource.Attribute.spinBars;
@@ -292,8 +303,11 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Attribute.srcCompat = global::XFGlossSample.Droid.Resource.Attribute.srcCompat;
 			global::XFGloss.Droid.Resource.Attribute.stackFromEnd = global::XFGlossSample.Droid.Resource.Attribute.stackFromEnd;
 			global::XFGloss.Droid.Resource.Attribute.state_above_anchor = global::XFGlossSample.Droid.Resource.Attribute.state_above_anchor;
+			global::XFGloss.Droid.Resource.Attribute.state_collapsed = global::XFGlossSample.Droid.Resource.Attribute.state_collapsed;
+			global::XFGloss.Droid.Resource.Attribute.state_collapsible = global::XFGlossSample.Droid.Resource.Attribute.state_collapsible;
 			global::XFGloss.Droid.Resource.Attribute.statusBarBackground = global::XFGlossSample.Droid.Resource.Attribute.statusBarBackground;
 			global::XFGloss.Droid.Resource.Attribute.statusBarScrim = global::XFGlossSample.Droid.Resource.Attribute.statusBarScrim;
+			global::XFGloss.Droid.Resource.Attribute.subMenuArrow = global::XFGlossSample.Droid.Resource.Attribute.subMenuArrow;
 			global::XFGloss.Droid.Resource.Attribute.submitBackground = global::XFGlossSample.Droid.Resource.Attribute.submitBackground;
 			global::XFGloss.Droid.Resource.Attribute.subtitle = global::XFGlossSample.Droid.Resource.Attribute.subtitle;
 			global::XFGloss.Droid.Resource.Attribute.subtitleTextAppearance = global::XFGlossSample.Droid.Resource.Attribute.subtitleTextAppearance;
@@ -324,6 +338,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Attribute.textAppearanceLargePopupMenu = global::XFGlossSample.Droid.Resource.Attribute.textAppearanceLargePopupMenu;
 			global::XFGloss.Droid.Resource.Attribute.textAppearanceListItem = global::XFGlossSample.Droid.Resource.Attribute.textAppearanceListItem;
 			global::XFGloss.Droid.Resource.Attribute.textAppearanceListItemSmall = global::XFGlossSample.Droid.Resource.Attribute.textAppearanceListItemSmall;
+			global::XFGloss.Droid.Resource.Attribute.textAppearancePopupMenuHeader = global::XFGlossSample.Droid.Resource.Attribute.textAppearancePopupMenuHeader;
 			global::XFGloss.Droid.Resource.Attribute.textAppearanceSearchResultSubtitle = global::XFGlossSample.Droid.Resource.Attribute.textAppearanceSearchResultSubtitle;
 			global::XFGloss.Droid.Resource.Attribute.textAppearanceSearchResultTitle = global::XFGlossSample.Droid.Resource.Attribute.textAppearanceSearchResultTitle;
 			global::XFGloss.Droid.Resource.Attribute.textAppearanceSmallPopupMenu = global::XFGlossSample.Droid.Resource.Attribute.textAppearanceSmallPopupMenu;
@@ -333,8 +348,14 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Attribute.theme = global::XFGlossSample.Droid.Resource.Attribute.theme;
 			global::XFGloss.Droid.Resource.Attribute.thickness = global::XFGlossSample.Droid.Resource.Attribute.thickness;
 			global::XFGloss.Droid.Resource.Attribute.thumbTextPadding = global::XFGlossSample.Droid.Resource.Attribute.thumbTextPadding;
+			global::XFGloss.Droid.Resource.Attribute.thumbTint = global::XFGlossSample.Droid.Resource.Attribute.thumbTint;
+			global::XFGloss.Droid.Resource.Attribute.thumbTintMode = global::XFGlossSample.Droid.Resource.Attribute.thumbTintMode;
+			global::XFGloss.Droid.Resource.Attribute.tickMark = global::XFGlossSample.Droid.Resource.Attribute.tickMark;
+			global::XFGloss.Droid.Resource.Attribute.tickMarkTint = global::XFGlossSample.Droid.Resource.Attribute.tickMarkTint;
+			global::XFGloss.Droid.Resource.Attribute.tickMarkTintMode = global::XFGlossSample.Droid.Resource.Attribute.tickMarkTintMode;
 			global::XFGloss.Droid.Resource.Attribute.title = global::XFGlossSample.Droid.Resource.Attribute.title;
 			global::XFGloss.Droid.Resource.Attribute.titleEnabled = global::XFGlossSample.Droid.Resource.Attribute.titleEnabled;
+			global::XFGloss.Droid.Resource.Attribute.titleMargin = global::XFGlossSample.Droid.Resource.Attribute.titleMargin;
 			global::XFGloss.Droid.Resource.Attribute.titleMarginBottom = global::XFGlossSample.Droid.Resource.Attribute.titleMarginBottom;
 			global::XFGloss.Droid.Resource.Attribute.titleMarginEnd = global::XFGlossSample.Droid.Resource.Attribute.titleMarginEnd;
 			global::XFGloss.Droid.Resource.Attribute.titleMarginStart = global::XFGlossSample.Droid.Resource.Attribute.titleMarginStart;
@@ -347,6 +368,8 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Attribute.toolbarNavigationButtonStyle = global::XFGlossSample.Droid.Resource.Attribute.toolbarNavigationButtonStyle;
 			global::XFGloss.Droid.Resource.Attribute.toolbarStyle = global::XFGlossSample.Droid.Resource.Attribute.toolbarStyle;
 			global::XFGloss.Droid.Resource.Attribute.track = global::XFGlossSample.Droid.Resource.Attribute.track;
+			global::XFGloss.Droid.Resource.Attribute.trackTint = global::XFGlossSample.Droid.Resource.Attribute.trackTint;
+			global::XFGloss.Droid.Resource.Attribute.trackTintMode = global::XFGlossSample.Droid.Resource.Attribute.trackTintMode;
 			global::XFGloss.Droid.Resource.Attribute.useCompatPadding = global::XFGlossSample.Droid.Resource.Attribute.useCompatPadding;
 			global::XFGloss.Droid.Resource.Attribute.voiceIcon = global::XFGlossSample.Droid.Resource.Attribute.voiceIcon;
 			global::XFGloss.Droid.Resource.Attribute.windowActionBar = global::XFGlossSample.Droid.Resource.Attribute.windowActionBar;
@@ -360,16 +383,17 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Attribute.windowMinWidthMinor = global::XFGlossSample.Droid.Resource.Attribute.windowMinWidthMinor;
 			global::XFGloss.Droid.Resource.Attribute.windowNoTitle = global::XFGlossSample.Droid.Resource.Attribute.windowNoTitle;
 			global::XFGloss.Droid.Resource.Boolean.abc_action_bar_embed_tabs = global::XFGlossSample.Droid.Resource.Boolean.abc_action_bar_embed_tabs;
-			global::XFGloss.Droid.Resource.Boolean.abc_action_bar_embed_tabs_pre_jb = global::XFGlossSample.Droid.Resource.Boolean.abc_action_bar_embed_tabs_pre_jb;
-			global::XFGloss.Droid.Resource.Boolean.abc_action_bar_expanded_action_views_exclusive = global::XFGlossSample.Droid.Resource.Boolean.abc_action_bar_expanded_action_views_exclusive;
 			global::XFGloss.Droid.Resource.Boolean.abc_allow_stacked_button_bar = global::XFGlossSample.Droid.Resource.Boolean.abc_allow_stacked_button_bar;
 			global::XFGloss.Droid.Resource.Boolean.abc_config_actionMenuItemAllCaps = global::XFGlossSample.Droid.Resource.Boolean.abc_config_actionMenuItemAllCaps;
-			global::XFGloss.Droid.Resource.Boolean.abc_config_allowActionMenuItemTextWithIcon = global::XFGlossSample.Droid.Resource.Boolean.abc_config_allowActionMenuItemTextWithIcon;
 			global::XFGloss.Droid.Resource.Boolean.abc_config_closeDialogWhenTouchOutside = global::XFGlossSample.Droid.Resource.Boolean.abc_config_closeDialogWhenTouchOutside;
 			global::XFGloss.Droid.Resource.Boolean.abc_config_showMenuShortcutsWhenKeyboardPresent = global::XFGlossSample.Droid.Resource.Boolean.abc_config_showMenuShortcutsWhenKeyboardPresent;
 			global::XFGloss.Droid.Resource.Color.abc_background_cache_hint_selector_material_dark = global::XFGlossSample.Droid.Resource.Color.abc_background_cache_hint_selector_material_dark;
 			global::XFGloss.Droid.Resource.Color.abc_background_cache_hint_selector_material_light = global::XFGlossSample.Droid.Resource.Color.abc_background_cache_hint_selector_material_light;
+			global::XFGloss.Droid.Resource.Color.abc_btn_colored_borderless_text_material = global::XFGlossSample.Droid.Resource.Color.abc_btn_colored_borderless_text_material;
+			global::XFGloss.Droid.Resource.Color.abc_btn_colored_text_material = global::XFGlossSample.Droid.Resource.Color.abc_btn_colored_text_material;
 			global::XFGloss.Droid.Resource.Color.abc_color_highlight_material = global::XFGlossSample.Droid.Resource.Color.abc_color_highlight_material;
+			global::XFGloss.Droid.Resource.Color.abc_hint_foreground_material_dark = global::XFGlossSample.Droid.Resource.Color.abc_hint_foreground_material_dark;
+			global::XFGloss.Droid.Resource.Color.abc_hint_foreground_material_light = global::XFGlossSample.Droid.Resource.Color.abc_hint_foreground_material_light;
 			global::XFGloss.Droid.Resource.Color.abc_input_method_navigation_guard = global::XFGlossSample.Droid.Resource.Color.abc_input_method_navigation_guard;
 			global::XFGloss.Droid.Resource.Color.abc_primary_text_disable_only_material_dark = global::XFGlossSample.Droid.Resource.Color.abc_primary_text_disable_only_material_dark;
 			global::XFGloss.Droid.Resource.Color.abc_primary_text_disable_only_material_light = global::XFGlossSample.Droid.Resource.Color.abc_primary_text_disable_only_material_light;
@@ -381,6 +405,13 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Color.abc_search_url_text_selected = global::XFGlossSample.Droid.Resource.Color.abc_search_url_text_selected;
 			global::XFGloss.Droid.Resource.Color.abc_secondary_text_material_dark = global::XFGlossSample.Droid.Resource.Color.abc_secondary_text_material_dark;
 			global::XFGloss.Droid.Resource.Color.abc_secondary_text_material_light = global::XFGlossSample.Droid.Resource.Color.abc_secondary_text_material_light;
+			global::XFGloss.Droid.Resource.Color.abc_tint_btn_checkable = global::XFGlossSample.Droid.Resource.Color.abc_tint_btn_checkable;
+			global::XFGloss.Droid.Resource.Color.abc_tint_default = global::XFGlossSample.Droid.Resource.Color.abc_tint_default;
+			global::XFGloss.Droid.Resource.Color.abc_tint_edittext = global::XFGlossSample.Droid.Resource.Color.abc_tint_edittext;
+			global::XFGloss.Droid.Resource.Color.abc_tint_seek_thumb = global::XFGlossSample.Droid.Resource.Color.abc_tint_seek_thumb;
+			global::XFGloss.Droid.Resource.Color.abc_tint_spinner = global::XFGlossSample.Droid.Resource.Color.abc_tint_spinner;
+			global::XFGloss.Droid.Resource.Color.abc_tint_switch_thumb = global::XFGlossSample.Droid.Resource.Color.abc_tint_switch_thumb;
+			global::XFGloss.Droid.Resource.Color.abc_tint_switch_track = global::XFGlossSample.Droid.Resource.Color.abc_tint_switch_track;
 			global::XFGloss.Droid.Resource.Color.accent_material_dark = global::XFGlossSample.Droid.Resource.Color.accent_material_dark;
 			global::XFGloss.Droid.Resource.Color.accent_material_light = global::XFGlossSample.Droid.Resource.Color.accent_material_light;
 			global::XFGloss.Droid.Resource.Color.background_floating_material_dark = global::XFGlossSample.Droid.Resource.Color.background_floating_material_dark;
@@ -399,6 +430,8 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Color.cardview_light_background = global::XFGlossSample.Droid.Resource.Color.cardview_light_background;
 			global::XFGloss.Droid.Resource.Color.cardview_shadow_end_color = global::XFGlossSample.Droid.Resource.Color.cardview_shadow_end_color;
 			global::XFGloss.Droid.Resource.Color.cardview_shadow_start_color = global::XFGlossSample.Droid.Resource.Color.cardview_shadow_start_color;
+			global::XFGloss.Droid.Resource.Color.design_bottom_navigation_shadow_color = global::XFGlossSample.Droid.Resource.Color.design_bottom_navigation_shadow_color;
+			global::XFGloss.Droid.Resource.Color.design_error = global::XFGlossSample.Droid.Resource.Color.design_error;
 			global::XFGloss.Droid.Resource.Color.design_fab_shadow_end_color = global::XFGlossSample.Droid.Resource.Color.design_fab_shadow_end_color;
 			global::XFGloss.Droid.Resource.Color.design_fab_shadow_mid_color = global::XFGlossSample.Droid.Resource.Color.design_fab_shadow_mid_color;
 			global::XFGloss.Droid.Resource.Color.design_fab_shadow_start_color = global::XFGlossSample.Droid.Resource.Color.design_fab_shadow_start_color;
@@ -409,6 +442,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Color.design_snackbar_background_color = global::XFGlossSample.Droid.Resource.Color.design_snackbar_background_color;
 			global::XFGloss.Droid.Resource.Color.design_textinput_error_color_dark = global::XFGlossSample.Droid.Resource.Color.design_textinput_error_color_dark;
 			global::XFGloss.Droid.Resource.Color.design_textinput_error_color_light = global::XFGlossSample.Droid.Resource.Color.design_textinput_error_color_light;
+			global::XFGloss.Droid.Resource.Color.design_tint_password_toggle = global::XFGlossSample.Droid.Resource.Color.design_tint_password_toggle;
 			global::XFGloss.Droid.Resource.Color.dim_foreground_disabled_material_dark = global::XFGlossSample.Droid.Resource.Color.dim_foreground_disabled_material_dark;
 			global::XFGloss.Droid.Resource.Color.dim_foreground_disabled_material_light = global::XFGlossSample.Droid.Resource.Color.dim_foreground_disabled_material_light;
 			global::XFGloss.Droid.Resource.Color.dim_foreground_material_dark = global::XFGlossSample.Droid.Resource.Color.dim_foreground_material_dark;
@@ -417,8 +451,6 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Color.foreground_material_light = global::XFGlossSample.Droid.Resource.Color.foreground_material_light;
 			global::XFGloss.Droid.Resource.Color.highlighted_text_material_dark = global::XFGlossSample.Droid.Resource.Color.highlighted_text_material_dark;
 			global::XFGloss.Droid.Resource.Color.highlighted_text_material_light = global::XFGlossSample.Droid.Resource.Color.highlighted_text_material_light;
-			global::XFGloss.Droid.Resource.Color.hint_foreground_material_dark = global::XFGlossSample.Droid.Resource.Color.hint_foreground_material_dark;
-			global::XFGloss.Droid.Resource.Color.hint_foreground_material_light = global::XFGlossSample.Droid.Resource.Color.hint_foreground_material_light;
 			global::XFGloss.Droid.Resource.Color.material_blue_grey_800 = global::XFGlossSample.Droid.Resource.Color.material_blue_grey_800;
 			global::XFGloss.Droid.Resource.Color.material_blue_grey_900 = global::XFGlossSample.Droid.Resource.Color.material_blue_grey_900;
 			global::XFGloss.Droid.Resource.Color.material_blue_grey_950 = global::XFGlossSample.Droid.Resource.Color.material_blue_grey_950;
@@ -431,6 +463,9 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Color.material_grey_800 = global::XFGlossSample.Droid.Resource.Color.material_grey_800;
 			global::XFGloss.Droid.Resource.Color.material_grey_850 = global::XFGlossSample.Droid.Resource.Color.material_grey_850;
 			global::XFGloss.Droid.Resource.Color.material_grey_900 = global::XFGlossSample.Droid.Resource.Color.material_grey_900;
+			global::XFGloss.Droid.Resource.Color.notification_action_color_filter = global::XFGlossSample.Droid.Resource.Color.notification_action_color_filter;
+			global::XFGloss.Droid.Resource.Color.notification_icon_bg_color = global::XFGlossSample.Droid.Resource.Color.notification_icon_bg_color;
+			global::XFGloss.Droid.Resource.Color.notification_material_background_media_default_color = global::XFGlossSample.Droid.Resource.Color.notification_material_background_media_default_color;
 			global::XFGloss.Droid.Resource.Color.primary_dark_material_dark = global::XFGlossSample.Droid.Resource.Color.primary_dark_material_dark;
 			global::XFGloss.Droid.Resource.Color.primary_dark_material_light = global::XFGlossSample.Droid.Resource.Color.primary_dark_material_light;
 			global::XFGloss.Droid.Resource.Color.primary_material_dark = global::XFGlossSample.Droid.Resource.Color.primary_material_dark;
@@ -452,9 +487,11 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Color.switch_thumb_normal_material_dark = global::XFGlossSample.Droid.Resource.Color.switch_thumb_normal_material_dark;
 			global::XFGloss.Droid.Resource.Color.switch_thumb_normal_material_light = global::XFGlossSample.Droid.Resource.Color.switch_thumb_normal_material_light;
 			global::XFGloss.Droid.Resource.Dimension.abc_action_bar_content_inset_material = global::XFGlossSample.Droid.Resource.Dimension.abc_action_bar_content_inset_material;
+			global::XFGloss.Droid.Resource.Dimension.abc_action_bar_content_inset_with_nav = global::XFGlossSample.Droid.Resource.Dimension.abc_action_bar_content_inset_with_nav;
 			global::XFGloss.Droid.Resource.Dimension.abc_action_bar_default_height_material = global::XFGlossSample.Droid.Resource.Dimension.abc_action_bar_default_height_material;
 			global::XFGloss.Droid.Resource.Dimension.abc_action_bar_default_padding_end_material = global::XFGlossSample.Droid.Resource.Dimension.abc_action_bar_default_padding_end_material;
 			global::XFGloss.Droid.Resource.Dimension.abc_action_bar_default_padding_start_material = global::XFGlossSample.Droid.Resource.Dimension.abc_action_bar_default_padding_start_material;
+			global::XFGloss.Droid.Resource.Dimension.abc_action_bar_elevation_material = global::XFGlossSample.Droid.Resource.Dimension.abc_action_bar_elevation_material;
 			global::XFGloss.Droid.Resource.Dimension.abc_action_bar_icon_vertical_padding_material = global::XFGlossSample.Droid.Resource.Dimension.abc_action_bar_icon_vertical_padding_material;
 			global::XFGloss.Droid.Resource.Dimension.abc_action_bar_overflow_padding_end_material = global::XFGlossSample.Droid.Resource.Dimension.abc_action_bar_overflow_padding_end_material;
 			global::XFGloss.Droid.Resource.Dimension.abc_action_bar_overflow_padding_start_material = global::XFGlossSample.Droid.Resource.Dimension.abc_action_bar_overflow_padding_start_material;
@@ -471,6 +508,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Dimension.abc_button_inset_vertical_material = global::XFGlossSample.Droid.Resource.Dimension.abc_button_inset_vertical_material;
 			global::XFGloss.Droid.Resource.Dimension.abc_button_padding_horizontal_material = global::XFGlossSample.Droid.Resource.Dimension.abc_button_padding_horizontal_material;
 			global::XFGloss.Droid.Resource.Dimension.abc_button_padding_vertical_material = global::XFGlossSample.Droid.Resource.Dimension.abc_button_padding_vertical_material;
+			global::XFGloss.Droid.Resource.Dimension.abc_cascading_menus_min_smallest_width = global::XFGlossSample.Droid.Resource.Dimension.abc_cascading_menus_min_smallest_width;
 			global::XFGloss.Droid.Resource.Dimension.abc_config_prefDialogWidth = global::XFGlossSample.Droid.Resource.Dimension.abc_config_prefDialogWidth;
 			global::XFGloss.Droid.Resource.Dimension.abc_control_corner_material = global::XFGlossSample.Droid.Resource.Dimension.abc_control_corner_material;
 			global::XFGloss.Droid.Resource.Dimension.abc_control_inset_material = global::XFGlossSample.Droid.Resource.Dimension.abc_control_inset_material;
@@ -479,11 +517,13 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Dimension.abc_dialog_fixed_height_minor = global::XFGlossSample.Droid.Resource.Dimension.abc_dialog_fixed_height_minor;
 			global::XFGloss.Droid.Resource.Dimension.abc_dialog_fixed_width_major = global::XFGlossSample.Droid.Resource.Dimension.abc_dialog_fixed_width_major;
 			global::XFGloss.Droid.Resource.Dimension.abc_dialog_fixed_width_minor = global::XFGlossSample.Droid.Resource.Dimension.abc_dialog_fixed_width_minor;
-			global::XFGloss.Droid.Resource.Dimension.abc_dialog_list_padding_vertical_material = global::XFGlossSample.Droid.Resource.Dimension.abc_dialog_list_padding_vertical_material;
+			global::XFGloss.Droid.Resource.Dimension.abc_dialog_list_padding_bottom_no_buttons = global::XFGlossSample.Droid.Resource.Dimension.abc_dialog_list_padding_bottom_no_buttons;
+			global::XFGloss.Droid.Resource.Dimension.abc_dialog_list_padding_top_no_title = global::XFGlossSample.Droid.Resource.Dimension.abc_dialog_list_padding_top_no_title;
 			global::XFGloss.Droid.Resource.Dimension.abc_dialog_min_width_major = global::XFGlossSample.Droid.Resource.Dimension.abc_dialog_min_width_major;
 			global::XFGloss.Droid.Resource.Dimension.abc_dialog_min_width_minor = global::XFGlossSample.Droid.Resource.Dimension.abc_dialog_min_width_minor;
 			global::XFGloss.Droid.Resource.Dimension.abc_dialog_padding_material = global::XFGlossSample.Droid.Resource.Dimension.abc_dialog_padding_material;
 			global::XFGloss.Droid.Resource.Dimension.abc_dialog_padding_top_material = global::XFGlossSample.Droid.Resource.Dimension.abc_dialog_padding_top_material;
+			global::XFGloss.Droid.Resource.Dimension.abc_dialog_title_divider_material = global::XFGlossSample.Droid.Resource.Dimension.abc_dialog_title_divider_material;
 			global::XFGloss.Droid.Resource.Dimension.abc_disabled_alpha_material_dark = global::XFGlossSample.Droid.Resource.Dimension.abc_disabled_alpha_material_dark;
 			global::XFGloss.Droid.Resource.Dimension.abc_disabled_alpha_material_light = global::XFGlossSample.Droid.Resource.Dimension.abc_disabled_alpha_material_light;
 			global::XFGloss.Droid.Resource.Dimension.abc_dropdownitem_icon_width = global::XFGlossSample.Droid.Resource.Dimension.abc_dropdownitem_icon_width;
@@ -495,8 +535,9 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Dimension.abc_floating_window_z = global::XFGlossSample.Droid.Resource.Dimension.abc_floating_window_z;
 			global::XFGloss.Droid.Resource.Dimension.abc_list_item_padding_horizontal_material = global::XFGlossSample.Droid.Resource.Dimension.abc_list_item_padding_horizontal_material;
 			global::XFGloss.Droid.Resource.Dimension.abc_panel_menu_list_width = global::XFGlossSample.Droid.Resource.Dimension.abc_panel_menu_list_width;
+			global::XFGloss.Droid.Resource.Dimension.abc_progress_bar_height_material = global::XFGlossSample.Droid.Resource.Dimension.abc_progress_bar_height_material;
+			global::XFGloss.Droid.Resource.Dimension.abc_search_view_preferred_height = global::XFGlossSample.Droid.Resource.Dimension.abc_search_view_preferred_height;
 			global::XFGloss.Droid.Resource.Dimension.abc_search_view_preferred_width = global::XFGlossSample.Droid.Resource.Dimension.abc_search_view_preferred_width;
-			global::XFGloss.Droid.Resource.Dimension.abc_search_view_text_min_width = global::XFGlossSample.Droid.Resource.Dimension.abc_search_view_text_min_width;
 			global::XFGloss.Droid.Resource.Dimension.abc_seekbar_track_background_height_material = global::XFGlossSample.Droid.Resource.Dimension.abc_seekbar_track_background_height_material;
 			global::XFGloss.Droid.Resource.Dimension.abc_seekbar_track_progress_height_material = global::XFGlossSample.Droid.Resource.Dimension.abc_seekbar_track_progress_height_material;
 			global::XFGloss.Droid.Resource.Dimension.abc_select_dialog_padding_start_material = global::XFGlossSample.Droid.Resource.Dimension.abc_select_dialog_padding_start_material;
@@ -512,6 +553,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Dimension.abc_text_size_headline_material = global::XFGlossSample.Droid.Resource.Dimension.abc_text_size_headline_material;
 			global::XFGloss.Droid.Resource.Dimension.abc_text_size_large_material = global::XFGlossSample.Droid.Resource.Dimension.abc_text_size_large_material;
 			global::XFGloss.Droid.Resource.Dimension.abc_text_size_medium_material = global::XFGlossSample.Droid.Resource.Dimension.abc_text_size_medium_material;
+			global::XFGloss.Droid.Resource.Dimension.abc_text_size_menu_header_material = global::XFGlossSample.Droid.Resource.Dimension.abc_text_size_menu_header_material;
 			global::XFGloss.Droid.Resource.Dimension.abc_text_size_menu_material = global::XFGlossSample.Droid.Resource.Dimension.abc_text_size_menu_material;
 			global::XFGloss.Droid.Resource.Dimension.abc_text_size_small_material = global::XFGlossSample.Droid.Resource.Dimension.abc_text_size_small_material;
 			global::XFGloss.Droid.Resource.Dimension.abc_text_size_subhead_material = global::XFGlossSample.Droid.Resource.Dimension.abc_text_size_subhead_material;
@@ -522,8 +564,17 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Dimension.cardview_default_elevation = global::XFGlossSample.Droid.Resource.Dimension.cardview_default_elevation;
 			global::XFGloss.Droid.Resource.Dimension.cardview_default_radius = global::XFGlossSample.Droid.Resource.Dimension.cardview_default_radius;
 			global::XFGloss.Droid.Resource.Dimension.design_appbar_elevation = global::XFGlossSample.Droid.Resource.Dimension.design_appbar_elevation;
+			global::XFGloss.Droid.Resource.Dimension.design_bottom_navigation_active_item_max_width = global::XFGlossSample.Droid.Resource.Dimension.design_bottom_navigation_active_item_max_width;
+			global::XFGloss.Droid.Resource.Dimension.design_bottom_navigation_active_text_size = global::XFGlossSample.Droid.Resource.Dimension.design_bottom_navigation_active_text_size;
+			global::XFGloss.Droid.Resource.Dimension.design_bottom_navigation_elevation = global::XFGlossSample.Droid.Resource.Dimension.design_bottom_navigation_elevation;
+			global::XFGloss.Droid.Resource.Dimension.design_bottom_navigation_height = global::XFGlossSample.Droid.Resource.Dimension.design_bottom_navigation_height;
+			global::XFGloss.Droid.Resource.Dimension.design_bottom_navigation_item_max_width = global::XFGlossSample.Droid.Resource.Dimension.design_bottom_navigation_item_max_width;
+			global::XFGloss.Droid.Resource.Dimension.design_bottom_navigation_item_min_width = global::XFGlossSample.Droid.Resource.Dimension.design_bottom_navigation_item_min_width;
+			global::XFGloss.Droid.Resource.Dimension.design_bottom_navigation_margin = global::XFGlossSample.Droid.Resource.Dimension.design_bottom_navigation_margin;
+			global::XFGloss.Droid.Resource.Dimension.design_bottom_navigation_shadow_height = global::XFGlossSample.Droid.Resource.Dimension.design_bottom_navigation_shadow_height;
+			global::XFGloss.Droid.Resource.Dimension.design_bottom_navigation_text_size = global::XFGlossSample.Droid.Resource.Dimension.design_bottom_navigation_text_size;
 			global::XFGloss.Droid.Resource.Dimension.design_bottom_sheet_modal_elevation = global::XFGlossSample.Droid.Resource.Dimension.design_bottom_sheet_modal_elevation;
-			global::XFGloss.Droid.Resource.Dimension.design_bottom_sheet_modal_peek_height = global::XFGlossSample.Droid.Resource.Dimension.design_bottom_sheet_modal_peek_height;
+			global::XFGloss.Droid.Resource.Dimension.design_bottom_sheet_peek_height_min = global::XFGlossSample.Droid.Resource.Dimension.design_bottom_sheet_peek_height_min;
 			global::XFGloss.Droid.Resource.Dimension.design_fab_border_width = global::XFGlossSample.Droid.Resource.Dimension.design_fab_border_width;
 			global::XFGloss.Droid.Resource.Dimension.design_fab_elevation = global::XFGlossSample.Droid.Resource.Dimension.design_fab_elevation;
 			global::XFGloss.Droid.Resource.Dimension.design_fab_image_size = global::XFGlossSample.Droid.Resource.Dimension.design_fab_image_size;
@@ -555,6 +606,10 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Dimension.highlight_alpha_material_colored = global::XFGlossSample.Droid.Resource.Dimension.highlight_alpha_material_colored;
 			global::XFGloss.Droid.Resource.Dimension.highlight_alpha_material_dark = global::XFGlossSample.Droid.Resource.Dimension.highlight_alpha_material_dark;
 			global::XFGloss.Droid.Resource.Dimension.highlight_alpha_material_light = global::XFGlossSample.Droid.Resource.Dimension.highlight_alpha_material_light;
+			global::XFGloss.Droid.Resource.Dimension.hint_alpha_material_dark = global::XFGlossSample.Droid.Resource.Dimension.hint_alpha_material_dark;
+			global::XFGloss.Droid.Resource.Dimension.hint_alpha_material_light = global::XFGlossSample.Droid.Resource.Dimension.hint_alpha_material_light;
+			global::XFGloss.Droid.Resource.Dimension.hint_pressed_alpha_material_dark = global::XFGlossSample.Droid.Resource.Dimension.hint_pressed_alpha_material_dark;
+			global::XFGloss.Droid.Resource.Dimension.hint_pressed_alpha_material_light = global::XFGlossSample.Droid.Resource.Dimension.hint_pressed_alpha_material_light;
 			global::XFGloss.Droid.Resource.Dimension.item_touch_helper_max_drag_scroll_per_frame = global::XFGlossSample.Droid.Resource.Dimension.item_touch_helper_max_drag_scroll_per_frame;
 			global::XFGloss.Droid.Resource.Dimension.item_touch_helper_swipe_escape_max_velocity = global::XFGlossSample.Droid.Resource.Dimension.item_touch_helper_swipe_escape_max_velocity;
 			global::XFGloss.Droid.Resource.Dimension.item_touch_helper_swipe_escape_velocity = global::XFGlossSample.Droid.Resource.Dimension.item_touch_helper_swipe_escape_velocity;
@@ -564,9 +619,21 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Dimension.mr_controller_volume_group_list_padding_top = global::XFGlossSample.Droid.Resource.Dimension.mr_controller_volume_group_list_padding_top;
 			global::XFGloss.Droid.Resource.Dimension.mr_dialog_fixed_width_major = global::XFGlossSample.Droid.Resource.Dimension.mr_dialog_fixed_width_major;
 			global::XFGloss.Droid.Resource.Dimension.mr_dialog_fixed_width_minor = global::XFGlossSample.Droid.Resource.Dimension.mr_dialog_fixed_width_minor;
+			global::XFGloss.Droid.Resource.Dimension.notification_action_icon_size = global::XFGlossSample.Droid.Resource.Dimension.notification_action_icon_size;
+			global::XFGloss.Droid.Resource.Dimension.notification_action_text_size = global::XFGlossSample.Droid.Resource.Dimension.notification_action_text_size;
+			global::XFGloss.Droid.Resource.Dimension.notification_big_circle_margin = global::XFGlossSample.Droid.Resource.Dimension.notification_big_circle_margin;
+			global::XFGloss.Droid.Resource.Dimension.notification_content_margin_start = global::XFGlossSample.Droid.Resource.Dimension.notification_content_margin_start;
 			global::XFGloss.Droid.Resource.Dimension.notification_large_icon_height = global::XFGlossSample.Droid.Resource.Dimension.notification_large_icon_height;
 			global::XFGloss.Droid.Resource.Dimension.notification_large_icon_width = global::XFGlossSample.Droid.Resource.Dimension.notification_large_icon_width;
+			global::XFGloss.Droid.Resource.Dimension.notification_main_column_padding_top = global::XFGlossSample.Droid.Resource.Dimension.notification_main_column_padding_top;
+			global::XFGloss.Droid.Resource.Dimension.notification_media_narrow_margin = global::XFGlossSample.Droid.Resource.Dimension.notification_media_narrow_margin;
+			global::XFGloss.Droid.Resource.Dimension.notification_right_icon_size = global::XFGlossSample.Droid.Resource.Dimension.notification_right_icon_size;
+			global::XFGloss.Droid.Resource.Dimension.notification_right_side_padding_top = global::XFGlossSample.Droid.Resource.Dimension.notification_right_side_padding_top;
+			global::XFGloss.Droid.Resource.Dimension.notification_small_icon_background_padding = global::XFGlossSample.Droid.Resource.Dimension.notification_small_icon_background_padding;
+			global::XFGloss.Droid.Resource.Dimension.notification_small_icon_size_as_large = global::XFGlossSample.Droid.Resource.Dimension.notification_small_icon_size_as_large;
 			global::XFGloss.Droid.Resource.Dimension.notification_subtext_size = global::XFGlossSample.Droid.Resource.Dimension.notification_subtext_size;
+			global::XFGloss.Droid.Resource.Dimension.notification_top_pad = global::XFGlossSample.Droid.Resource.Dimension.notification_top_pad;
+			global::XFGloss.Droid.Resource.Dimension.notification_top_pad_large_text = global::XFGlossSample.Droid.Resource.Dimension.notification_top_pad_large_text;
 			global::XFGloss.Droid.Resource.Drawable.abc_ab_share_pack_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_ab_share_pack_mtrl_alpha;
 			global::XFGloss.Droid.Resource.Drawable.abc_action_bar_item_background_material = global::XFGlossSample.Droid.Resource.Drawable.abc_action_bar_item_background_material;
 			global::XFGloss.Droid.Resource.Drawable.abc_btn_borderless_material = global::XFGlossSample.Droid.Resource.Drawable.abc_btn_borderless_material;
@@ -578,33 +645,33 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Drawable.abc_btn_radio_material = global::XFGlossSample.Droid.Resource.Drawable.abc_btn_radio_material;
 			global::XFGloss.Droid.Resource.Drawable.abc_btn_radio_to_on_mtrl_000 = global::XFGlossSample.Droid.Resource.Drawable.abc_btn_radio_to_on_mtrl_000;
 			global::XFGloss.Droid.Resource.Drawable.abc_btn_radio_to_on_mtrl_015 = global::XFGlossSample.Droid.Resource.Drawable.abc_btn_radio_to_on_mtrl_015;
-			global::XFGloss.Droid.Resource.Drawable.abc_btn_rating_star_off_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_btn_rating_star_off_mtrl_alpha;
-			global::XFGloss.Droid.Resource.Drawable.abc_btn_rating_star_on_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_btn_rating_star_on_mtrl_alpha;
 			global::XFGloss.Droid.Resource.Drawable.abc_btn_switch_to_on_mtrl_00001 = global::XFGlossSample.Droid.Resource.Drawable.abc_btn_switch_to_on_mtrl_00001;
 			global::XFGloss.Droid.Resource.Drawable.abc_btn_switch_to_on_mtrl_00012 = global::XFGlossSample.Droid.Resource.Drawable.abc_btn_switch_to_on_mtrl_00012;
 			global::XFGloss.Droid.Resource.Drawable.abc_cab_background_internal_bg = global::XFGlossSample.Droid.Resource.Drawable.abc_cab_background_internal_bg;
 			global::XFGloss.Droid.Resource.Drawable.abc_cab_background_top_material = global::XFGlossSample.Droid.Resource.Drawable.abc_cab_background_top_material;
 			global::XFGloss.Droid.Resource.Drawable.abc_cab_background_top_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_cab_background_top_mtrl_alpha;
 			global::XFGloss.Droid.Resource.Drawable.abc_control_background_material = global::XFGlossSample.Droid.Resource.Drawable.abc_control_background_material;
-			global::XFGloss.Droid.Resource.Drawable.abc_dialog_material_background_dark = global::XFGlossSample.Droid.Resource.Drawable.abc_dialog_material_background_dark;
-			global::XFGloss.Droid.Resource.Drawable.abc_dialog_material_background_light = global::XFGlossSample.Droid.Resource.Drawable.abc_dialog_material_background_light;
+			global::XFGloss.Droid.Resource.Drawable.abc_dialog_material_background = global::XFGlossSample.Droid.Resource.Drawable.abc_dialog_material_background;
 			global::XFGloss.Droid.Resource.Drawable.abc_edit_text_material = global::XFGlossSample.Droid.Resource.Drawable.abc_edit_text_material;
-			global::XFGloss.Droid.Resource.Drawable.abc_ic_ab_back_mtrl_am_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_ab_back_mtrl_am_alpha;
-			global::XFGloss.Droid.Resource.Drawable.abc_ic_clear_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_clear_mtrl_alpha;
+			global::XFGloss.Droid.Resource.Drawable.abc_ic_ab_back_material = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_ab_back_material;
+			global::XFGloss.Droid.Resource.Drawable.abc_ic_arrow_drop_right_black_24dp = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_arrow_drop_right_black_24dp;
+			global::XFGloss.Droid.Resource.Drawable.abc_ic_clear_material = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_clear_material;
 			global::XFGloss.Droid.Resource.Drawable.abc_ic_commit_search_api_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_commit_search_api_mtrl_alpha;
-			global::XFGloss.Droid.Resource.Drawable.abc_ic_go_search_api_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_go_search_api_mtrl_alpha;
+			global::XFGloss.Droid.Resource.Drawable.abc_ic_go_search_api_material = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_go_search_api_material;
 			global::XFGloss.Droid.Resource.Drawable.abc_ic_menu_copy_mtrl_am_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_menu_copy_mtrl_am_alpha;
 			global::XFGloss.Droid.Resource.Drawable.abc_ic_menu_cut_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_menu_cut_mtrl_alpha;
-			global::XFGloss.Droid.Resource.Drawable.abc_ic_menu_moreoverflow_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_menu_moreoverflow_mtrl_alpha;
+			global::XFGloss.Droid.Resource.Drawable.abc_ic_menu_overflow_material = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_menu_overflow_material;
 			global::XFGloss.Droid.Resource.Drawable.abc_ic_menu_paste_mtrl_am_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_menu_paste_mtrl_am_alpha;
 			global::XFGloss.Droid.Resource.Drawable.abc_ic_menu_selectall_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_menu_selectall_mtrl_alpha;
 			global::XFGloss.Droid.Resource.Drawable.abc_ic_menu_share_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_menu_share_mtrl_alpha;
-			global::XFGloss.Droid.Resource.Drawable.abc_ic_search_api_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_search_api_mtrl_alpha;
+			global::XFGloss.Droid.Resource.Drawable.abc_ic_search_api_material = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_search_api_material;
 			global::XFGloss.Droid.Resource.Drawable.abc_ic_star_black_16dp = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_star_black_16dp;
 			global::XFGloss.Droid.Resource.Drawable.abc_ic_star_black_36dp = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_star_black_36dp;
+			global::XFGloss.Droid.Resource.Drawable.abc_ic_star_black_48dp = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_star_black_48dp;
 			global::XFGloss.Droid.Resource.Drawable.abc_ic_star_half_black_16dp = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_star_half_black_16dp;
 			global::XFGloss.Droid.Resource.Drawable.abc_ic_star_half_black_36dp = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_star_half_black_36dp;
-			global::XFGloss.Droid.Resource.Drawable.abc_ic_voice_search_api_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_voice_search_api_mtrl_alpha;
+			global::XFGloss.Droid.Resource.Drawable.abc_ic_star_half_black_48dp = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_star_half_black_48dp;
+			global::XFGloss.Droid.Resource.Drawable.abc_ic_voice_search_api_material = global::XFGlossSample.Droid.Resource.Drawable.abc_ic_voice_search_api_material;
 			global::XFGloss.Droid.Resource.Drawable.abc_item_background_holo_dark = global::XFGlossSample.Droid.Resource.Drawable.abc_item_background_holo_dark;
 			global::XFGloss.Droid.Resource.Drawable.abc_item_background_holo_light = global::XFGlossSample.Droid.Resource.Drawable.abc_item_background_holo_light;
 			global::XFGloss.Droid.Resource.Drawable.abc_list_divider_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_list_divider_mtrl_alpha;
@@ -620,8 +687,8 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Drawable.abc_list_selector_holo_light = global::XFGlossSample.Droid.Resource.Drawable.abc_list_selector_holo_light;
 			global::XFGloss.Droid.Resource.Drawable.abc_menu_hardkey_panel_mtrl_mult = global::XFGlossSample.Droid.Resource.Drawable.abc_menu_hardkey_panel_mtrl_mult;
 			global::XFGloss.Droid.Resource.Drawable.abc_popup_background_mtrl_mult = global::XFGlossSample.Droid.Resource.Drawable.abc_popup_background_mtrl_mult;
-			global::XFGloss.Droid.Resource.Drawable.abc_ratingbar_full_material = global::XFGlossSample.Droid.Resource.Drawable.abc_ratingbar_full_material;
 			global::XFGloss.Droid.Resource.Drawable.abc_ratingbar_indicator_material = global::XFGlossSample.Droid.Resource.Drawable.abc_ratingbar_indicator_material;
+			global::XFGloss.Droid.Resource.Drawable.abc_ratingbar_material = global::XFGlossSample.Droid.Resource.Drawable.abc_ratingbar_material;
 			global::XFGloss.Droid.Resource.Drawable.abc_ratingbar_small_material = global::XFGlossSample.Droid.Resource.Drawable.abc_ratingbar_small_material;
 			global::XFGloss.Droid.Resource.Drawable.abc_scrubber_control_off_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_scrubber_control_off_mtrl_alpha;
 			global::XFGloss.Droid.Resource.Drawable.abc_scrubber_control_to_pressed_mtrl_000 = global::XFGlossSample.Droid.Resource.Drawable.abc_scrubber_control_to_pressed_mtrl_000;
@@ -629,6 +696,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Drawable.abc_scrubber_primary_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_scrubber_primary_mtrl_alpha;
 			global::XFGloss.Droid.Resource.Drawable.abc_scrubber_track_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_scrubber_track_mtrl_alpha;
 			global::XFGloss.Droid.Resource.Drawable.abc_seekbar_thumb_material = global::XFGlossSample.Droid.Resource.Drawable.abc_seekbar_thumb_material;
+			global::XFGloss.Droid.Resource.Drawable.abc_seekbar_tick_mark_material = global::XFGlossSample.Droid.Resource.Drawable.abc_seekbar_tick_mark_material;
 			global::XFGloss.Droid.Resource.Drawable.abc_seekbar_track_material = global::XFGlossSample.Droid.Resource.Drawable.abc_seekbar_track_material;
 			global::XFGloss.Droid.Resource.Drawable.abc_spinner_mtrl_am_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_spinner_mtrl_am_alpha;
 			global::XFGloss.Droid.Resource.Drawable.abc_spinner_textfield_background_material = global::XFGlossSample.Droid.Resource.Drawable.abc_spinner_textfield_background_material;
@@ -637,97 +705,210 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Drawable.abc_tab_indicator_material = global::XFGlossSample.Droid.Resource.Drawable.abc_tab_indicator_material;
 			global::XFGloss.Droid.Resource.Drawable.abc_tab_indicator_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_tab_indicator_mtrl_alpha;
 			global::XFGloss.Droid.Resource.Drawable.abc_text_cursor_material = global::XFGlossSample.Droid.Resource.Drawable.abc_text_cursor_material;
+			global::XFGloss.Droid.Resource.Drawable.abc_text_select_handle_left_mtrl_dark = global::XFGlossSample.Droid.Resource.Drawable.abc_text_select_handle_left_mtrl_dark;
+			global::XFGloss.Droid.Resource.Drawable.abc_text_select_handle_left_mtrl_light = global::XFGlossSample.Droid.Resource.Drawable.abc_text_select_handle_left_mtrl_light;
+			global::XFGloss.Droid.Resource.Drawable.abc_text_select_handle_middle_mtrl_dark = global::XFGlossSample.Droid.Resource.Drawable.abc_text_select_handle_middle_mtrl_dark;
+			global::XFGloss.Droid.Resource.Drawable.abc_text_select_handle_middle_mtrl_light = global::XFGlossSample.Droid.Resource.Drawable.abc_text_select_handle_middle_mtrl_light;
+			global::XFGloss.Droid.Resource.Drawable.abc_text_select_handle_right_mtrl_dark = global::XFGlossSample.Droid.Resource.Drawable.abc_text_select_handle_right_mtrl_dark;
+			global::XFGloss.Droid.Resource.Drawable.abc_text_select_handle_right_mtrl_light = global::XFGlossSample.Droid.Resource.Drawable.abc_text_select_handle_right_mtrl_light;
 			global::XFGloss.Droid.Resource.Drawable.abc_textfield_activated_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_textfield_activated_mtrl_alpha;
 			global::XFGloss.Droid.Resource.Drawable.abc_textfield_default_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_textfield_default_mtrl_alpha;
 			global::XFGloss.Droid.Resource.Drawable.abc_textfield_search_activated_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_textfield_search_activated_mtrl_alpha;
 			global::XFGloss.Droid.Resource.Drawable.abc_textfield_search_default_mtrl_alpha = global::XFGlossSample.Droid.Resource.Drawable.abc_textfield_search_default_mtrl_alpha;
 			global::XFGloss.Droid.Resource.Drawable.abc_textfield_search_material = global::XFGlossSample.Droid.Resource.Drawable.abc_textfield_search_material;
+			global::XFGloss.Droid.Resource.Drawable.abc_vector_test = global::XFGlossSample.Droid.Resource.Drawable.abc_vector_test;
+			global::XFGloss.Droid.Resource.Drawable.avd_hide_password = global::XFGlossSample.Droid.Resource.Drawable.avd_hide_password;
+			global::XFGloss.Droid.Resource.Drawable.avd_hide_password_1 = global::XFGlossSample.Droid.Resource.Drawable.avd_hide_password_1;
+			global::XFGloss.Droid.Resource.Drawable.avd_hide_password_2 = global::XFGlossSample.Droid.Resource.Drawable.avd_hide_password_2;
+			global::XFGloss.Droid.Resource.Drawable.avd_hide_password_3 = global::XFGlossSample.Droid.Resource.Drawable.avd_hide_password_3;
+			global::XFGloss.Droid.Resource.Drawable.avd_show_password = global::XFGlossSample.Droid.Resource.Drawable.avd_show_password;
+			global::XFGloss.Droid.Resource.Drawable.avd_show_password_1 = global::XFGlossSample.Droid.Resource.Drawable.avd_show_password_1;
+			global::XFGloss.Droid.Resource.Drawable.avd_show_password_2 = global::XFGlossSample.Droid.Resource.Drawable.avd_show_password_2;
+			global::XFGloss.Droid.Resource.Drawable.avd_show_password_3 = global::XFGlossSample.Droid.Resource.Drawable.avd_show_password_3;
+			global::XFGloss.Droid.Resource.Drawable.design_bottom_navigation_item_background = global::XFGlossSample.Droid.Resource.Drawable.design_bottom_navigation_item_background;
 			global::XFGloss.Droid.Resource.Drawable.design_fab_background = global::XFGlossSample.Droid.Resource.Drawable.design_fab_background;
+			global::XFGloss.Droid.Resource.Drawable.design_ic_visibility = global::XFGlossSample.Droid.Resource.Drawable.design_ic_visibility;
+			global::XFGloss.Droid.Resource.Drawable.design_ic_visibility_off = global::XFGlossSample.Droid.Resource.Drawable.design_ic_visibility_off;
+			global::XFGloss.Droid.Resource.Drawable.design_password_eye = global::XFGlossSample.Droid.Resource.Drawable.design_password_eye;
 			global::XFGloss.Droid.Resource.Drawable.design_snackbar_background = global::XFGlossSample.Droid.Resource.Drawable.design_snackbar_background;
-			global::XFGloss.Droid.Resource.Drawable.ic_audiotrack = global::XFGlossSample.Droid.Resource.Drawable.ic_audiotrack;
+			global::XFGloss.Droid.Resource.Drawable.ic_audiotrack_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_audiotrack_dark;
 			global::XFGloss.Droid.Resource.Drawable.ic_audiotrack_light = global::XFGlossSample.Droid.Resource.Drawable.ic_audiotrack_light;
-			global::XFGloss.Droid.Resource.Drawable.ic_bluetooth_grey = global::XFGlossSample.Droid.Resource.Drawable.ic_bluetooth_grey;
-			global::XFGloss.Droid.Resource.Drawable.ic_bluetooth_white = global::XFGlossSample.Droid.Resource.Drawable.ic_bluetooth_white;
-			global::XFGloss.Droid.Resource.Drawable.ic_cast_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_cast_dark;
-			global::XFGloss.Droid.Resource.Drawable.ic_cast_disabled_light = global::XFGlossSample.Droid.Resource.Drawable.ic_cast_disabled_light;
-			global::XFGloss.Droid.Resource.Drawable.ic_cast_grey = global::XFGlossSample.Droid.Resource.Drawable.ic_cast_grey;
-			global::XFGloss.Droid.Resource.Drawable.ic_cast_light = global::XFGlossSample.Droid.Resource.Drawable.ic_cast_light;
-			global::XFGloss.Droid.Resource.Drawable.ic_cast_off_light = global::XFGlossSample.Droid.Resource.Drawable.ic_cast_off_light;
-			global::XFGloss.Droid.Resource.Drawable.ic_cast_on_0_light = global::XFGlossSample.Droid.Resource.Drawable.ic_cast_on_0_light;
-			global::XFGloss.Droid.Resource.Drawable.ic_cast_on_1_light = global::XFGlossSample.Droid.Resource.Drawable.ic_cast_on_1_light;
-			global::XFGloss.Droid.Resource.Drawable.ic_cast_on_2_light = global::XFGlossSample.Droid.Resource.Drawable.ic_cast_on_2_light;
-			global::XFGloss.Droid.Resource.Drawable.ic_cast_on_light = global::XFGlossSample.Droid.Resource.Drawable.ic_cast_on_light;
-			global::XFGloss.Droid.Resource.Drawable.ic_cast_white = global::XFGlossSample.Droid.Resource.Drawable.ic_cast_white;
-			global::XFGloss.Droid.Resource.Drawable.ic_close_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_close_dark;
-			global::XFGloss.Droid.Resource.Drawable.ic_close_light = global::XFGlossSample.Droid.Resource.Drawable.ic_close_light;
-			global::XFGloss.Droid.Resource.Drawable.ic_collapse = global::XFGlossSample.Droid.Resource.Drawable.ic_collapse;
-			global::XFGloss.Droid.Resource.Drawable.ic_collapse_00000 = global::XFGlossSample.Droid.Resource.Drawable.ic_collapse_00000;
-			global::XFGloss.Droid.Resource.Drawable.ic_collapse_00001 = global::XFGlossSample.Droid.Resource.Drawable.ic_collapse_00001;
-			global::XFGloss.Droid.Resource.Drawable.ic_collapse_00002 = global::XFGlossSample.Droid.Resource.Drawable.ic_collapse_00002;
-			global::XFGloss.Droid.Resource.Drawable.ic_collapse_00003 = global::XFGlossSample.Droid.Resource.Drawable.ic_collapse_00003;
-			global::XFGloss.Droid.Resource.Drawable.ic_collapse_00004 = global::XFGlossSample.Droid.Resource.Drawable.ic_collapse_00004;
-			global::XFGloss.Droid.Resource.Drawable.ic_collapse_00005 = global::XFGlossSample.Droid.Resource.Drawable.ic_collapse_00005;
-			global::XFGloss.Droid.Resource.Drawable.ic_collapse_00006 = global::XFGlossSample.Droid.Resource.Drawable.ic_collapse_00006;
-			global::XFGloss.Droid.Resource.Drawable.ic_collapse_00007 = global::XFGlossSample.Droid.Resource.Drawable.ic_collapse_00007;
-			global::XFGloss.Droid.Resource.Drawable.ic_collapse_00008 = global::XFGlossSample.Droid.Resource.Drawable.ic_collapse_00008;
-			global::XFGloss.Droid.Resource.Drawable.ic_collapse_00009 = global::XFGlossSample.Droid.Resource.Drawable.ic_collapse_00009;
-			global::XFGloss.Droid.Resource.Drawable.ic_collapse_00010 = global::XFGlossSample.Droid.Resource.Drawable.ic_collapse_00010;
-			global::XFGloss.Droid.Resource.Drawable.ic_collapse_00011 = global::XFGlossSample.Droid.Resource.Drawable.ic_collapse_00011;
-			global::XFGloss.Droid.Resource.Drawable.ic_collapse_00012 = global::XFGlossSample.Droid.Resource.Drawable.ic_collapse_00012;
-			global::XFGloss.Droid.Resource.Drawable.ic_collapse_00013 = global::XFGlossSample.Droid.Resource.Drawable.ic_collapse_00013;
-			global::XFGloss.Droid.Resource.Drawable.ic_collapse_00014 = global::XFGlossSample.Droid.Resource.Drawable.ic_collapse_00014;
-			global::XFGloss.Droid.Resource.Drawable.ic_collapse_00015 = global::XFGlossSample.Droid.Resource.Drawable.ic_collapse_00015;
-			global::XFGloss.Droid.Resource.Drawable.ic_expand = global::XFGlossSample.Droid.Resource.Drawable.ic_expand;
-			global::XFGloss.Droid.Resource.Drawable.ic_expand_00000 = global::XFGlossSample.Droid.Resource.Drawable.ic_expand_00000;
-			global::XFGloss.Droid.Resource.Drawable.ic_expand_00001 = global::XFGlossSample.Droid.Resource.Drawable.ic_expand_00001;
-			global::XFGloss.Droid.Resource.Drawable.ic_expand_00002 = global::XFGlossSample.Droid.Resource.Drawable.ic_expand_00002;
-			global::XFGloss.Droid.Resource.Drawable.ic_expand_00003 = global::XFGlossSample.Droid.Resource.Drawable.ic_expand_00003;
-			global::XFGloss.Droid.Resource.Drawable.ic_expand_00004 = global::XFGlossSample.Droid.Resource.Drawable.ic_expand_00004;
-			global::XFGloss.Droid.Resource.Drawable.ic_expand_00005 = global::XFGlossSample.Droid.Resource.Drawable.ic_expand_00005;
-			global::XFGloss.Droid.Resource.Drawable.ic_expand_00006 = global::XFGlossSample.Droid.Resource.Drawable.ic_expand_00006;
-			global::XFGloss.Droid.Resource.Drawable.ic_expand_00007 = global::XFGlossSample.Droid.Resource.Drawable.ic_expand_00007;
-			global::XFGloss.Droid.Resource.Drawable.ic_expand_00008 = global::XFGlossSample.Droid.Resource.Drawable.ic_expand_00008;
-			global::XFGloss.Droid.Resource.Drawable.ic_expand_00009 = global::XFGlossSample.Droid.Resource.Drawable.ic_expand_00009;
-			global::XFGloss.Droid.Resource.Drawable.ic_expand_00010 = global::XFGlossSample.Droid.Resource.Drawable.ic_expand_00010;
-			global::XFGloss.Droid.Resource.Drawable.ic_expand_00011 = global::XFGlossSample.Droid.Resource.Drawable.ic_expand_00011;
-			global::XFGloss.Droid.Resource.Drawable.ic_expand_00012 = global::XFGlossSample.Droid.Resource.Drawable.ic_expand_00012;
-			global::XFGloss.Droid.Resource.Drawable.ic_expand_00013 = global::XFGlossSample.Droid.Resource.Drawable.ic_expand_00013;
-			global::XFGloss.Droid.Resource.Drawable.ic_expand_00014 = global::XFGlossSample.Droid.Resource.Drawable.ic_expand_00014;
-			global::XFGloss.Droid.Resource.Drawable.ic_expand_00015 = global::XFGlossSample.Droid.Resource.Drawable.ic_expand_00015;
-			global::XFGloss.Droid.Resource.Drawable.ic_media_pause = global::XFGlossSample.Droid.Resource.Drawable.ic_media_pause;
-			global::XFGloss.Droid.Resource.Drawable.ic_media_play = global::XFGlossSample.Droid.Resource.Drawable.ic_media_play;
-			global::XFGloss.Droid.Resource.Drawable.ic_media_route_disabled_mono_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_media_route_disabled_mono_dark;
-			global::XFGloss.Droid.Resource.Drawable.ic_media_route_off_mono_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_media_route_off_mono_dark;
-			global::XFGloss.Droid.Resource.Drawable.ic_media_route_on_0_mono_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_media_route_on_0_mono_dark;
-			global::XFGloss.Droid.Resource.Drawable.ic_media_route_on_1_mono_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_media_route_on_1_mono_dark;
-			global::XFGloss.Droid.Resource.Drawable.ic_media_route_on_2_mono_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_media_route_on_2_mono_dark;
-			global::XFGloss.Droid.Resource.Drawable.ic_media_route_on_mono_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_media_route_on_mono_dark;
-			global::XFGloss.Droid.Resource.Drawable.ic_pause_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_pause_dark;
-			global::XFGloss.Droid.Resource.Drawable.ic_pause_light = global::XFGlossSample.Droid.Resource.Drawable.ic_pause_light;
-			global::XFGloss.Droid.Resource.Drawable.ic_play_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_play_dark;
-			global::XFGloss.Droid.Resource.Drawable.ic_play_light = global::XFGlossSample.Droid.Resource.Drawable.ic_play_light;
-			global::XFGloss.Droid.Resource.Drawable.ic_speaker_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_speaker_dark;
-			global::XFGloss.Droid.Resource.Drawable.ic_speaker_group_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_speaker_group_dark;
-			global::XFGloss.Droid.Resource.Drawable.ic_speaker_group_light = global::XFGlossSample.Droid.Resource.Drawable.ic_speaker_group_light;
-			global::XFGloss.Droid.Resource.Drawable.ic_speaker_light = global::XFGlossSample.Droid.Resource.Drawable.ic_speaker_light;
-			global::XFGloss.Droid.Resource.Drawable.ic_tv_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_tv_dark;
-			global::XFGloss.Droid.Resource.Drawable.ic_tv_light = global::XFGlossSample.Droid.Resource.Drawable.ic_tv_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_dialog_close_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_dialog_close_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_dialog_close_light = global::XFGlossSample.Droid.Resource.Drawable.ic_dialog_close_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_collapse_00 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_collapse_00;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_collapse_01 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_collapse_01;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_collapse_02 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_collapse_02;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_collapse_03 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_collapse_03;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_collapse_04 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_collapse_04;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_collapse_05 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_collapse_05;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_collapse_06 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_collapse_06;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_collapse_07 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_collapse_07;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_collapse_08 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_collapse_08;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_collapse_09 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_collapse_09;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_collapse_10 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_collapse_10;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_collapse_11 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_collapse_11;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_collapse_12 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_collapse_12;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_collapse_13 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_collapse_13;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_collapse_14 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_collapse_14;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_collapse_15 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_collapse_15;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_expand_00 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_expand_00;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_expand_01 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_expand_01;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_expand_02 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_expand_02;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_expand_03 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_expand_03;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_expand_04 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_expand_04;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_expand_05 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_expand_05;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_expand_06 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_expand_06;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_expand_07 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_expand_07;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_expand_08 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_expand_08;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_expand_09 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_expand_09;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_expand_10 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_expand_10;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_expand_11 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_expand_11;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_expand_12 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_expand_12;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_expand_13 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_expand_13;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_expand_14 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_expand_14;
+			global::XFGloss.Droid.Resource.Drawable.ic_group_expand_15 = global::XFGlossSample.Droid.Resource.Drawable.ic_group_expand_15;
+			global::XFGloss.Droid.Resource.Drawable.ic_media_pause_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_media_pause_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_media_pause_light = global::XFGlossSample.Droid.Resource.Drawable.ic_media_pause_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_media_play_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_media_play_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_media_play_light = global::XFGlossSample.Droid.Resource.Drawable.ic_media_play_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_media_stop_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_media_stop_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_media_stop_light = global::XFGlossSample.Droid.Resource.Drawable.ic_media_stop_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_00_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_00_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_00_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_00_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_01_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_01_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_01_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_01_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_02_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_02_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_02_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_02_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_03_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_03_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_03_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_03_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_04_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_04_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_04_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_04_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_05_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_05_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_05_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_05_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_06_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_06_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_06_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_06_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_07_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_07_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_07_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_07_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_08_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_08_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_08_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_08_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_09_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_09_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_09_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_09_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_10_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_10_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_10_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_10_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_11_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_11_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_11_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_11_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_12_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_12_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_12_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_12_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_13_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_13_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_13_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_13_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_14_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_14_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_14_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_14_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_15_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_15_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_15_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_15_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_16_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_16_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_16_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_16_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_17_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_17_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_17_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_17_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_18_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_18_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_18_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_18_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_19_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_19_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_19_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_19_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_20_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_20_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_20_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_20_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_21_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_21_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_21_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_21_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_22_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_22_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connected_22_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connected_22_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_00_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_00_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_00_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_00_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_01_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_01_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_01_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_01_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_02_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_02_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_02_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_02_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_03_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_03_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_03_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_03_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_04_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_04_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_04_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_04_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_05_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_05_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_05_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_05_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_06_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_06_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_06_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_06_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_07_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_07_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_07_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_07_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_08_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_08_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_08_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_08_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_09_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_09_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_09_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_09_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_10_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_10_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_10_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_10_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_11_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_11_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_11_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_11_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_12_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_12_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_12_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_12_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_13_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_13_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_13_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_13_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_14_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_14_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_14_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_14_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_15_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_15_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_15_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_15_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_16_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_16_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_16_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_16_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_17_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_17_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_17_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_17_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_18_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_18_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_18_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_18_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_19_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_19_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_19_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_19_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_20_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_20_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_20_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_20_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_21_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_21_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_21_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_21_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_22_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_22_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_connecting_22_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_connecting_22_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_disabled_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_disabled_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_disabled_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_disabled_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_disconnected_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_disconnected_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_disconnected_light = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_disconnected_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_mr_button_grey = global::XFGlossSample.Droid.Resource.Drawable.ic_mr_button_grey;
+			global::XFGloss.Droid.Resource.Drawable.ic_vol_type_speaker_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_vol_type_speaker_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_vol_type_speaker_group_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_vol_type_speaker_group_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_vol_type_speaker_group_light = global::XFGlossSample.Droid.Resource.Drawable.ic_vol_type_speaker_group_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_vol_type_speaker_light = global::XFGlossSample.Droid.Resource.Drawable.ic_vol_type_speaker_light;
+			global::XFGloss.Droid.Resource.Drawable.ic_vol_type_tv_dark = global::XFGlossSample.Droid.Resource.Drawable.ic_vol_type_tv_dark;
+			global::XFGloss.Droid.Resource.Drawable.ic_vol_type_tv_light = global::XFGlossSample.Droid.Resource.Drawable.ic_vol_type_tv_light;
+			global::XFGloss.Droid.Resource.Drawable.mr_button_connected_dark = global::XFGlossSample.Droid.Resource.Drawable.mr_button_connected_dark;
+			global::XFGloss.Droid.Resource.Drawable.mr_button_connected_light = global::XFGlossSample.Droid.Resource.Drawable.mr_button_connected_light;
+			global::XFGloss.Droid.Resource.Drawable.mr_button_connecting_dark = global::XFGlossSample.Droid.Resource.Drawable.mr_button_connecting_dark;
+			global::XFGloss.Droid.Resource.Drawable.mr_button_connecting_light = global::XFGlossSample.Droid.Resource.Drawable.mr_button_connecting_light;
+			global::XFGloss.Droid.Resource.Drawable.mr_button_dark = global::XFGlossSample.Droid.Resource.Drawable.mr_button_dark;
+			global::XFGloss.Droid.Resource.Drawable.mr_button_light = global::XFGlossSample.Droid.Resource.Drawable.mr_button_light;
+			global::XFGloss.Droid.Resource.Drawable.mr_dialog_close_dark = global::XFGlossSample.Droid.Resource.Drawable.mr_dialog_close_dark;
+			global::XFGloss.Droid.Resource.Drawable.mr_dialog_close_light = global::XFGlossSample.Droid.Resource.Drawable.mr_dialog_close_light;
 			global::XFGloss.Droid.Resource.Drawable.mr_dialog_material_background_dark = global::XFGlossSample.Droid.Resource.Drawable.mr_dialog_material_background_dark;
 			global::XFGloss.Droid.Resource.Drawable.mr_dialog_material_background_light = global::XFGlossSample.Droid.Resource.Drawable.mr_dialog_material_background_light;
-			global::XFGloss.Droid.Resource.Drawable.mr_ic_audiotrack_light = global::XFGlossSample.Droid.Resource.Drawable.mr_ic_audiotrack_light;
-			global::XFGloss.Droid.Resource.Drawable.mr_ic_cast_dark = global::XFGlossSample.Droid.Resource.Drawable.mr_ic_cast_dark;
-			global::XFGloss.Droid.Resource.Drawable.mr_ic_cast_light = global::XFGlossSample.Droid.Resource.Drawable.mr_ic_cast_light;
-			global::XFGloss.Droid.Resource.Drawable.mr_ic_close_dark = global::XFGlossSample.Droid.Resource.Drawable.mr_ic_close_dark;
-			global::XFGloss.Droid.Resource.Drawable.mr_ic_close_light = global::XFGlossSample.Droid.Resource.Drawable.mr_ic_close_light;
-			global::XFGloss.Droid.Resource.Drawable.mr_ic_media_route_connecting_mono_dark = global::XFGlossSample.Droid.Resource.Drawable.mr_ic_media_route_connecting_mono_dark;
-			global::XFGloss.Droid.Resource.Drawable.mr_ic_media_route_connecting_mono_light = global::XFGlossSample.Droid.Resource.Drawable.mr_ic_media_route_connecting_mono_light;
-			global::XFGloss.Droid.Resource.Drawable.mr_ic_media_route_mono_dark = global::XFGlossSample.Droid.Resource.Drawable.mr_ic_media_route_mono_dark;
-			global::XFGloss.Droid.Resource.Drawable.mr_ic_media_route_mono_light = global::XFGlossSample.Droid.Resource.Drawable.mr_ic_media_route_mono_light;
-			global::XFGloss.Droid.Resource.Drawable.mr_ic_pause_dark = global::XFGlossSample.Droid.Resource.Drawable.mr_ic_pause_dark;
-			global::XFGloss.Droid.Resource.Drawable.mr_ic_pause_light = global::XFGlossSample.Droid.Resource.Drawable.mr_ic_pause_light;
-			global::XFGloss.Droid.Resource.Drawable.mr_ic_play_dark = global::XFGlossSample.Droid.Resource.Drawable.mr_ic_play_dark;
-			global::XFGloss.Droid.Resource.Drawable.mr_ic_play_light = global::XFGlossSample.Droid.Resource.Drawable.mr_ic_play_light;
+			global::XFGloss.Droid.Resource.Drawable.mr_group_collapse = global::XFGlossSample.Droid.Resource.Drawable.mr_group_collapse;
+			global::XFGloss.Droid.Resource.Drawable.mr_group_expand = global::XFGlossSample.Droid.Resource.Drawable.mr_group_expand;
+			global::XFGloss.Droid.Resource.Drawable.mr_media_pause_dark = global::XFGlossSample.Droid.Resource.Drawable.mr_media_pause_dark;
+			global::XFGloss.Droid.Resource.Drawable.mr_media_pause_light = global::XFGlossSample.Droid.Resource.Drawable.mr_media_pause_light;
+			global::XFGloss.Droid.Resource.Drawable.mr_media_play_dark = global::XFGlossSample.Droid.Resource.Drawable.mr_media_play_dark;
+			global::XFGloss.Droid.Resource.Drawable.mr_media_play_light = global::XFGlossSample.Droid.Resource.Drawable.mr_media_play_light;
+			global::XFGloss.Droid.Resource.Drawable.mr_media_stop_dark = global::XFGlossSample.Droid.Resource.Drawable.mr_media_stop_dark;
+			global::XFGloss.Droid.Resource.Drawable.mr_media_stop_light = global::XFGlossSample.Droid.Resource.Drawable.mr_media_stop_light;
+			global::XFGloss.Droid.Resource.Drawable.mr_vol_type_audiotrack_dark = global::XFGlossSample.Droid.Resource.Drawable.mr_vol_type_audiotrack_dark;
+			global::XFGloss.Droid.Resource.Drawable.mr_vol_type_audiotrack_light = global::XFGlossSample.Droid.Resource.Drawable.mr_vol_type_audiotrack_light;
+			global::XFGloss.Droid.Resource.Drawable.navigation_empty_icon = global::XFGlossSample.Droid.Resource.Drawable.navigation_empty_icon;
+			global::XFGloss.Droid.Resource.Drawable.notification_action_background = global::XFGlossSample.Droid.Resource.Drawable.notification_action_background;
+			global::XFGloss.Droid.Resource.Drawable.notification_bg = global::XFGlossSample.Droid.Resource.Drawable.notification_bg;
+			global::XFGloss.Droid.Resource.Drawable.notification_bg_low = global::XFGlossSample.Droid.Resource.Drawable.notification_bg_low;
+			global::XFGloss.Droid.Resource.Drawable.notification_bg_low_normal = global::XFGlossSample.Droid.Resource.Drawable.notification_bg_low_normal;
+			global::XFGloss.Droid.Resource.Drawable.notification_bg_low_pressed = global::XFGlossSample.Droid.Resource.Drawable.notification_bg_low_pressed;
+			global::XFGloss.Droid.Resource.Drawable.notification_bg_normal = global::XFGlossSample.Droid.Resource.Drawable.notification_bg_normal;
+			global::XFGloss.Droid.Resource.Drawable.notification_bg_normal_pressed = global::XFGlossSample.Droid.Resource.Drawable.notification_bg_normal_pressed;
+			global::XFGloss.Droid.Resource.Drawable.notification_icon_background = global::XFGlossSample.Droid.Resource.Drawable.notification_icon_background;
 			global::XFGloss.Droid.Resource.Drawable.notification_template_icon_bg = global::XFGlossSample.Droid.Resource.Drawable.notification_template_icon_bg;
+			global::XFGloss.Droid.Resource.Drawable.notification_template_icon_low_bg = global::XFGlossSample.Droid.Resource.Drawable.notification_template_icon_low_bg;
+			global::XFGloss.Droid.Resource.Drawable.notification_tile_bg = global::XFGlossSample.Droid.Resource.Drawable.notification_tile_bg;
+			global::XFGloss.Droid.Resource.Drawable.notify_panel_notification_icon_bg = global::XFGlossSample.Droid.Resource.Drawable.notify_panel_notification_icon_bg;
 			global::XFGloss.Droid.Resource.Id.action0 = global::XFGlossSample.Droid.Resource.Id.action0;
 			global::XFGloss.Droid.Resource.Id.action_bar = global::XFGlossSample.Droid.Resource.Id.action_bar;
 			global::XFGloss.Droid.Resource.Id.action_bar_activity_content = global::XFGlossSample.Droid.Resource.Id.action_bar_activity_content;
@@ -736,16 +917,23 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Id.action_bar_spinner = global::XFGlossSample.Droid.Resource.Id.action_bar_spinner;
 			global::XFGloss.Droid.Resource.Id.action_bar_subtitle = global::XFGlossSample.Droid.Resource.Id.action_bar_subtitle;
 			global::XFGloss.Droid.Resource.Id.action_bar_title = global::XFGlossSample.Droid.Resource.Id.action_bar_title;
+			global::XFGloss.Droid.Resource.Id.action_container = global::XFGlossSample.Droid.Resource.Id.action_container;
 			global::XFGloss.Droid.Resource.Id.action_context_bar = global::XFGlossSample.Droid.Resource.Id.action_context_bar;
 			global::XFGloss.Droid.Resource.Id.action_divider = global::XFGlossSample.Droid.Resource.Id.action_divider;
+			global::XFGloss.Droid.Resource.Id.action_image = global::XFGlossSample.Droid.Resource.Id.action_image;
 			global::XFGloss.Droid.Resource.Id.action_menu_divider = global::XFGlossSample.Droid.Resource.Id.action_menu_divider;
 			global::XFGloss.Droid.Resource.Id.action_menu_presenter = global::XFGlossSample.Droid.Resource.Id.action_menu_presenter;
 			global::XFGloss.Droid.Resource.Id.action_mode_bar = global::XFGlossSample.Droid.Resource.Id.action_mode_bar;
 			global::XFGloss.Droid.Resource.Id.action_mode_bar_stub = global::XFGlossSample.Droid.Resource.Id.action_mode_bar_stub;
 			global::XFGloss.Droid.Resource.Id.action_mode_close_button = global::XFGlossSample.Droid.Resource.Id.action_mode_close_button;
+			global::XFGloss.Droid.Resource.Id.action_text = global::XFGlossSample.Droid.Resource.Id.action_text;
+			global::XFGloss.Droid.Resource.Id.actions = global::XFGlossSample.Droid.Resource.Id.actions;
 			global::XFGloss.Droid.Resource.Id.activity_chooser_view_content = global::XFGlossSample.Droid.Resource.Id.activity_chooser_view_content;
+			global::XFGloss.Droid.Resource.Id.add = global::XFGlossSample.Droid.Resource.Id.add;
 			global::XFGloss.Droid.Resource.Id.alertTitle = global::XFGlossSample.Droid.Resource.Id.alertTitle;
+			global::XFGloss.Droid.Resource.Id.all = global::XFGlossSample.Droid.Resource.Id.all;
 			global::XFGloss.Droid.Resource.Id.always = global::XFGlossSample.Droid.Resource.Id.always;
+			global::XFGloss.Droid.Resource.Id.auto = global::XFGlossSample.Droid.Resource.Id.auto;
 			global::XFGloss.Droid.Resource.Id.beginning = global::XFGlossSample.Droid.Resource.Id.beginning;
 			global::XFGloss.Droid.Resource.Id.bottom = global::XFGlossSample.Droid.Resource.Id.bottom;
 			global::XFGloss.Droid.Resource.Id.buttonPanel = global::XFGlossSample.Droid.Resource.Id.buttonPanel;
@@ -784,15 +972,18 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Id.home = global::XFGlossSample.Droid.Resource.Id.home;
 			global::XFGloss.Droid.Resource.Id.homeAsUp = global::XFGlossSample.Droid.Resource.Id.homeAsUp;
 			global::XFGloss.Droid.Resource.Id.icon = global::XFGlossSample.Droid.Resource.Id.icon;
+			global::XFGloss.Droid.Resource.Id.icon_group = global::XFGlossSample.Droid.Resource.Id.icon_group;
 			global::XFGloss.Droid.Resource.Id.ifRoom = global::XFGlossSample.Droid.Resource.Id.ifRoom;
 			global::XFGloss.Droid.Resource.Id.image = global::XFGlossSample.Droid.Resource.Id.image;
 			global::XFGloss.Droid.Resource.Id.info = global::XFGlossSample.Droid.Resource.Id.info;
 			global::XFGloss.Droid.Resource.Id.item_touch_helper_previous_elevation = global::XFGlossSample.Droid.Resource.Id.item_touch_helper_previous_elevation;
+			global::XFGloss.Droid.Resource.Id.largeLabel = global::XFGlossSample.Droid.Resource.Id.largeLabel;
 			global::XFGloss.Droid.Resource.Id.left = global::XFGlossSample.Droid.Resource.Id.left;
 			global::XFGloss.Droid.Resource.Id.line1 = global::XFGlossSample.Droid.Resource.Id.line1;
 			global::XFGloss.Droid.Resource.Id.line3 = global::XFGlossSample.Droid.Resource.Id.line3;
 			global::XFGloss.Droid.Resource.Id.listMode = global::XFGlossSample.Droid.Resource.Id.listMode;
 			global::XFGloss.Droid.Resource.Id.list_item = global::XFGlossSample.Droid.Resource.Id.list_item;
+			global::XFGloss.Droid.Resource.Id.masked = global::XFGlossSample.Droid.Resource.Id.masked;
 			global::XFGloss.Droid.Resource.Id.media_actions = global::XFGlossSample.Droid.Resource.Id.media_actions;
 			global::XFGloss.Droid.Resource.Id.middle = global::XFGlossSample.Droid.Resource.Id.middle;
 			global::XFGloss.Droid.Resource.Id.mini = global::XFGlossSample.Droid.Resource.Id.mini;
@@ -801,9 +992,10 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Id.mr_chooser_route_desc = global::XFGlossSample.Droid.Resource.Id.mr_chooser_route_desc;
 			global::XFGloss.Droid.Resource.Id.mr_chooser_route_icon = global::XFGlossSample.Droid.Resource.Id.mr_chooser_route_icon;
 			global::XFGloss.Droid.Resource.Id.mr_chooser_route_name = global::XFGlossSample.Droid.Resource.Id.mr_chooser_route_name;
+			global::XFGloss.Droid.Resource.Id.mr_chooser_title = global::XFGlossSample.Droid.Resource.Id.mr_chooser_title;
 			global::XFGloss.Droid.Resource.Id.mr_close = global::XFGlossSample.Droid.Resource.Id.mr_close;
 			global::XFGloss.Droid.Resource.Id.mr_control_divider = global::XFGlossSample.Droid.Resource.Id.mr_control_divider;
-			global::XFGloss.Droid.Resource.Id.mr_control_play_pause = global::XFGlossSample.Droid.Resource.Id.mr_control_play_pause;
+			global::XFGloss.Droid.Resource.Id.mr_control_playback_ctrl = global::XFGlossSample.Droid.Resource.Id.mr_control_playback_ctrl;
 			global::XFGloss.Droid.Resource.Id.mr_control_subtitle = global::XFGlossSample.Droid.Resource.Id.mr_control_subtitle;
 			global::XFGloss.Droid.Resource.Id.mr_control_title = global::XFGlossSample.Droid.Resource.Id.mr_control_title;
 			global::XFGloss.Droid.Resource.Id.mr_control_title_container = global::XFGlossSample.Droid.Resource.Id.mr_control_title_container;
@@ -825,6 +1017,9 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Id.never = global::XFGlossSample.Droid.Resource.Id.never;
 			global::XFGloss.Droid.Resource.Id.none = global::XFGlossSample.Droid.Resource.Id.none;
 			global::XFGloss.Droid.Resource.Id.normal = global::XFGlossSample.Droid.Resource.Id.normal;
+			global::XFGloss.Droid.Resource.Id.notification_background = global::XFGlossSample.Droid.Resource.Id.notification_background;
+			global::XFGloss.Droid.Resource.Id.notification_main_column = global::XFGlossSample.Droid.Resource.Id.notification_main_column;
+			global::XFGloss.Droid.Resource.Id.notification_main_column_container = global::XFGlossSample.Droid.Resource.Id.notification_main_column_container;
 			global::XFGloss.Droid.Resource.Id.parallax = global::XFGlossSample.Droid.Resource.Id.parallax;
 			global::XFGloss.Droid.Resource.Id.parentPanel = global::XFGlossSample.Droid.Resource.Id.parentPanel;
 			global::XFGloss.Droid.Resource.Id.pin = global::XFGlossSample.Droid.Resource.Id.pin;
@@ -832,6 +1027,8 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Id.progress_horizontal = global::XFGlossSample.Droid.Resource.Id.progress_horizontal;
 			global::XFGloss.Droid.Resource.Id.radio = global::XFGlossSample.Droid.Resource.Id.radio;
 			global::XFGloss.Droid.Resource.Id.right = global::XFGlossSample.Droid.Resource.Id.right;
+			global::XFGloss.Droid.Resource.Id.right_icon = global::XFGlossSample.Droid.Resource.Id.right_icon;
+			global::XFGloss.Droid.Resource.Id.right_side = global::XFGlossSample.Droid.Resource.Id.right_side;
 			global::XFGloss.Droid.Resource.Id.screen = global::XFGlossSample.Droid.Resource.Id.screen;
 			global::XFGloss.Droid.Resource.Id.scroll = global::XFGlossSample.Droid.Resource.Id.scroll;
 			global::XFGloss.Droid.Resource.Id.scrollIndicatorDown = global::XFGlossSample.Droid.Resource.Id.scrollIndicatorDown;
@@ -853,6 +1050,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Id.showCustom = global::XFGlossSample.Droid.Resource.Id.showCustom;
 			global::XFGloss.Droid.Resource.Id.showHome = global::XFGlossSample.Droid.Resource.Id.showHome;
 			global::XFGloss.Droid.Resource.Id.showTitle = global::XFGlossSample.Droid.Resource.Id.showTitle;
+			global::XFGloss.Droid.Resource.Id.smallLabel = global::XFGlossSample.Droid.Resource.Id.smallLabel;
 			global::XFGloss.Droid.Resource.Id.snackbar_action = global::XFGlossSample.Droid.Resource.Id.snackbar_action;
 			global::XFGloss.Droid.Resource.Id.snackbar_text = global::XFGlossSample.Droid.Resource.Id.snackbar_text;
 			global::XFGloss.Droid.Resource.Id.snap = global::XFGlossSample.Droid.Resource.Id.snap;
@@ -863,32 +1061,43 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Id.src_over = global::XFGlossSample.Droid.Resource.Id.src_over;
 			global::XFGloss.Droid.Resource.Id.start = global::XFGlossSample.Droid.Resource.Id.start;
 			global::XFGloss.Droid.Resource.Id.status_bar_latest_event_content = global::XFGlossSample.Droid.Resource.Id.status_bar_latest_event_content;
+			global::XFGloss.Droid.Resource.Id.submenuarrow = global::XFGlossSample.Droid.Resource.Id.submenuarrow;
 			global::XFGloss.Droid.Resource.Id.submit_area = global::XFGlossSample.Droid.Resource.Id.submit_area;
 			global::XFGloss.Droid.Resource.Id.tabMode = global::XFGlossSample.Droid.Resource.Id.tabMode;
 			global::XFGloss.Droid.Resource.Id.text = global::XFGlossSample.Droid.Resource.Id.text;
 			global::XFGloss.Droid.Resource.Id.text2 = global::XFGlossSample.Droid.Resource.Id.text2;
 			global::XFGloss.Droid.Resource.Id.textSpacerNoButtons = global::XFGlossSample.Droid.Resource.Id.textSpacerNoButtons;
+			global::XFGloss.Droid.Resource.Id.textSpacerNoTitle = global::XFGlossSample.Droid.Resource.Id.textSpacerNoTitle;
+			global::XFGloss.Droid.Resource.Id.text_input_password_toggle = global::XFGlossSample.Droid.Resource.Id.text_input_password_toggle;
+			global::XFGloss.Droid.Resource.Id.textinput_counter = global::XFGlossSample.Droid.Resource.Id.textinput_counter;
+			global::XFGloss.Droid.Resource.Id.textinput_error = global::XFGlossSample.Droid.Resource.Id.textinput_error;
 			global::XFGloss.Droid.Resource.Id.time = global::XFGlossSample.Droid.Resource.Id.time;
 			global::XFGloss.Droid.Resource.Id.title = global::XFGlossSample.Droid.Resource.Id.title;
+			global::XFGloss.Droid.Resource.Id.titleDividerNoCustom = global::XFGlossSample.Droid.Resource.Id.titleDividerNoCustom;
 			global::XFGloss.Droid.Resource.Id.title_template = global::XFGlossSample.Droid.Resource.Id.title_template;
 			global::XFGloss.Droid.Resource.Id.top = global::XFGlossSample.Droid.Resource.Id.top;
 			global::XFGloss.Droid.Resource.Id.topPanel = global::XFGlossSample.Droid.Resource.Id.topPanel;
 			global::XFGloss.Droid.Resource.Id.touch_outside = global::XFGlossSample.Droid.Resource.Id.touch_outside;
+			global::XFGloss.Droid.Resource.Id.transition_current_scene = global::XFGlossSample.Droid.Resource.Id.transition_current_scene;
+			global::XFGloss.Droid.Resource.Id.transition_scene_layoutid_cache = global::XFGlossSample.Droid.Resource.Id.transition_scene_layoutid_cache;
 			global::XFGloss.Droid.Resource.Id.up = global::XFGlossSample.Droid.Resource.Id.up;
 			global::XFGloss.Droid.Resource.Id.useLogo = global::XFGlossSample.Droid.Resource.Id.useLogo;
 			global::XFGloss.Droid.Resource.Id.view_offset_helper = global::XFGlossSample.Droid.Resource.Id.view_offset_helper;
+			global::XFGloss.Droid.Resource.Id.visible = global::XFGlossSample.Droid.Resource.Id.visible;
 			global::XFGloss.Droid.Resource.Id.volume_item_container = global::XFGlossSample.Droid.Resource.Id.volume_item_container;
 			global::XFGloss.Droid.Resource.Id.withText = global::XFGlossSample.Droid.Resource.Id.withText;
 			global::XFGloss.Droid.Resource.Id.wrap_content = global::XFGlossSample.Droid.Resource.Id.wrap_content;
 			global::XFGloss.Droid.Resource.Integer.abc_config_activityDefaultDur = global::XFGlossSample.Droid.Resource.Integer.abc_config_activityDefaultDur;
 			global::XFGloss.Droid.Resource.Integer.abc_config_activityShortDur = global::XFGlossSample.Droid.Resource.Integer.abc_config_activityShortDur;
-			global::XFGloss.Droid.Resource.Integer.abc_max_action_buttons = global::XFGlossSample.Droid.Resource.Integer.abc_max_action_buttons;
+			global::XFGloss.Droid.Resource.Integer.app_bar_elevation_anim_duration = global::XFGlossSample.Droid.Resource.Integer.app_bar_elevation_anim_duration;
 			global::XFGloss.Droid.Resource.Integer.bottom_sheet_slide_duration = global::XFGlossSample.Droid.Resource.Integer.bottom_sheet_slide_duration;
 			global::XFGloss.Droid.Resource.Integer.cancel_button_image_alpha = global::XFGlossSample.Droid.Resource.Integer.cancel_button_image_alpha;
 			global::XFGloss.Droid.Resource.Integer.design_snackbar_text_max_lines = global::XFGlossSample.Droid.Resource.Integer.design_snackbar_text_max_lines;
+			global::XFGloss.Droid.Resource.Integer.hide_password_duration = global::XFGlossSample.Droid.Resource.Integer.hide_password_duration;
 			global::XFGloss.Droid.Resource.Integer.mr_controller_volume_group_list_animation_duration_ms = global::XFGlossSample.Droid.Resource.Integer.mr_controller_volume_group_list_animation_duration_ms;
 			global::XFGloss.Droid.Resource.Integer.mr_controller_volume_group_list_fade_in_duration_ms = global::XFGlossSample.Droid.Resource.Integer.mr_controller_volume_group_list_fade_in_duration_ms;
 			global::XFGloss.Droid.Resource.Integer.mr_controller_volume_group_list_fade_out_duration_ms = global::XFGlossSample.Droid.Resource.Integer.mr_controller_volume_group_list_fade_out_duration_ms;
+			global::XFGloss.Droid.Resource.Integer.show_password_duration = global::XFGlossSample.Droid.Resource.Integer.show_password_duration;
 			global::XFGloss.Droid.Resource.Integer.status_bar_notification_info_maxnum = global::XFGlossSample.Droid.Resource.Integer.status_bar_notification_info_maxnum;
 			global::XFGloss.Droid.Resource.Interpolator.mr_fast_out_slow_in = global::XFGlossSample.Droid.Resource.Interpolator.mr_fast_out_slow_in;
 			global::XFGloss.Droid.Resource.Interpolator.mr_linear_out_slow_in = global::XFGlossSample.Droid.Resource.Interpolator.mr_linear_out_slow_in;
@@ -903,12 +1112,14 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Layout.abc_activity_chooser_view_list_item = global::XFGlossSample.Droid.Resource.Layout.abc_activity_chooser_view_list_item;
 			global::XFGloss.Droid.Resource.Layout.abc_alert_dialog_button_bar_material = global::XFGlossSample.Droid.Resource.Layout.abc_alert_dialog_button_bar_material;
 			global::XFGloss.Droid.Resource.Layout.abc_alert_dialog_material = global::XFGlossSample.Droid.Resource.Layout.abc_alert_dialog_material;
+			global::XFGloss.Droid.Resource.Layout.abc_alert_dialog_title_material = global::XFGlossSample.Droid.Resource.Layout.abc_alert_dialog_title_material;
 			global::XFGloss.Droid.Resource.Layout.abc_dialog_title_material = global::XFGlossSample.Droid.Resource.Layout.abc_dialog_title_material;
 			global::XFGloss.Droid.Resource.Layout.abc_expanded_menu_layout = global::XFGlossSample.Droid.Resource.Layout.abc_expanded_menu_layout;
 			global::XFGloss.Droid.Resource.Layout.abc_list_menu_item_checkbox = global::XFGlossSample.Droid.Resource.Layout.abc_list_menu_item_checkbox;
 			global::XFGloss.Droid.Resource.Layout.abc_list_menu_item_icon = global::XFGlossSample.Droid.Resource.Layout.abc_list_menu_item_icon;
 			global::XFGloss.Droid.Resource.Layout.abc_list_menu_item_layout = global::XFGlossSample.Droid.Resource.Layout.abc_list_menu_item_layout;
 			global::XFGloss.Droid.Resource.Layout.abc_list_menu_item_radio = global::XFGlossSample.Droid.Resource.Layout.abc_list_menu_item_radio;
+			global::XFGloss.Droid.Resource.Layout.abc_popup_menu_header_item_layout = global::XFGlossSample.Droid.Resource.Layout.abc_popup_menu_header_item_layout;
 			global::XFGloss.Droid.Resource.Layout.abc_popup_menu_item_layout = global::XFGlossSample.Droid.Resource.Layout.abc_popup_menu_item_layout;
 			global::XFGloss.Droid.Resource.Layout.abc_screen_content_include = global::XFGlossSample.Droid.Resource.Layout.abc_screen_content_include;
 			global::XFGloss.Droid.Resource.Layout.abc_screen_simple = global::XFGlossSample.Droid.Resource.Layout.abc_screen_simple;
@@ -917,6 +1128,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Layout.abc_search_dropdown_item_icons_2line = global::XFGlossSample.Droid.Resource.Layout.abc_search_dropdown_item_icons_2line;
 			global::XFGloss.Droid.Resource.Layout.abc_search_view = global::XFGlossSample.Droid.Resource.Layout.abc_search_view;
 			global::XFGloss.Droid.Resource.Layout.abc_select_dialog_material = global::XFGlossSample.Droid.Resource.Layout.abc_select_dialog_material;
+			global::XFGloss.Droid.Resource.Layout.design_bottom_navigation_item = global::XFGlossSample.Droid.Resource.Layout.design_bottom_navigation_item;
 			global::XFGloss.Droid.Resource.Layout.design_bottom_sheet_dialog = global::XFGlossSample.Droid.Resource.Layout.design_bottom_sheet_dialog;
 			global::XFGloss.Droid.Resource.Layout.design_layout_snackbar = global::XFGlossSample.Droid.Resource.Layout.design_layout_snackbar;
 			global::XFGloss.Droid.Resource.Layout.design_layout_snackbar_include = global::XFGlossSample.Droid.Resource.Layout.design_layout_snackbar_include;
@@ -929,18 +1141,26 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Layout.design_navigation_item_subheader = global::XFGlossSample.Droid.Resource.Layout.design_navigation_item_subheader;
 			global::XFGloss.Droid.Resource.Layout.design_navigation_menu = global::XFGlossSample.Droid.Resource.Layout.design_navigation_menu;
 			global::XFGloss.Droid.Resource.Layout.design_navigation_menu_item = global::XFGlossSample.Droid.Resource.Layout.design_navigation_menu_item;
+			global::XFGloss.Droid.Resource.Layout.design_text_input_password_icon = global::XFGlossSample.Droid.Resource.Layout.design_text_input_password_icon;
 			global::XFGloss.Droid.Resource.Layout.mr_chooser_dialog = global::XFGlossSample.Droid.Resource.Layout.mr_chooser_dialog;
 			global::XFGloss.Droid.Resource.Layout.mr_chooser_list_item = global::XFGlossSample.Droid.Resource.Layout.mr_chooser_list_item;
 			global::XFGloss.Droid.Resource.Layout.mr_controller_material_dialog_b = global::XFGlossSample.Droid.Resource.Layout.mr_controller_material_dialog_b;
 			global::XFGloss.Droid.Resource.Layout.mr_controller_volume_item = global::XFGlossSample.Droid.Resource.Layout.mr_controller_volume_item;
 			global::XFGloss.Droid.Resource.Layout.mr_playback_control = global::XFGlossSample.Droid.Resource.Layout.mr_playback_control;
 			global::XFGloss.Droid.Resource.Layout.mr_volume_control = global::XFGlossSample.Droid.Resource.Layout.mr_volume_control;
+			global::XFGloss.Droid.Resource.Layout.notification_action = global::XFGlossSample.Droid.Resource.Layout.notification_action;
+			global::XFGloss.Droid.Resource.Layout.notification_action_tombstone = global::XFGlossSample.Droid.Resource.Layout.notification_action_tombstone;
 			global::XFGloss.Droid.Resource.Layout.notification_media_action = global::XFGlossSample.Droid.Resource.Layout.notification_media_action;
 			global::XFGloss.Droid.Resource.Layout.notification_media_cancel_action = global::XFGlossSample.Droid.Resource.Layout.notification_media_cancel_action;
 			global::XFGloss.Droid.Resource.Layout.notification_template_big_media = global::XFGlossSample.Droid.Resource.Layout.notification_template_big_media;
+			global::XFGloss.Droid.Resource.Layout.notification_template_big_media_custom = global::XFGlossSample.Droid.Resource.Layout.notification_template_big_media_custom;
 			global::XFGloss.Droid.Resource.Layout.notification_template_big_media_narrow = global::XFGlossSample.Droid.Resource.Layout.notification_template_big_media_narrow;
-			global::XFGloss.Droid.Resource.Layout.notification_template_lines = global::XFGlossSample.Droid.Resource.Layout.notification_template_lines;
+			global::XFGloss.Droid.Resource.Layout.notification_template_big_media_narrow_custom = global::XFGlossSample.Droid.Resource.Layout.notification_template_big_media_narrow_custom;
+			global::XFGloss.Droid.Resource.Layout.notification_template_custom_big = global::XFGlossSample.Droid.Resource.Layout.notification_template_custom_big;
+			global::XFGloss.Droid.Resource.Layout.notification_template_icon_group = global::XFGlossSample.Droid.Resource.Layout.notification_template_icon_group;
+			global::XFGloss.Droid.Resource.Layout.notification_template_lines_media = global::XFGlossSample.Droid.Resource.Layout.notification_template_lines_media;
 			global::XFGloss.Droid.Resource.Layout.notification_template_media = global::XFGlossSample.Droid.Resource.Layout.notification_template_media;
+			global::XFGloss.Droid.Resource.Layout.notification_template_media_custom = global::XFGlossSample.Droid.Resource.Layout.notification_template_media_custom;
 			global::XFGloss.Droid.Resource.Layout.notification_template_part_chronometer = global::XFGlossSample.Droid.Resource.Layout.notification_template_part_chronometer;
 			global::XFGloss.Droid.Resource.Layout.notification_template_part_time = global::XFGlossSample.Droid.Resource.Layout.notification_template_part_time;
 			global::XFGloss.Droid.Resource.Layout.select_dialog_item_material = global::XFGlossSample.Droid.Resource.Layout.select_dialog_item_material;
@@ -957,6 +1177,18 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.String.abc_activitychooserview_choose_application = global::XFGlossSample.Droid.Resource.String.abc_activitychooserview_choose_application;
 			global::XFGloss.Droid.Resource.String.abc_capital_off = global::XFGlossSample.Droid.Resource.String.abc_capital_off;
 			global::XFGloss.Droid.Resource.String.abc_capital_on = global::XFGlossSample.Droid.Resource.String.abc_capital_on;
+			global::XFGloss.Droid.Resource.String.abc_font_family_body_1_material = global::XFGlossSample.Droid.Resource.String.abc_font_family_body_1_material;
+			global::XFGloss.Droid.Resource.String.abc_font_family_body_2_material = global::XFGlossSample.Droid.Resource.String.abc_font_family_body_2_material;
+			global::XFGloss.Droid.Resource.String.abc_font_family_button_material = global::XFGlossSample.Droid.Resource.String.abc_font_family_button_material;
+			global::XFGloss.Droid.Resource.String.abc_font_family_caption_material = global::XFGlossSample.Droid.Resource.String.abc_font_family_caption_material;
+			global::XFGloss.Droid.Resource.String.abc_font_family_display_1_material = global::XFGlossSample.Droid.Resource.String.abc_font_family_display_1_material;
+			global::XFGloss.Droid.Resource.String.abc_font_family_display_2_material = global::XFGlossSample.Droid.Resource.String.abc_font_family_display_2_material;
+			global::XFGloss.Droid.Resource.String.abc_font_family_display_3_material = global::XFGlossSample.Droid.Resource.String.abc_font_family_display_3_material;
+			global::XFGloss.Droid.Resource.String.abc_font_family_display_4_material = global::XFGlossSample.Droid.Resource.String.abc_font_family_display_4_material;
+			global::XFGloss.Droid.Resource.String.abc_font_family_headline_material = global::XFGlossSample.Droid.Resource.String.abc_font_family_headline_material;
+			global::XFGloss.Droid.Resource.String.abc_font_family_menu_material = global::XFGlossSample.Droid.Resource.String.abc_font_family_menu_material;
+			global::XFGloss.Droid.Resource.String.abc_font_family_subhead_material = global::XFGlossSample.Droid.Resource.String.abc_font_family_subhead_material;
+			global::XFGloss.Droid.Resource.String.abc_font_family_title_material = global::XFGlossSample.Droid.Resource.String.abc_font_family_title_material;
 			global::XFGloss.Droid.Resource.String.abc_search_hint = global::XFGlossSample.Droid.Resource.String.abc_search_hint;
 			global::XFGloss.Droid.Resource.String.abc_searchview_description_clear = global::XFGlossSample.Droid.Resource.String.abc_searchview_description_clear;
 			global::XFGloss.Droid.Resource.String.abc_searchview_description_query = global::XFGlossSample.Droid.Resource.String.abc_searchview_description_query;
@@ -971,8 +1203,12 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.String.character_counter_pattern = global::XFGlossSample.Droid.Resource.String.character_counter_pattern;
 			global::XFGloss.Droid.Resource.String.library_name = global::XFGlossSample.Droid.Resource.String.library_name;
 			global::XFGloss.Droid.Resource.String.mr_button_content_description = global::XFGlossSample.Droid.Resource.String.mr_button_content_description;
+			global::XFGloss.Droid.Resource.String.mr_cast_button_connected = global::XFGlossSample.Droid.Resource.String.mr_cast_button_connected;
+			global::XFGloss.Droid.Resource.String.mr_cast_button_connecting = global::XFGlossSample.Droid.Resource.String.mr_cast_button_connecting;
+			global::XFGloss.Droid.Resource.String.mr_cast_button_disconnected = global::XFGlossSample.Droid.Resource.String.mr_cast_button_disconnected;
 			global::XFGloss.Droid.Resource.String.mr_chooser_searching = global::XFGlossSample.Droid.Resource.String.mr_chooser_searching;
 			global::XFGloss.Droid.Resource.String.mr_chooser_title = global::XFGlossSample.Droid.Resource.String.mr_chooser_title;
+			global::XFGloss.Droid.Resource.String.mr_controller_album_art = global::XFGlossSample.Droid.Resource.String.mr_controller_album_art;
 			global::XFGloss.Droid.Resource.String.mr_controller_casting_screen = global::XFGlossSample.Droid.Resource.String.mr_controller_casting_screen;
 			global::XFGloss.Droid.Resource.String.mr_controller_close_description = global::XFGlossSample.Droid.Resource.String.mr_controller_close_description;
 			global::XFGloss.Droid.Resource.String.mr_controller_collapse_group = global::XFGlossSample.Droid.Resource.String.mr_controller_collapse_group;
@@ -983,8 +1219,16 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.String.mr_controller_pause = global::XFGlossSample.Droid.Resource.String.mr_controller_pause;
 			global::XFGloss.Droid.Resource.String.mr_controller_play = global::XFGlossSample.Droid.Resource.String.mr_controller_play;
 			global::XFGloss.Droid.Resource.String.mr_controller_stop = global::XFGlossSample.Droid.Resource.String.mr_controller_stop;
+			global::XFGloss.Droid.Resource.String.mr_controller_stop_casting = global::XFGlossSample.Droid.Resource.String.mr_controller_stop_casting;
+			global::XFGloss.Droid.Resource.String.mr_controller_volume_slider = global::XFGlossSample.Droid.Resource.String.mr_controller_volume_slider;
 			global::XFGloss.Droid.Resource.String.mr_system_route_name = global::XFGlossSample.Droid.Resource.String.mr_system_route_name;
 			global::XFGloss.Droid.Resource.String.mr_user_route_category_name = global::XFGlossSample.Droid.Resource.String.mr_user_route_category_name;
+			global::XFGloss.Droid.Resource.String.password_toggle_content_description = global::XFGlossSample.Droid.Resource.String.password_toggle_content_description;
+			global::XFGloss.Droid.Resource.String.path_password_eye = global::XFGlossSample.Droid.Resource.String.path_password_eye;
+			global::XFGloss.Droid.Resource.String.path_password_eye_mask_strike_through = global::XFGlossSample.Droid.Resource.String.path_password_eye_mask_strike_through;
+			global::XFGloss.Droid.Resource.String.path_password_eye_mask_visible = global::XFGlossSample.Droid.Resource.String.path_password_eye_mask_visible;
+			global::XFGloss.Droid.Resource.String.path_password_strike_through = global::XFGlossSample.Droid.Resource.String.path_password_strike_through;
+			global::XFGloss.Droid.Resource.String.search_menu_title = global::XFGlossSample.Droid.Resource.String.search_menu_title;
 			global::XFGloss.Droid.Resource.String.status_bar_notification_info_overflow = global::XFGlossSample.Droid.Resource.String.status_bar_notification_info_overflow;
 			global::XFGloss.Droid.Resource.Style.AlertDialog_AppCompat = global::XFGlossSample.Droid.Resource.Style.AlertDialog_AppCompat;
 			global::XFGloss.Droid.Resource.Style.AlertDialog_AppCompat_Light = global::XFGlossSample.Droid.Resource.Style.AlertDialog_AppCompat_Light;
@@ -1033,8 +1277,11 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = global::XFGlossSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle;
 			global::XFGloss.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_ActionMode_Title = global::XFGlossSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_ActionMode_Title;
 			global::XFGloss.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button = global::XFGlossSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button;
+			global::XFGloss.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button_Borderless_Colored = global::XFGlossSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button_Borderless_Colored;
+			global::XFGloss.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button_Colored = global::XFGlossSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button_Colored;
 			global::XFGloss.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button_Inverse = global::XFGlossSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button_Inverse;
 			global::XFGloss.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_DropDownItem = global::XFGlossSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_DropDownItem;
+			global::XFGloss.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_PopupMenu_Header = global::XFGlossSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_PopupMenu_Header;
 			global::XFGloss.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = global::XFGlossSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_PopupMenu_Large;
 			global::XFGloss.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = global::XFGlossSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_PopupMenu_Small;
 			global::XFGloss.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Switch = global::XFGlossSample.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Switch;
@@ -1060,15 +1307,19 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_ActionBar = global::XFGlossSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_ActionBar;
 			global::XFGloss.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dark = global::XFGlossSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dark;
 			global::XFGloss.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dark_ActionBar = global::XFGlossSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dark_ActionBar;
+			global::XFGloss.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog = global::XFGlossSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog;
+			global::XFGloss.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog_Alert = global::XFGlossSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog_Alert;
 			global::XFGloss.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Light = global::XFGlossSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Light;
 			global::XFGloss.Droid.Resource.Style.Base_V11_Theme_AppCompat_Dialog = global::XFGlossSample.Droid.Resource.Style.Base_V11_Theme_AppCompat_Dialog;
 			global::XFGloss.Droid.Resource.Style.Base_V11_Theme_AppCompat_Light_Dialog = global::XFGlossSample.Droid.Resource.Style.Base_V11_Theme_AppCompat_Light_Dialog;
+			global::XFGloss.Droid.Resource.Style.Base_V11_ThemeOverlay_AppCompat_Dialog = global::XFGlossSample.Droid.Resource.Style.Base_V11_ThemeOverlay_AppCompat_Dialog;
 			global::XFGloss.Droid.Resource.Style.Base_V12_Widget_AppCompat_AutoCompleteTextView = global::XFGlossSample.Droid.Resource.Style.Base_V12_Widget_AppCompat_AutoCompleteTextView;
 			global::XFGloss.Droid.Resource.Style.Base_V12_Widget_AppCompat_EditText = global::XFGlossSample.Droid.Resource.Style.Base_V12_Widget_AppCompat_EditText;
 			global::XFGloss.Droid.Resource.Style.Base_V21_Theme_AppCompat = global::XFGlossSample.Droid.Resource.Style.Base_V21_Theme_AppCompat;
 			global::XFGloss.Droid.Resource.Style.Base_V21_Theme_AppCompat_Dialog = global::XFGlossSample.Droid.Resource.Style.Base_V21_Theme_AppCompat_Dialog;
 			global::XFGloss.Droid.Resource.Style.Base_V21_Theme_AppCompat_Light = global::XFGlossSample.Droid.Resource.Style.Base_V21_Theme_AppCompat_Light;
 			global::XFGloss.Droid.Resource.Style.Base_V21_Theme_AppCompat_Light_Dialog = global::XFGlossSample.Droid.Resource.Style.Base_V21_Theme_AppCompat_Light_Dialog;
+			global::XFGloss.Droid.Resource.Style.Base_V21_ThemeOverlay_AppCompat_Dialog = global::XFGlossSample.Droid.Resource.Style.Base_V21_ThemeOverlay_AppCompat_Dialog;
 			global::XFGloss.Droid.Resource.Style.Base_V22_Theme_AppCompat = global::XFGlossSample.Droid.Resource.Style.Base_V22_Theme_AppCompat;
 			global::XFGloss.Droid.Resource.Style.Base_V22_Theme_AppCompat_Light = global::XFGlossSample.Droid.Resource.Style.Base_V22_Theme_AppCompat_Light;
 			global::XFGloss.Droid.Resource.Style.Base_V23_Theme_AppCompat = global::XFGlossSample.Droid.Resource.Style.Base_V23_Theme_AppCompat;
@@ -1077,6 +1328,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Style.Base_V7_Theme_AppCompat_Dialog = global::XFGlossSample.Droid.Resource.Style.Base_V7_Theme_AppCompat_Dialog;
 			global::XFGloss.Droid.Resource.Style.Base_V7_Theme_AppCompat_Light = global::XFGlossSample.Droid.Resource.Style.Base_V7_Theme_AppCompat_Light;
 			global::XFGloss.Droid.Resource.Style.Base_V7_Theme_AppCompat_Light_Dialog = global::XFGlossSample.Droid.Resource.Style.Base_V7_Theme_AppCompat_Light_Dialog;
+			global::XFGloss.Droid.Resource.Style.Base_V7_ThemeOverlay_AppCompat_Dialog = global::XFGlossSample.Droid.Resource.Style.Base_V7_ThemeOverlay_AppCompat_Dialog;
 			global::XFGloss.Droid.Resource.Style.Base_V7_Widget_AppCompat_AutoCompleteTextView = global::XFGlossSample.Droid.Resource.Style.Base_V7_Widget_AppCompat_AutoCompleteTextView;
 			global::XFGloss.Droid.Resource.Style.Base_V7_Widget_AppCompat_EditText = global::XFGlossSample.Droid.Resource.Style.Base_V7_Widget_AppCompat_EditText;
 			global::XFGloss.Droid.Resource.Style.Base_Widget_AppCompat_ActionBar = global::XFGlossSample.Droid.Resource.Style.Base_Widget_AppCompat_ActionBar;
@@ -1114,6 +1366,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Style.Base_Widget_AppCompat_Light_ActionBar_TabView = global::XFGlossSample.Droid.Resource.Style.Base_Widget_AppCompat_Light_ActionBar_TabView;
 			global::XFGloss.Droid.Resource.Style.Base_Widget_AppCompat_Light_PopupMenu = global::XFGlossSample.Droid.Resource.Style.Base_Widget_AppCompat_Light_PopupMenu;
 			global::XFGloss.Droid.Resource.Style.Base_Widget_AppCompat_Light_PopupMenu_Overflow = global::XFGlossSample.Droid.Resource.Style.Base_Widget_AppCompat_Light_PopupMenu_Overflow;
+			global::XFGloss.Droid.Resource.Style.Base_Widget_AppCompat_ListMenuView = global::XFGlossSample.Droid.Resource.Style.Base_Widget_AppCompat_ListMenuView;
 			global::XFGloss.Droid.Resource.Style.Base_Widget_AppCompat_ListPopupWindow = global::XFGlossSample.Droid.Resource.Style.Base_Widget_AppCompat_ListPopupWindow;
 			global::XFGloss.Droid.Resource.Style.Base_Widget_AppCompat_ListView = global::XFGlossSample.Droid.Resource.Style.Base_Widget_AppCompat_ListView;
 			global::XFGloss.Droid.Resource.Style.Base_Widget_AppCompat_ListView_DropDown = global::XFGlossSample.Droid.Resource.Style.Base_Widget_AppCompat_ListView_DropDown;
@@ -1129,11 +1382,13 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Style.Base_Widget_AppCompat_SearchView = global::XFGlossSample.Droid.Resource.Style.Base_Widget_AppCompat_SearchView;
 			global::XFGloss.Droid.Resource.Style.Base_Widget_AppCompat_SearchView_ActionBar = global::XFGlossSample.Droid.Resource.Style.Base_Widget_AppCompat_SearchView_ActionBar;
 			global::XFGloss.Droid.Resource.Style.Base_Widget_AppCompat_SeekBar = global::XFGlossSample.Droid.Resource.Style.Base_Widget_AppCompat_SeekBar;
+			global::XFGloss.Droid.Resource.Style.Base_Widget_AppCompat_SeekBar_Discrete = global::XFGlossSample.Droid.Resource.Style.Base_Widget_AppCompat_SeekBar_Discrete;
 			global::XFGloss.Droid.Resource.Style.Base_Widget_AppCompat_Spinner = global::XFGlossSample.Droid.Resource.Style.Base_Widget_AppCompat_Spinner;
 			global::XFGloss.Droid.Resource.Style.Base_Widget_AppCompat_Spinner_Underlined = global::XFGlossSample.Droid.Resource.Style.Base_Widget_AppCompat_Spinner_Underlined;
 			global::XFGloss.Droid.Resource.Style.Base_Widget_AppCompat_TextView_SpinnerItem = global::XFGlossSample.Droid.Resource.Style.Base_Widget_AppCompat_TextView_SpinnerItem;
 			global::XFGloss.Droid.Resource.Style.Base_Widget_AppCompat_Toolbar = global::XFGlossSample.Droid.Resource.Style.Base_Widget_AppCompat_Toolbar;
 			global::XFGloss.Droid.Resource.Style.Base_Widget_AppCompat_Toolbar_Button_Navigation = global::XFGlossSample.Droid.Resource.Style.Base_Widget_AppCompat_Toolbar_Button_Navigation;
+			global::XFGloss.Droid.Resource.Style.Base_Widget_Design_AppBarLayout = global::XFGlossSample.Droid.Resource.Style.Base_Widget_Design_AppBarLayout;
 			global::XFGloss.Droid.Resource.Style.Base_Widget_Design_TabLayout = global::XFGlossSample.Droid.Resource.Style.Base_Widget_Design_TabLayout;
 			global::XFGloss.Droid.Resource.Style.CardView = global::XFGlossSample.Droid.Resource.Style.CardView;
 			global::XFGloss.Droid.Resource.Style.CardView_Dark = global::XFGlossSample.Droid.Resource.Style.CardView_Dark;
@@ -1147,6 +1402,10 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Style.Platform_V11_AppCompat_Light = global::XFGlossSample.Droid.Resource.Style.Platform_V11_AppCompat_Light;
 			global::XFGloss.Droid.Resource.Style.Platform_V14_AppCompat = global::XFGlossSample.Droid.Resource.Style.Platform_V14_AppCompat;
 			global::XFGloss.Droid.Resource.Style.Platform_V14_AppCompat_Light = global::XFGlossSample.Droid.Resource.Style.Platform_V14_AppCompat_Light;
+			global::XFGloss.Droid.Resource.Style.Platform_V21_AppCompat = global::XFGlossSample.Droid.Resource.Style.Platform_V21_AppCompat;
+			global::XFGloss.Droid.Resource.Style.Platform_V21_AppCompat_Light = global::XFGlossSample.Droid.Resource.Style.Platform_V21_AppCompat_Light;
+			global::XFGloss.Droid.Resource.Style.Platform_V25_AppCompat = global::XFGlossSample.Droid.Resource.Style.Platform_V25_AppCompat;
+			global::XFGloss.Droid.Resource.Style.Platform_V25_AppCompat_Light = global::XFGlossSample.Droid.Resource.Style.Platform_V25_AppCompat_Light;
 			global::XFGloss.Droid.Resource.Style.Platform_Widget_AppCompat_Spinner = global::XFGlossSample.Droid.Resource.Style.Platform_Widget_AppCompat_Spinner;
 			global::XFGloss.Droid.Resource.Style.RtlOverlay_DialogWindowTitle_AppCompat = global::XFGlossSample.Droid.Resource.Style.RtlOverlay_DialogWindowTitle_AppCompat;
 			global::XFGloss.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = global::XFGlossSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_ActionBar_TitleItem;
@@ -1182,6 +1441,16 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Medium = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Medium;
 			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Medium_Inverse = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Medium_Inverse;
 			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Menu = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Menu;
+			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Notification = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification;
+			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Info = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Info;
+			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Info_Media = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Info_Media;
+			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Line2 = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Line2;
+			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Line2_Media = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Line2_Media;
+			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Media = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Media;
+			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Time = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Time;
+			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Time_Media = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Time_Media;
+			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Title = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Title;
+			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Title_Media = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Title_Media;
 			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_SearchResult_Subtitle = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_SearchResult_Subtitle;
 			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_SearchResult_Title = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_SearchResult_Title;
 			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Small = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Small;
@@ -1200,8 +1469,11 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Widget_ActionMode_Title = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_ActionMode_Title;
 			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse;
 			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button;
+			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button_Borderless_Colored = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button_Borderless_Colored;
+			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button_Colored = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button_Colored;
 			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button_Inverse = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button_Inverse;
 			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Widget_DropDownItem = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_DropDownItem;
+			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Widget_PopupMenu_Header = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_PopupMenu_Header;
 			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Widget_PopupMenu_Large = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_PopupMenu_Large;
 			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Widget_PopupMenu_Small = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_PopupMenu_Small;
 			global::XFGloss.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Switch = global::XFGlossSample.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Switch;
@@ -1213,6 +1485,9 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Style.TextAppearance_Design_Hint = global::XFGlossSample.Droid.Resource.Style.TextAppearance_Design_Hint;
 			global::XFGloss.Droid.Resource.Style.TextAppearance_Design_Snackbar_Message = global::XFGlossSample.Droid.Resource.Style.TextAppearance_Design_Snackbar_Message;
 			global::XFGloss.Droid.Resource.Style.TextAppearance_Design_Tab = global::XFGlossSample.Droid.Resource.Style.TextAppearance_Design_Tab;
+			global::XFGloss.Droid.Resource.Style.TextAppearance_MediaRouter_PrimaryText = global::XFGlossSample.Droid.Resource.Style.TextAppearance_MediaRouter_PrimaryText;
+			global::XFGloss.Droid.Resource.Style.TextAppearance_MediaRouter_SecondaryText = global::XFGlossSample.Droid.Resource.Style.TextAppearance_MediaRouter_SecondaryText;
+			global::XFGloss.Droid.Resource.Style.TextAppearance_MediaRouter_Title = global::XFGlossSample.Droid.Resource.Style.TextAppearance_MediaRouter_Title;
 			global::XFGloss.Droid.Resource.Style.TextAppearance_StatusBar_EventContent = global::XFGlossSample.Droid.Resource.Style.TextAppearance_StatusBar_EventContent;
 			global::XFGloss.Droid.Resource.Style.TextAppearance_StatusBar_EventContent_Info = global::XFGlossSample.Droid.Resource.Style.TextAppearance_StatusBar_EventContent_Info;
 			global::XFGloss.Droid.Resource.Style.TextAppearance_StatusBar_EventContent_Line2 = global::XFGlossSample.Droid.Resource.Style.TextAppearance_StatusBar_EventContent_Line2;
@@ -1256,7 +1531,11 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Style.ThemeOverlay_AppCompat_ActionBar = global::XFGlossSample.Droid.Resource.Style.ThemeOverlay_AppCompat_ActionBar;
 			global::XFGloss.Droid.Resource.Style.ThemeOverlay_AppCompat_Dark = global::XFGlossSample.Droid.Resource.Style.ThemeOverlay_AppCompat_Dark;
 			global::XFGloss.Droid.Resource.Style.ThemeOverlay_AppCompat_Dark_ActionBar = global::XFGlossSample.Droid.Resource.Style.ThemeOverlay_AppCompat_Dark_ActionBar;
+			global::XFGloss.Droid.Resource.Style.ThemeOverlay_AppCompat_Dialog = global::XFGlossSample.Droid.Resource.Style.ThemeOverlay_AppCompat_Dialog;
+			global::XFGloss.Droid.Resource.Style.ThemeOverlay_AppCompat_Dialog_Alert = global::XFGlossSample.Droid.Resource.Style.ThemeOverlay_AppCompat_Dialog_Alert;
 			global::XFGloss.Droid.Resource.Style.ThemeOverlay_AppCompat_Light = global::XFGlossSample.Droid.Resource.Style.ThemeOverlay_AppCompat_Light;
+			global::XFGloss.Droid.Resource.Style.ThemeOverlay_MediaRouter_Dark = global::XFGlossSample.Droid.Resource.Style.ThemeOverlay_MediaRouter_Dark;
+			global::XFGloss.Droid.Resource.Style.ThemeOverlay_MediaRouter_Light = global::XFGlossSample.Droid.Resource.Style.ThemeOverlay_MediaRouter_Light;
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_ActionBar = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_ActionBar;
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_ActionBar_Solid = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_ActionBar_Solid;
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_ActionBar_TabBar = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_ActionBar_TabBar;
@@ -1305,10 +1584,13 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_Light_PopupMenu_Overflow = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_Light_PopupMenu_Overflow;
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_Light_SearchView = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_Light_SearchView;
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_Light_Spinner_DropDown_ActionBar = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_Light_Spinner_DropDown_ActionBar;
+			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_ListMenuView = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_ListMenuView;
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_ListPopupWindow = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_ListPopupWindow;
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_ListView = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_ListView;
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_ListView_DropDown = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_ListView_DropDown;
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_ListView_Menu = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_ListView_Menu;
+			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_NotificationActionContainer = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_NotificationActionContainer;
+			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_NotificationActionText = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_NotificationActionText;
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_PopupMenu = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_PopupMenu;
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_PopupMenu_Overflow = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_PopupMenu_Overflow;
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_PopupWindow = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_PopupWindow;
@@ -1320,6 +1602,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_SearchView = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_SearchView;
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_SearchView_ActionBar = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_SearchView_ActionBar;
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_SeekBar = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_SeekBar;
+			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_SeekBar_Discrete = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_SeekBar_Discrete;
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_Spinner = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_Spinner;
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_Spinner_DropDown = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_Spinner_DropDown;
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_Spinner_DropDown_ActionBar = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_Spinner_DropDown_ActionBar;
@@ -1328,6 +1611,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_Toolbar = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_Toolbar;
 			global::XFGloss.Droid.Resource.Style.Widget_AppCompat_Toolbar_Button_Navigation = global::XFGlossSample.Droid.Resource.Style.Widget_AppCompat_Toolbar_Button_Navigation;
 			global::XFGloss.Droid.Resource.Style.Widget_Design_AppBarLayout = global::XFGlossSample.Droid.Resource.Style.Widget_Design_AppBarLayout;
+			global::XFGloss.Droid.Resource.Style.Widget_Design_BottomNavigationView = global::XFGlossSample.Droid.Resource.Style.Widget_Design_BottomNavigationView;
 			global::XFGloss.Droid.Resource.Style.Widget_Design_BottomSheet_Modal = global::XFGlossSample.Droid.Resource.Style.Widget_Design_BottomSheet_Modal;
 			global::XFGloss.Droid.Resource.Style.Widget_Design_CollapsingToolbar = global::XFGlossSample.Droid.Resource.Style.Widget_Design_CollapsingToolbar;
 			global::XFGloss.Droid.Resource.Style.Widget_Design_CoordinatorLayout = global::XFGlossSample.Droid.Resource.Style.Widget_Design_CoordinatorLayout;
@@ -1337,23 +1621,6 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Style.Widget_Design_Snackbar = global::XFGlossSample.Droid.Resource.Style.Widget_Design_Snackbar;
 			global::XFGloss.Droid.Resource.Style.Widget_Design_TabLayout = global::XFGlossSample.Droid.Resource.Style.Widget_Design_TabLayout;
 			global::XFGloss.Droid.Resource.Style.Widget_Design_TextInputLayout = global::XFGlossSample.Droid.Resource.Style.Widget_Design_TextInputLayout;
-			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_ChooserText = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_ChooserText;
-			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Primary = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Primary;
-			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Primary_Dark = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Primary_Dark;
-			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Primary_Light = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Primary_Light;
-			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Secondary = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Secondary;
-			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Secondary_Dark = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Secondary_Dark;
-			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Secondary_Light = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_ChooserText_Secondary_Light;
-			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_ControllerText = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText;
-			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Primary = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Primary;
-			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Primary_Dark = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Primary_Dark;
-			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Primary_Light = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Primary_Light;
-			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Secondary = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Secondary;
-			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Secondary_Dark = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Secondary_Dark;
-			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Secondary_Light = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Secondary_Light;
-			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Title = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Title;
-			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Title_Dark = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Title_Dark;
-			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Title_Light = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_ControllerText_Title_Light;
 			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_Light_MediaRouteButton = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_Light_MediaRouteButton;
 			global::XFGloss.Droid.Resource.Style.Widget_MediaRouter_MediaRouteButton = global::XFGlossSample.Droid.Resource.Style.Widget_MediaRouter_MediaRouteButton;
 			global::XFGloss.Droid.Resource.Styleable.ActionBar = global::XFGlossSample.Droid.Resource.Styleable.ActionBar;
@@ -1361,9 +1628,11 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Styleable.ActionBar_backgroundSplit = global::XFGlossSample.Droid.Resource.Styleable.ActionBar_backgroundSplit;
 			global::XFGloss.Droid.Resource.Styleable.ActionBar_backgroundStacked = global::XFGlossSample.Droid.Resource.Styleable.ActionBar_backgroundStacked;
 			global::XFGloss.Droid.Resource.Styleable.ActionBar_contentInsetEnd = global::XFGlossSample.Droid.Resource.Styleable.ActionBar_contentInsetEnd;
+			global::XFGloss.Droid.Resource.Styleable.ActionBar_contentInsetEndWithActions = global::XFGlossSample.Droid.Resource.Styleable.ActionBar_contentInsetEndWithActions;
 			global::XFGloss.Droid.Resource.Styleable.ActionBar_contentInsetLeft = global::XFGlossSample.Droid.Resource.Styleable.ActionBar_contentInsetLeft;
 			global::XFGloss.Droid.Resource.Styleable.ActionBar_contentInsetRight = global::XFGlossSample.Droid.Resource.Styleable.ActionBar_contentInsetRight;
 			global::XFGloss.Droid.Resource.Styleable.ActionBar_contentInsetStart = global::XFGlossSample.Droid.Resource.Styleable.ActionBar_contentInsetStart;
+			global::XFGloss.Droid.Resource.Styleable.ActionBar_contentInsetStartWithNavigation = global::XFGlossSample.Droid.Resource.Styleable.ActionBar_contentInsetStartWithNavigation;
 			global::XFGloss.Droid.Resource.Styleable.ActionBar_customNavigationLayout = global::XFGlossSample.Droid.Resource.Styleable.ActionBar_customNavigationLayout;
 			global::XFGloss.Droid.Resource.Styleable.ActionBar_displayOptions = global::XFGlossSample.Droid.Resource.Styleable.ActionBar_displayOptions;
 			global::XFGloss.Droid.Resource.Styleable.ActionBar_divider = global::XFGlossSample.Droid.Resource.Styleable.ActionBar_divider;
@@ -1405,17 +1674,34 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Styleable.AlertDialog_listItemLayout = global::XFGlossSample.Droid.Resource.Styleable.AlertDialog_listItemLayout;
 			global::XFGloss.Droid.Resource.Styleable.AlertDialog_listLayout = global::XFGlossSample.Droid.Resource.Styleable.AlertDialog_listLayout;
 			global::XFGloss.Droid.Resource.Styleable.AlertDialog_multiChoiceItemLayout = global::XFGlossSample.Droid.Resource.Styleable.AlertDialog_multiChoiceItemLayout;
+			global::XFGloss.Droid.Resource.Styleable.AlertDialog_showTitle = global::XFGlossSample.Droid.Resource.Styleable.AlertDialog_showTitle;
 			global::XFGloss.Droid.Resource.Styleable.AlertDialog_singleChoiceItemLayout = global::XFGlossSample.Droid.Resource.Styleable.AlertDialog_singleChoiceItemLayout;
 			global::XFGloss.Droid.Resource.Styleable.AppBarLayout = global::XFGlossSample.Droid.Resource.Styleable.AppBarLayout;
 			global::XFGloss.Droid.Resource.Styleable.AppBarLayout_android_background = global::XFGlossSample.Droid.Resource.Styleable.AppBarLayout_android_background;
 			global::XFGloss.Droid.Resource.Styleable.AppBarLayout_elevation = global::XFGlossSample.Droid.Resource.Styleable.AppBarLayout_elevation;
 			global::XFGloss.Droid.Resource.Styleable.AppBarLayout_expanded = global::XFGlossSample.Droid.Resource.Styleable.AppBarLayout_expanded;
-			global::XFGloss.Droid.Resource.Styleable.AppBarLayout_LayoutParams = global::XFGlossSample.Droid.Resource.Styleable.AppBarLayout_LayoutParams;
-			global::XFGloss.Droid.Resource.Styleable.AppBarLayout_LayoutParams_layout_scrollFlags = global::XFGlossSample.Droid.Resource.Styleable.AppBarLayout_LayoutParams_layout_scrollFlags;
-			global::XFGloss.Droid.Resource.Styleable.AppBarLayout_LayoutParams_layout_scrollInterpolator = global::XFGlossSample.Droid.Resource.Styleable.AppBarLayout_LayoutParams_layout_scrollInterpolator;
+			global::XFGloss.Droid.Resource.Styleable.AppBarLayoutStates = global::XFGlossSample.Droid.Resource.Styleable.AppBarLayoutStates;
+			global::XFGloss.Droid.Resource.Styleable.AppBarLayoutStates_state_collapsed = global::XFGlossSample.Droid.Resource.Styleable.AppBarLayoutStates_state_collapsed;
+			global::XFGloss.Droid.Resource.Styleable.AppBarLayoutStates_state_collapsible = global::XFGlossSample.Droid.Resource.Styleable.AppBarLayoutStates_state_collapsible;
+			global::XFGloss.Droid.Resource.Styleable.AppBarLayout_Layout = global::XFGlossSample.Droid.Resource.Styleable.AppBarLayout_Layout;
+			global::XFGloss.Droid.Resource.Styleable.AppBarLayout_Layout_layout_scrollFlags = global::XFGlossSample.Droid.Resource.Styleable.AppBarLayout_Layout_layout_scrollFlags;
+			global::XFGloss.Droid.Resource.Styleable.AppBarLayout_Layout_layout_scrollInterpolator = global::XFGlossSample.Droid.Resource.Styleable.AppBarLayout_Layout_layout_scrollInterpolator;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatImageView = global::XFGlossSample.Droid.Resource.Styleable.AppCompatImageView;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatImageView_android_src = global::XFGlossSample.Droid.Resource.Styleable.AppCompatImageView_android_src;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatImageView_srcCompat = global::XFGlossSample.Droid.Resource.Styleable.AppCompatImageView_srcCompat;
+			global::XFGloss.Droid.Resource.Styleable.AppCompatSeekBar = global::XFGlossSample.Droid.Resource.Styleable.AppCompatSeekBar;
+			global::XFGloss.Droid.Resource.Styleable.AppCompatSeekBar_android_thumb = global::XFGlossSample.Droid.Resource.Styleable.AppCompatSeekBar_android_thumb;
+			global::XFGloss.Droid.Resource.Styleable.AppCompatSeekBar_tickMark = global::XFGlossSample.Droid.Resource.Styleable.AppCompatSeekBar_tickMark;
+			global::XFGloss.Droid.Resource.Styleable.AppCompatSeekBar_tickMarkTint = global::XFGlossSample.Droid.Resource.Styleable.AppCompatSeekBar_tickMarkTint;
+			global::XFGloss.Droid.Resource.Styleable.AppCompatSeekBar_tickMarkTintMode = global::XFGlossSample.Droid.Resource.Styleable.AppCompatSeekBar_tickMarkTintMode;
+			global::XFGloss.Droid.Resource.Styleable.AppCompatTextHelper = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTextHelper;
+			global::XFGloss.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableBottom = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableBottom;
+			global::XFGloss.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableEnd = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableEnd;
+			global::XFGloss.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableLeft = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableLeft;
+			global::XFGloss.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableRight = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableRight;
+			global::XFGloss.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableStart = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableStart;
+			global::XFGloss.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableTop = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableTop;
+			global::XFGloss.Droid.Resource.Styleable.AppCompatTextHelper_android_textAppearance = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTextHelper_android_textAppearance;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTextView = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTextView;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTextView_android_textAppearance = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTextView_android_textAppearance;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTextView_textAllCaps = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTextView_textAllCaps;
@@ -1469,6 +1755,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_checkboxStyle = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_checkboxStyle;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_checkedTextViewStyle = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_checkedTextViewStyle;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_colorAccent = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_colorAccent;
+			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_colorBackgroundFloating = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_colorBackgroundFloating;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_colorButtonNormal = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_colorButtonNormal;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_colorControlActivated = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_colorControlActivated;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_colorControlHighlight = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_colorControlHighlight;
@@ -1490,6 +1777,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_imageButtonStyle = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_imageButtonStyle;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_listChoiceBackgroundIndicator = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_listChoiceBackgroundIndicator;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_listDividerAlertDialog = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_listDividerAlertDialog;
+			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_listMenuViewStyle = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_listMenuViewStyle;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_listPopupWindowStyle = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_listPopupWindowStyle;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_listPreferredItemHeight = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_listPreferredItemHeight;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_listPreferredItemHeightLarge = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_listPreferredItemHeightLarge;
@@ -1515,6 +1803,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_textAppearanceLargePopupMenu = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_textAppearanceLargePopupMenu;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_textAppearanceListItem = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_textAppearanceListItem;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_textAppearanceListItemSmall = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_textAppearanceListItemSmall;
+			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_textAppearancePopupMenuHeader = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_textAppearancePopupMenuHeader;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_textAppearanceSearchResultSubtitle = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_textAppearanceSearchResultSubtitle;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_textAppearanceSearchResultTitle = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_textAppearanceSearchResultTitle;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_textAppearanceSmallPopupMenu = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_textAppearanceSmallPopupMenu;
@@ -1532,9 +1821,16 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_windowMinWidthMajor = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_windowMinWidthMajor;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_windowMinWidthMinor = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_windowMinWidthMinor;
 			global::XFGloss.Droid.Resource.Styleable.AppCompatTheme_windowNoTitle = global::XFGlossSample.Droid.Resource.Styleable.AppCompatTheme_windowNoTitle;
-			global::XFGloss.Droid.Resource.Styleable.BottomSheetBehavior_Params = global::XFGlossSample.Droid.Resource.Styleable.BottomSheetBehavior_Params;
-			global::XFGloss.Droid.Resource.Styleable.BottomSheetBehavior_Params_behavior_hideable = global::XFGlossSample.Droid.Resource.Styleable.BottomSheetBehavior_Params_behavior_hideable;
-			global::XFGloss.Droid.Resource.Styleable.BottomSheetBehavior_Params_behavior_peekHeight = global::XFGlossSample.Droid.Resource.Styleable.BottomSheetBehavior_Params_behavior_peekHeight;
+			global::XFGloss.Droid.Resource.Styleable.BottomNavigationView = global::XFGlossSample.Droid.Resource.Styleable.BottomNavigationView;
+			global::XFGloss.Droid.Resource.Styleable.BottomNavigationView_elevation = global::XFGlossSample.Droid.Resource.Styleable.BottomNavigationView_elevation;
+			global::XFGloss.Droid.Resource.Styleable.BottomNavigationView_itemBackground = global::XFGlossSample.Droid.Resource.Styleable.BottomNavigationView_itemBackground;
+			global::XFGloss.Droid.Resource.Styleable.BottomNavigationView_itemIconTint = global::XFGlossSample.Droid.Resource.Styleable.BottomNavigationView_itemIconTint;
+			global::XFGloss.Droid.Resource.Styleable.BottomNavigationView_itemTextColor = global::XFGlossSample.Droid.Resource.Styleable.BottomNavigationView_itemTextColor;
+			global::XFGloss.Droid.Resource.Styleable.BottomNavigationView_menu = global::XFGlossSample.Droid.Resource.Styleable.BottomNavigationView_menu;
+			global::XFGloss.Droid.Resource.Styleable.BottomSheetBehavior_Layout = global::XFGlossSample.Droid.Resource.Styleable.BottomSheetBehavior_Layout;
+			global::XFGloss.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_hideable = global::XFGlossSample.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_hideable;
+			global::XFGloss.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_peekHeight = global::XFGlossSample.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_peekHeight;
+			global::XFGloss.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_skipCollapsed = global::XFGlossSample.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_skipCollapsed;
 			global::XFGloss.Droid.Resource.Styleable.ButtonBarLayout = global::XFGlossSample.Droid.Resource.Styleable.ButtonBarLayout;
 			global::XFGloss.Droid.Resource.Styleable.ButtonBarLayout_allowStacking = global::XFGlossSample.Droid.Resource.Styleable.ButtonBarLayout_allowStacking;
 			global::XFGloss.Droid.Resource.Styleable.CardView = global::XFGlossSample.Droid.Resource.Styleable.CardView;
@@ -1551,9 +1847,6 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Styleable.CardView_contentPaddingLeft = global::XFGlossSample.Droid.Resource.Styleable.CardView_contentPaddingLeft;
 			global::XFGloss.Droid.Resource.Styleable.CardView_contentPaddingRight = global::XFGlossSample.Droid.Resource.Styleable.CardView_contentPaddingRight;
 			global::XFGloss.Droid.Resource.Styleable.CardView_contentPaddingTop = global::XFGlossSample.Droid.Resource.Styleable.CardView_contentPaddingTop;
-			global::XFGloss.Droid.Resource.Styleable.CollapsingAppBarLayout_LayoutParams = global::XFGlossSample.Droid.Resource.Styleable.CollapsingAppBarLayout_LayoutParams;
-			global::XFGloss.Droid.Resource.Styleable.CollapsingAppBarLayout_LayoutParams_layout_collapseMode = global::XFGlossSample.Droid.Resource.Styleable.CollapsingAppBarLayout_LayoutParams_layout_collapseMode;
-			global::XFGloss.Droid.Resource.Styleable.CollapsingAppBarLayout_LayoutParams_layout_collapseParallaxMultiplier = global::XFGlossSample.Droid.Resource.Styleable.CollapsingAppBarLayout_LayoutParams_layout_collapseParallaxMultiplier;
 			global::XFGloss.Droid.Resource.Styleable.CollapsingToolbarLayout = global::XFGlossSample.Droid.Resource.Styleable.CollapsingToolbarLayout;
 			global::XFGloss.Droid.Resource.Styleable.CollapsingToolbarLayout_collapsedTitleGravity = global::XFGlossSample.Droid.Resource.Styleable.CollapsingToolbarLayout_collapsedTitleGravity;
 			global::XFGloss.Droid.Resource.Styleable.CollapsingToolbarLayout_collapsedTitleTextAppearance = global::XFGlossSample.Droid.Resource.Styleable.CollapsingToolbarLayout_collapsedTitleTextAppearance;
@@ -1565,10 +1858,19 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Styleable.CollapsingToolbarLayout_expandedTitleMarginStart = global::XFGlossSample.Droid.Resource.Styleable.CollapsingToolbarLayout_expandedTitleMarginStart;
 			global::XFGloss.Droid.Resource.Styleable.CollapsingToolbarLayout_expandedTitleMarginTop = global::XFGlossSample.Droid.Resource.Styleable.CollapsingToolbarLayout_expandedTitleMarginTop;
 			global::XFGloss.Droid.Resource.Styleable.CollapsingToolbarLayout_expandedTitleTextAppearance = global::XFGlossSample.Droid.Resource.Styleable.CollapsingToolbarLayout_expandedTitleTextAppearance;
+			global::XFGloss.Droid.Resource.Styleable.CollapsingToolbarLayout_scrimAnimationDuration = global::XFGlossSample.Droid.Resource.Styleable.CollapsingToolbarLayout_scrimAnimationDuration;
+			global::XFGloss.Droid.Resource.Styleable.CollapsingToolbarLayout_scrimVisibleHeightTrigger = global::XFGlossSample.Droid.Resource.Styleable.CollapsingToolbarLayout_scrimVisibleHeightTrigger;
 			global::XFGloss.Droid.Resource.Styleable.CollapsingToolbarLayout_statusBarScrim = global::XFGlossSample.Droid.Resource.Styleable.CollapsingToolbarLayout_statusBarScrim;
 			global::XFGloss.Droid.Resource.Styleable.CollapsingToolbarLayout_title = global::XFGlossSample.Droid.Resource.Styleable.CollapsingToolbarLayout_title;
 			global::XFGloss.Droid.Resource.Styleable.CollapsingToolbarLayout_titleEnabled = global::XFGlossSample.Droid.Resource.Styleable.CollapsingToolbarLayout_titleEnabled;
 			global::XFGloss.Droid.Resource.Styleable.CollapsingToolbarLayout_toolbarId = global::XFGlossSample.Droid.Resource.Styleable.CollapsingToolbarLayout_toolbarId;
+			global::XFGloss.Droid.Resource.Styleable.CollapsingToolbarLayout_Layout = global::XFGlossSample.Droid.Resource.Styleable.CollapsingToolbarLayout_Layout;
+			global::XFGloss.Droid.Resource.Styleable.CollapsingToolbarLayout_Layout_layout_collapseMode = global::XFGlossSample.Droid.Resource.Styleable.CollapsingToolbarLayout_Layout_layout_collapseMode;
+			global::XFGloss.Droid.Resource.Styleable.CollapsingToolbarLayout_Layout_layout_collapseParallaxMultiplier = global::XFGlossSample.Droid.Resource.Styleable.CollapsingToolbarLayout_Layout_layout_collapseParallaxMultiplier;
+			global::XFGloss.Droid.Resource.Styleable.ColorStateListItem = global::XFGlossSample.Droid.Resource.Styleable.ColorStateListItem;
+			global::XFGloss.Droid.Resource.Styleable.ColorStateListItem_alpha = global::XFGlossSample.Droid.Resource.Styleable.ColorStateListItem_alpha;
+			global::XFGloss.Droid.Resource.Styleable.ColorStateListItem_android_alpha = global::XFGlossSample.Droid.Resource.Styleable.ColorStateListItem_android_alpha;
+			global::XFGloss.Droid.Resource.Styleable.ColorStateListItem_android_color = global::XFGlossSample.Droid.Resource.Styleable.ColorStateListItem_android_color;
 			global::XFGloss.Droid.Resource.Styleable.CompoundButton = global::XFGlossSample.Droid.Resource.Styleable.CompoundButton;
 			global::XFGloss.Droid.Resource.Styleable.CompoundButton_android_button = global::XFGlossSample.Droid.Resource.Styleable.CompoundButton_android_button;
 			global::XFGloss.Droid.Resource.Styleable.CompoundButton_buttonTint = global::XFGlossSample.Droid.Resource.Styleable.CompoundButton_buttonTint;
@@ -1576,12 +1878,14 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Styleable.CoordinatorLayout = global::XFGlossSample.Droid.Resource.Styleable.CoordinatorLayout;
 			global::XFGloss.Droid.Resource.Styleable.CoordinatorLayout_keylines = global::XFGlossSample.Droid.Resource.Styleable.CoordinatorLayout_keylines;
 			global::XFGloss.Droid.Resource.Styleable.CoordinatorLayout_statusBarBackground = global::XFGlossSample.Droid.Resource.Styleable.CoordinatorLayout_statusBarBackground;
-			global::XFGloss.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams = global::XFGlossSample.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams;
-			global::XFGloss.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_android_layout_gravity = global::XFGlossSample.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_android_layout_gravity;
-			global::XFGloss.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_layout_anchor = global::XFGlossSample.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_layout_anchor;
-			global::XFGloss.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_layout_anchorGravity = global::XFGlossSample.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_layout_anchorGravity;
-			global::XFGloss.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_layout_behavior = global::XFGlossSample.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_layout_behavior;
-			global::XFGloss.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_layout_keyline = global::XFGlossSample.Droid.Resource.Styleable.CoordinatorLayout_LayoutParams_layout_keyline;
+			global::XFGloss.Droid.Resource.Styleable.CoordinatorLayout_Layout = global::XFGlossSample.Droid.Resource.Styleable.CoordinatorLayout_Layout;
+			global::XFGloss.Droid.Resource.Styleable.CoordinatorLayout_Layout_android_layout_gravity = global::XFGlossSample.Droid.Resource.Styleable.CoordinatorLayout_Layout_android_layout_gravity;
+			global::XFGloss.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_anchor = global::XFGlossSample.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_anchor;
+			global::XFGloss.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_anchorGravity = global::XFGlossSample.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_anchorGravity;
+			global::XFGloss.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_behavior = global::XFGlossSample.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_behavior;
+			global::XFGloss.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_dodgeInsetEdges = global::XFGlossSample.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_dodgeInsetEdges;
+			global::XFGloss.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_insetEdge = global::XFGlossSample.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_insetEdge;
+			global::XFGloss.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_keyline = global::XFGlossSample.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_keyline;
 			global::XFGloss.Droid.Resource.Styleable.DesignTheme = global::XFGlossSample.Droid.Resource.Styleable.DesignTheme;
 			global::XFGloss.Droid.Resource.Styleable.DesignTheme_bottomSheetDialogTheme = global::XFGlossSample.Droid.Resource.Styleable.DesignTheme_bottomSheetDialogTheme;
 			global::XFGloss.Droid.Resource.Styleable.DesignTheme_bottomSheetStyle = global::XFGlossSample.Droid.Resource.Styleable.DesignTheme_bottomSheetStyle;
@@ -1604,6 +1908,8 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Styleable.FloatingActionButton_pressedTranslationZ = global::XFGlossSample.Droid.Resource.Styleable.FloatingActionButton_pressedTranslationZ;
 			global::XFGloss.Droid.Resource.Styleable.FloatingActionButton_rippleColor = global::XFGlossSample.Droid.Resource.Styleable.FloatingActionButton_rippleColor;
 			global::XFGloss.Droid.Resource.Styleable.FloatingActionButton_useCompatPadding = global::XFGlossSample.Droid.Resource.Styleable.FloatingActionButton_useCompatPadding;
+			global::XFGloss.Droid.Resource.Styleable.FloatingActionButton_Behavior_Layout = global::XFGlossSample.Droid.Resource.Styleable.FloatingActionButton_Behavior_Layout;
+			global::XFGloss.Droid.Resource.Styleable.FloatingActionButton_Behavior_Layout_behavior_autoHide = global::XFGlossSample.Droid.Resource.Styleable.FloatingActionButton_Behavior_Layout_behavior_autoHide;
 			global::XFGloss.Droid.Resource.Styleable.ForegroundLinearLayout = global::XFGlossSample.Droid.Resource.Styleable.ForegroundLinearLayout;
 			global::XFGloss.Droid.Resource.Styleable.ForegroundLinearLayout_android_foreground = global::XFGlossSample.Droid.Resource.Styleable.ForegroundLinearLayout_android_foreground;
 			global::XFGloss.Droid.Resource.Styleable.ForegroundLinearLayout_android_foregroundGravity = global::XFGlossSample.Droid.Resource.Styleable.ForegroundLinearLayout_android_foregroundGravity;
@@ -1629,6 +1935,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Styleable.MediaRouteButton = global::XFGlossSample.Droid.Resource.Styleable.MediaRouteButton;
 			global::XFGloss.Droid.Resource.Styleable.MediaRouteButton_android_minHeight = global::XFGlossSample.Droid.Resource.Styleable.MediaRouteButton_android_minHeight;
 			global::XFGloss.Droid.Resource.Styleable.MediaRouteButton_android_minWidth = global::XFGlossSample.Droid.Resource.Styleable.MediaRouteButton_android_minWidth;
+			global::XFGloss.Droid.Resource.Styleable.MediaRouteButton_buttonTint = global::XFGlossSample.Droid.Resource.Styleable.MediaRouteButton_buttonTint;
 			global::XFGloss.Droid.Resource.Styleable.MediaRouteButton_externalRouteEnabledDrawable = global::XFGlossSample.Droid.Resource.Styleable.MediaRouteButton_externalRouteEnabledDrawable;
 			global::XFGloss.Droid.Resource.Styleable.MenuGroup = global::XFGlossSample.Droid.Resource.Styleable.MenuGroup;
 			global::XFGloss.Droid.Resource.Styleable.MenuGroup_android_checkableBehavior = global::XFGlossSample.Droid.Resource.Styleable.MenuGroup_android_checkableBehavior;
@@ -1664,6 +1971,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Styleable.MenuView_android_verticalDivider = global::XFGlossSample.Droid.Resource.Styleable.MenuView_android_verticalDivider;
 			global::XFGloss.Droid.Resource.Styleable.MenuView_android_windowAnimationStyle = global::XFGlossSample.Droid.Resource.Styleable.MenuView_android_windowAnimationStyle;
 			global::XFGloss.Droid.Resource.Styleable.MenuView_preserveIconSpacing = global::XFGlossSample.Droid.Resource.Styleable.MenuView_preserveIconSpacing;
+			global::XFGloss.Droid.Resource.Styleable.MenuView_subMenuArrow = global::XFGlossSample.Droid.Resource.Styleable.MenuView_subMenuArrow;
 			global::XFGloss.Droid.Resource.Styleable.NavigationView = global::XFGlossSample.Droid.Resource.Styleable.NavigationView;
 			global::XFGloss.Droid.Resource.Styleable.NavigationView_android_background = global::XFGlossSample.Droid.Resource.Styleable.NavigationView_android_background;
 			global::XFGloss.Droid.Resource.Styleable.NavigationView_android_fitsSystemWindows = global::XFGlossSample.Droid.Resource.Styleable.NavigationView_android_fitsSystemWindows;
@@ -1676,11 +1984,16 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Styleable.NavigationView_itemTextColor = global::XFGlossSample.Droid.Resource.Styleable.NavigationView_itemTextColor;
 			global::XFGloss.Droid.Resource.Styleable.NavigationView_menu = global::XFGlossSample.Droid.Resource.Styleable.NavigationView_menu;
 			global::XFGloss.Droid.Resource.Styleable.PopupWindow = global::XFGlossSample.Droid.Resource.Styleable.PopupWindow;
+			global::XFGloss.Droid.Resource.Styleable.PopupWindow_android_popupAnimationStyle = global::XFGlossSample.Droid.Resource.Styleable.PopupWindow_android_popupAnimationStyle;
 			global::XFGloss.Droid.Resource.Styleable.PopupWindow_android_popupBackground = global::XFGlossSample.Droid.Resource.Styleable.PopupWindow_android_popupBackground;
 			global::XFGloss.Droid.Resource.Styleable.PopupWindow_overlapAnchor = global::XFGlossSample.Droid.Resource.Styleable.PopupWindow_overlapAnchor;
 			global::XFGloss.Droid.Resource.Styleable.PopupWindowBackgroundState = global::XFGlossSample.Droid.Resource.Styleable.PopupWindowBackgroundState;
 			global::XFGloss.Droid.Resource.Styleable.PopupWindowBackgroundState_state_above_anchor = global::XFGlossSample.Droid.Resource.Styleable.PopupWindowBackgroundState_state_above_anchor;
+			global::XFGloss.Droid.Resource.Styleable.RecycleListView = global::XFGlossSample.Droid.Resource.Styleable.RecycleListView;
+			global::XFGloss.Droid.Resource.Styleable.RecycleListView_paddingBottomNoButtons = global::XFGlossSample.Droid.Resource.Styleable.RecycleListView_paddingBottomNoButtons;
+			global::XFGloss.Droid.Resource.Styleable.RecycleListView_paddingTopNoTitle = global::XFGlossSample.Droid.Resource.Styleable.RecycleListView_paddingTopNoTitle;
 			global::XFGloss.Droid.Resource.Styleable.RecyclerView = global::XFGlossSample.Droid.Resource.Styleable.RecyclerView;
+			global::XFGloss.Droid.Resource.Styleable.RecyclerView_android_descendantFocusability = global::XFGlossSample.Droid.Resource.Styleable.RecyclerView_android_descendantFocusability;
 			global::XFGloss.Droid.Resource.Styleable.RecyclerView_android_orientation = global::XFGlossSample.Droid.Resource.Styleable.RecyclerView_android_orientation;
 			global::XFGloss.Droid.Resource.Styleable.RecyclerView_layoutManager = global::XFGlossSample.Droid.Resource.Styleable.RecyclerView_layoutManager;
 			global::XFGloss.Droid.Resource.Styleable.RecyclerView_reverseLayout = global::XFGlossSample.Droid.Resource.Styleable.RecyclerView_reverseLayout;
@@ -1688,8 +2001,8 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Styleable.RecyclerView_stackFromEnd = global::XFGlossSample.Droid.Resource.Styleable.RecyclerView_stackFromEnd;
 			global::XFGloss.Droid.Resource.Styleable.ScrimInsetsFrameLayout = global::XFGlossSample.Droid.Resource.Styleable.ScrimInsetsFrameLayout;
 			global::XFGloss.Droid.Resource.Styleable.ScrimInsetsFrameLayout_insetForeground = global::XFGlossSample.Droid.Resource.Styleable.ScrimInsetsFrameLayout_insetForeground;
-			global::XFGloss.Droid.Resource.Styleable.ScrollingViewBehavior_Params = global::XFGlossSample.Droid.Resource.Styleable.ScrollingViewBehavior_Params;
-			global::XFGloss.Droid.Resource.Styleable.ScrollingViewBehavior_Params_behavior_overlapTop = global::XFGlossSample.Droid.Resource.Styleable.ScrollingViewBehavior_Params_behavior_overlapTop;
+			global::XFGloss.Droid.Resource.Styleable.ScrollingViewBehavior_Layout = global::XFGlossSample.Droid.Resource.Styleable.ScrollingViewBehavior_Layout;
+			global::XFGloss.Droid.Resource.Styleable.ScrollingViewBehavior_Layout_behavior_overlapTop = global::XFGlossSample.Droid.Resource.Styleable.ScrollingViewBehavior_Layout_behavior_overlapTop;
 			global::XFGloss.Droid.Resource.Styleable.SearchView = global::XFGlossSample.Droid.Resource.Styleable.SearchView;
 			global::XFGloss.Droid.Resource.Styleable.SearchView_android_focusable = global::XFGlossSample.Droid.Resource.Styleable.SearchView_android_focusable;
 			global::XFGloss.Droid.Resource.Styleable.SearchView_android_imeOptions = global::XFGlossSample.Droid.Resource.Styleable.SearchView_android_imeOptions;
@@ -1728,7 +2041,11 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Styleable.SwitchCompat_switchPadding = global::XFGlossSample.Droid.Resource.Styleable.SwitchCompat_switchPadding;
 			global::XFGloss.Droid.Resource.Styleable.SwitchCompat_switchTextAppearance = global::XFGlossSample.Droid.Resource.Styleable.SwitchCompat_switchTextAppearance;
 			global::XFGloss.Droid.Resource.Styleable.SwitchCompat_thumbTextPadding = global::XFGlossSample.Droid.Resource.Styleable.SwitchCompat_thumbTextPadding;
+			global::XFGloss.Droid.Resource.Styleable.SwitchCompat_thumbTint = global::XFGlossSample.Droid.Resource.Styleable.SwitchCompat_thumbTint;
+			global::XFGloss.Droid.Resource.Styleable.SwitchCompat_thumbTintMode = global::XFGlossSample.Droid.Resource.Styleable.SwitchCompat_thumbTintMode;
 			global::XFGloss.Droid.Resource.Styleable.SwitchCompat_track = global::XFGlossSample.Droid.Resource.Styleable.SwitchCompat_track;
+			global::XFGloss.Droid.Resource.Styleable.SwitchCompat_trackTint = global::XFGlossSample.Droid.Resource.Styleable.SwitchCompat_trackTint;
+			global::XFGloss.Droid.Resource.Styleable.SwitchCompat_trackTintMode = global::XFGlossSample.Droid.Resource.Styleable.SwitchCompat_trackTintMode;
 			global::XFGloss.Droid.Resource.Styleable.TabItem = global::XFGlossSample.Droid.Resource.Styleable.TabItem;
 			global::XFGloss.Droid.Resource.Styleable.TabItem_android_icon = global::XFGlossSample.Droid.Resource.Styleable.TabItem_android_icon;
 			global::XFGloss.Droid.Resource.Styleable.TabItem_android_layout = global::XFGlossSample.Droid.Resource.Styleable.TabItem_android_layout;
@@ -1756,6 +2073,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Styleable.TextAppearance_android_shadowDy = global::XFGlossSample.Droid.Resource.Styleable.TextAppearance_android_shadowDy;
 			global::XFGloss.Droid.Resource.Styleable.TextAppearance_android_shadowRadius = global::XFGlossSample.Droid.Resource.Styleable.TextAppearance_android_shadowRadius;
 			global::XFGloss.Droid.Resource.Styleable.TextAppearance_android_textColor = global::XFGlossSample.Droid.Resource.Styleable.TextAppearance_android_textColor;
+			global::XFGloss.Droid.Resource.Styleable.TextAppearance_android_textColorHint = global::XFGlossSample.Droid.Resource.Styleable.TextAppearance_android_textColorHint;
 			global::XFGloss.Droid.Resource.Styleable.TextAppearance_android_textSize = global::XFGlossSample.Droid.Resource.Styleable.TextAppearance_android_textSize;
 			global::XFGloss.Droid.Resource.Styleable.TextAppearance_android_textStyle = global::XFGlossSample.Droid.Resource.Styleable.TextAppearance_android_textStyle;
 			global::XFGloss.Droid.Resource.Styleable.TextAppearance_android_typeface = global::XFGlossSample.Droid.Resource.Styleable.TextAppearance_android_typeface;
@@ -1772,15 +2090,23 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Styleable.TextInputLayout_hintAnimationEnabled = global::XFGlossSample.Droid.Resource.Styleable.TextInputLayout_hintAnimationEnabled;
 			global::XFGloss.Droid.Resource.Styleable.TextInputLayout_hintEnabled = global::XFGlossSample.Droid.Resource.Styleable.TextInputLayout_hintEnabled;
 			global::XFGloss.Droid.Resource.Styleable.TextInputLayout_hintTextAppearance = global::XFGlossSample.Droid.Resource.Styleable.TextInputLayout_hintTextAppearance;
+			global::XFGloss.Droid.Resource.Styleable.TextInputLayout_passwordToggleContentDescription = global::XFGlossSample.Droid.Resource.Styleable.TextInputLayout_passwordToggleContentDescription;
+			global::XFGloss.Droid.Resource.Styleable.TextInputLayout_passwordToggleDrawable = global::XFGlossSample.Droid.Resource.Styleable.TextInputLayout_passwordToggleDrawable;
+			global::XFGloss.Droid.Resource.Styleable.TextInputLayout_passwordToggleEnabled = global::XFGlossSample.Droid.Resource.Styleable.TextInputLayout_passwordToggleEnabled;
+			global::XFGloss.Droid.Resource.Styleable.TextInputLayout_passwordToggleTint = global::XFGlossSample.Droid.Resource.Styleable.TextInputLayout_passwordToggleTint;
+			global::XFGloss.Droid.Resource.Styleable.TextInputLayout_passwordToggleTintMode = global::XFGlossSample.Droid.Resource.Styleable.TextInputLayout_passwordToggleTintMode;
 			global::XFGloss.Droid.Resource.Styleable.Toolbar = global::XFGlossSample.Droid.Resource.Styleable.Toolbar;
 			global::XFGloss.Droid.Resource.Styleable.Toolbar_android_gravity = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_android_gravity;
 			global::XFGloss.Droid.Resource.Styleable.Toolbar_android_minHeight = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_android_minHeight;
+			global::XFGloss.Droid.Resource.Styleable.Toolbar_buttonGravity = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_buttonGravity;
 			global::XFGloss.Droid.Resource.Styleable.Toolbar_collapseContentDescription = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_collapseContentDescription;
 			global::XFGloss.Droid.Resource.Styleable.Toolbar_collapseIcon = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_collapseIcon;
 			global::XFGloss.Droid.Resource.Styleable.Toolbar_contentInsetEnd = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_contentInsetEnd;
+			global::XFGloss.Droid.Resource.Styleable.Toolbar_contentInsetEndWithActions = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_contentInsetEndWithActions;
 			global::XFGloss.Droid.Resource.Styleable.Toolbar_contentInsetLeft = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_contentInsetLeft;
 			global::XFGloss.Droid.Resource.Styleable.Toolbar_contentInsetRight = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_contentInsetRight;
 			global::XFGloss.Droid.Resource.Styleable.Toolbar_contentInsetStart = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_contentInsetStart;
+			global::XFGloss.Droid.Resource.Styleable.Toolbar_contentInsetStartWithNavigation = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_contentInsetStartWithNavigation;
 			global::XFGloss.Droid.Resource.Styleable.Toolbar_logo = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_logo;
 			global::XFGloss.Droid.Resource.Styleable.Toolbar_logoDescription = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_logoDescription;
 			global::XFGloss.Droid.Resource.Styleable.Toolbar_maxButtonHeight = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_maxButtonHeight;
@@ -1791,6 +2117,7 @@ namespace XFGlossSample.Droid
 			global::XFGloss.Droid.Resource.Styleable.Toolbar_subtitleTextAppearance = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_subtitleTextAppearance;
 			global::XFGloss.Droid.Resource.Styleable.Toolbar_subtitleTextColor = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_subtitleTextColor;
 			global::XFGloss.Droid.Resource.Styleable.Toolbar_title = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_title;
+			global::XFGloss.Droid.Resource.Styleable.Toolbar_titleMargin = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_titleMargin;
 			global::XFGloss.Droid.Resource.Styleable.Toolbar_titleMarginBottom = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_titleMarginBottom;
 			global::XFGloss.Droid.Resource.Styleable.Toolbar_titleMarginEnd = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_titleMarginEnd;
 			global::XFGloss.Droid.Resource.Styleable.Toolbar_titleMarginStart = global::XFGlossSample.Droid.Resource.Styleable.Toolbar_titleMarginStart;
@@ -1875,956 +2202,1038 @@ namespace XFGlossSample.Droid
 			}
 		}
 		
+		public partial class Animator
+		{
+			
+			// aapt resource value: 0x7f050000
+			public const int design_appbar_state_list_animator = 2131034112;
+			
+			static Animator()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Animator()
+			{
+			}
+		}
+		
 		public partial class Attribute
 		{
 			
-			// aapt resource value: 0x7f010000
-			public const int MediaRouteControllerWindowBackground = 2130771968;
-			
-			// aapt resource value: 0x7f0100a6
-			public const int actionBarDivider = 2130772134;
-			
-			// aapt resource value: 0x7f0100a7
-			public const int actionBarItemBackground = 2130772135;
-			
-			// aapt resource value: 0x7f0100a0
-			public const int actionBarPopupTheme = 2130772128;
-			
-			// aapt resource value: 0x7f0100a5
-			public const int actionBarSize = 2130772133;
-			
-			// aapt resource value: 0x7f0100a2
-			public const int actionBarSplitStyle = 2130772130;
-			
-			// aapt resource value: 0x7f0100a1
-			public const int actionBarStyle = 2130772129;
-			
-			// aapt resource value: 0x7f01009c
-			public const int actionBarTabBarStyle = 2130772124;
-			
-			// aapt resource value: 0x7f01009b
-			public const int actionBarTabStyle = 2130772123;
-			
-			// aapt resource value: 0x7f01009d
-			public const int actionBarTabTextStyle = 2130772125;
-			
-			// aapt resource value: 0x7f0100a3
-			public const int actionBarTheme = 2130772131;
-			
-			// aapt resource value: 0x7f0100a4
-			public const int actionBarWidgetTheme = 2130772132;
-			
-			// aapt resource value: 0x7f0100c0
-			public const int actionButtonStyle = 2130772160;
-			
-			// aapt resource value: 0x7f0100bc
-			public const int actionDropDownStyle = 2130772156;
-			
-			// aapt resource value: 0x7f01010e
-			public const int actionLayout = 2130772238;
-			
-			// aapt resource value: 0x7f0100a8
-			public const int actionMenuTextAppearance = 2130772136;
-			
-			// aapt resource value: 0x7f0100a9
-			public const int actionMenuTextColor = 2130772137;
-			
-			// aapt resource value: 0x7f0100ac
-			public const int actionModeBackground = 2130772140;
-			
-			// aapt resource value: 0x7f0100ab
-			public const int actionModeCloseButtonStyle = 2130772139;
-			
-			// aapt resource value: 0x7f0100ae
-			public const int actionModeCloseDrawable = 2130772142;
-			
-			// aapt resource value: 0x7f0100b0
-			public const int actionModeCopyDrawable = 2130772144;
-			
-			// aapt resource value: 0x7f0100af
-			public const int actionModeCutDrawable = 2130772143;
-			
-			// aapt resource value: 0x7f0100b4
-			public const int actionModeFindDrawable = 2130772148;
-			
-			// aapt resource value: 0x7f0100b1
-			public const int actionModePasteDrawable = 2130772145;
-			
-			// aapt resource value: 0x7f0100b6
-			public const int actionModePopupWindowStyle = 2130772150;
-			
-			// aapt resource value: 0x7f0100b2
-			public const int actionModeSelectAllDrawable = 2130772146;
-			
-			// aapt resource value: 0x7f0100b3
-			public const int actionModeShareDrawable = 2130772147;
-			
-			// aapt resource value: 0x7f0100ad
-			public const int actionModeSplitBackground = 2130772141;
-			
-			// aapt resource value: 0x7f0100aa
-			public const int actionModeStyle = 2130772138;
-			
-			// aapt resource value: 0x7f0100b5
-			public const int actionModeWebSearchDrawable = 2130772149;
-			
-			// aapt resource value: 0x7f01009e
-			public const int actionOverflowButtonStyle = 2130772126;
-			
-			// aapt resource value: 0x7f01009f
-			public const int actionOverflowMenuStyle = 2130772127;
-			
-			// aapt resource value: 0x7f010110
-			public const int actionProviderClass = 2130772240;
-			
-			// aapt resource value: 0x7f01010f
-			public const int actionViewClass = 2130772239;
-			
-			// aapt resource value: 0x7f0100c8
-			public const int activityChooserViewStyle = 2130772168;
-			
-			// aapt resource value: 0x7f0100eb
-			public const int alertDialogButtonGroupStyle = 2130772203;
-			
-			// aapt resource value: 0x7f0100ec
-			public const int alertDialogCenterButtons = 2130772204;
-			
-			// aapt resource value: 0x7f0100ea
-			public const int alertDialogStyle = 2130772202;
-			
-			// aapt resource value: 0x7f0100ed
-			public const int alertDialogTheme = 2130772205;
-			
-			// aapt resource value: 0x7f0100ff
-			public const int allowStacking = 2130772223;
-			
-			// aapt resource value: 0x7f010106
-			public const int arrowHeadLength = 2130772230;
-			
-			// aapt resource value: 0x7f010107
-			public const int arrowShaftLength = 2130772231;
-			
-			// aapt resource value: 0x7f0100f2
-			public const int autoCompleteTextViewStyle = 2130772210;
-			
-			// aapt resource value: 0x7f010077
-			public const int background = 2130772087;
-			
-			// aapt resource value: 0x7f010079
-			public const int backgroundSplit = 2130772089;
-			
-			// aapt resource value: 0x7f010078
-			public const int backgroundStacked = 2130772088;
-			
-			// aapt resource value: 0x7f01013a
-			public const int backgroundTint = 2130772282;
-			
-			// aapt resource value: 0x7f01013b
-			public const int backgroundTintMode = 2130772283;
-			
-			// aapt resource value: 0x7f010108
-			public const int barLength = 2130772232;
-			
-			// aapt resource value: 0x7f010026
-			public const int behavior_hideable = 2130772006;
-			
-			// aapt resource value: 0x7f01004c
-			public const int behavior_overlapTop = 2130772044;
-			
-			// aapt resource value: 0x7f010025
-			public const int behavior_peekHeight = 2130772005;
-			
-			// aapt resource value: 0x7f010042
-			public const int borderWidth = 2130772034;
-			
-			// aapt resource value: 0x7f0100c5
-			public const int borderlessButtonStyle = 2130772165;
-			
-			// aapt resource value: 0x7f01003c
-			public const int bottomSheetDialogTheme = 2130772028;
-			
-			// aapt resource value: 0x7f01003d
-			public const int bottomSheetStyle = 2130772029;
-			
-			// aapt resource value: 0x7f0100c2
-			public const int buttonBarButtonStyle = 2130772162;
-			
-			// aapt resource value: 0x7f0100f0
-			public const int buttonBarNegativeButtonStyle = 2130772208;
-			
-			// aapt resource value: 0x7f0100f1
-			public const int buttonBarNeutralButtonStyle = 2130772209;
-			
-			// aapt resource value: 0x7f0100ef
-			public const int buttonBarPositiveButtonStyle = 2130772207;
-			
-			// aapt resource value: 0x7f0100c1
-			public const int buttonBarStyle = 2130772161;
-			
-			// aapt resource value: 0x7f01008a
-			public const int buttonPanelSideLayout = 2130772106;
-			
-			// aapt resource value: 0x7f0100f3
-			public const int buttonStyle = 2130772211;
-			
-			// aapt resource value: 0x7f0100f4
-			public const int buttonStyleSmall = 2130772212;
-			
-			// aapt resource value: 0x7f010100
-			public const int buttonTint = 2130772224;
-			
-			// aapt resource value: 0x7f010101
-			public const int buttonTintMode = 2130772225;
-			
-			// aapt resource value: 0x7f010017
-			public const int cardBackgroundColor = 2130771991;
-			
-			// aapt resource value: 0x7f010018
-			public const int cardCornerRadius = 2130771992;
-			
-			// aapt resource value: 0x7f010019
-			public const int cardElevation = 2130771993;
-			
-			// aapt resource value: 0x7f01001a
-			public const int cardMaxElevation = 2130771994;
-			
-			// aapt resource value: 0x7f01001c
-			public const int cardPreventCornerOverlap = 2130771996;
-			
-			// aapt resource value: 0x7f01001b
-			public const int cardUseCompatPadding = 2130771995;
-			
-			// aapt resource value: 0x7f0100f5
-			public const int checkboxStyle = 2130772213;
-			
-			// aapt resource value: 0x7f0100f6
-			public const int checkedTextViewStyle = 2130772214;
-			
-			// aapt resource value: 0x7f010118
-			public const int closeIcon = 2130772248;
-			
-			// aapt resource value: 0x7f010087
-			public const int closeItemLayout = 2130772103;
-			
-			// aapt resource value: 0x7f010131
-			public const int collapseContentDescription = 2130772273;
-			
-			// aapt resource value: 0x7f010130
-			public const int collapseIcon = 2130772272;
-			
-			// aapt resource value: 0x7f010033
-			public const int collapsedTitleGravity = 2130772019;
-			
-			// aapt resource value: 0x7f01002f
-			public const int collapsedTitleTextAppearance = 2130772015;
-			
-			// aapt resource value: 0x7f010102
-			public const int color = 2130772226;
-			
-			// aapt resource value: 0x7f0100e3
-			public const int colorAccent = 2130772195;
-			
-			// aapt resource value: 0x7f0100e7
-			public const int colorButtonNormal = 2130772199;
-			
-			// aapt resource value: 0x7f0100e5
-			public const int colorControlActivated = 2130772197;
-			
-			// aapt resource value: 0x7f0100e6
-			public const int colorControlHighlight = 2130772198;
-			
-			// aapt resource value: 0x7f0100e4
-			public const int colorControlNormal = 2130772196;
-			
-			// aapt resource value: 0x7f0100e1
-			public const int colorPrimary = 2130772193;
-			
-			// aapt resource value: 0x7f0100e2
-			public const int colorPrimaryDark = 2130772194;
-			
-			// aapt resource value: 0x7f0100e8
-			public const int colorSwitchThumbNormal = 2130772200;
-			
-			// aapt resource value: 0x7f01011d
-			public const int commitIcon = 2130772253;
-			
-			// aapt resource value: 0x7f010082
-			public const int contentInsetEnd = 2130772098;
-			
-			// aapt resource value: 0x7f010083
-			public const int contentInsetLeft = 2130772099;
-			
-			// aapt resource value: 0x7f010084
-			public const int contentInsetRight = 2130772100;
-			
-			// aapt resource value: 0x7f010081
-			public const int contentInsetStart = 2130772097;
-			
-			// aapt resource value: 0x7f01001d
-			public const int contentPadding = 2130771997;
-			
-			// aapt resource value: 0x7f010021
-			public const int contentPaddingBottom = 2130772001;
-			
-			// aapt resource value: 0x7f01001e
-			public const int contentPaddingLeft = 2130771998;
-			
-			// aapt resource value: 0x7f01001f
-			public const int contentPaddingRight = 2130771999;
-			
-			// aapt resource value: 0x7f010020
-			public const int contentPaddingTop = 2130772000;
-			
-			// aapt resource value: 0x7f010030
-			public const int contentScrim = 2130772016;
-			
-			// aapt resource value: 0x7f0100e9
-			public const int controlBackground = 2130772201;
-			
-			// aapt resource value: 0x7f010062
-			public const int counterEnabled = 2130772066;
-			
-			// aapt resource value: 0x7f010063
-			public const int counterMaxLength = 2130772067;
-			
-			// aapt resource value: 0x7f010065
-			public const int counterOverflowTextAppearance = 2130772069;
-			
-			// aapt resource value: 0x7f010064
-			public const int counterTextAppearance = 2130772068;
-			
-			// aapt resource value: 0x7f01007a
-			public const int customNavigationLayout = 2130772090;
-			
-			// aapt resource value: 0x7f010117
-			public const int defaultQueryHint = 2130772247;
-			
-			// aapt resource value: 0x7f0100ba
-			public const int dialogPreferredPadding = 2130772154;
-			
-			// aapt resource value: 0x7f0100b9
-			public const int dialogTheme = 2130772153;
-			
-			// aapt resource value: 0x7f010070
-			public const int displayOptions = 2130772080;
-			
-			// aapt resource value: 0x7f010076
-			public const int divider = 2130772086;
-			
-			// aapt resource value: 0x7f0100c7
-			public const int dividerHorizontal = 2130772167;
-			
-			// aapt resource value: 0x7f01010c
-			public const int dividerPadding = 2130772236;
-			
-			// aapt resource value: 0x7f0100c6
-			public const int dividerVertical = 2130772166;
-			
-			// aapt resource value: 0x7f010104
-			public const int drawableSize = 2130772228;
-			
-			// aapt resource value: 0x7f01006b
-			public const int drawerArrowStyle = 2130772075;
-			
-			// aapt resource value: 0x7f0100d9
-			public const int dropDownListViewStyle = 2130772185;
-			
-			// aapt resource value: 0x7f0100bd
-			public const int dropdownListPreferredItemHeight = 2130772157;
-			
-			// aapt resource value: 0x7f0100ce
-			public const int editTextBackground = 2130772174;
-			
-			// aapt resource value: 0x7f0100cd
-			public const int editTextColor = 2130772173;
-			
-			// aapt resource value: 0x7f0100f7
-			public const int editTextStyle = 2130772215;
-			
-			// aapt resource value: 0x7f010085
-			public const int elevation = 2130772101;
-			
-			// aapt resource value: 0x7f010060
-			public const int errorEnabled = 2130772064;
-			
-			// aapt resource value: 0x7f010061
-			public const int errorTextAppearance = 2130772065;
-			
-			// aapt resource value: 0x7f010089
-			public const int expandActivityOverflowButtonDrawable = 2130772105;
-			
-			// aapt resource value: 0x7f010022
-			public const int expanded = 2130772002;
-			
-			// aapt resource value: 0x7f010034
-			public const int expandedTitleGravity = 2130772020;
-			
-			// aapt resource value: 0x7f010029
-			public const int expandedTitleMargin = 2130772009;
-			
-			// aapt resource value: 0x7f01002d
-			public const int expandedTitleMarginBottom = 2130772013;
-			
-			// aapt resource value: 0x7f01002c
-			public const int expandedTitleMarginEnd = 2130772012;
-			
-			// aapt resource value: 0x7f01002a
-			public const int expandedTitleMarginStart = 2130772010;
-			
-			// aapt resource value: 0x7f01002b
-			public const int expandedTitleMarginTop = 2130772011;
-			
-			// aapt resource value: 0x7f01002e
-			public const int expandedTitleTextAppearance = 2130772014;
-			
-			// aapt resource value: 0x7f010016
-			public const int externalRouteEnabledDrawable = 2130771990;
-			
-			// aapt resource value: 0x7f010040
-			public const int fabSize = 2130772032;
-			
-			// aapt resource value: 0x7f010044
-			public const int foregroundInsidePadding = 2130772036;
-			
-			// aapt resource value: 0x7f010105
-			public const int gapBetweenBars = 2130772229;
-			
-			// aapt resource value: 0x7f010119
-			public const int goIcon = 2130772249;
-			
-			// aapt resource value: 0x7f01004a
-			public const int headerLayout = 2130772042;
-			
-			// aapt resource value: 0x7f01006c
-			public const int height = 2130772076;
-			
-			// aapt resource value: 0x7f010080
-			public const int hideOnContentScroll = 2130772096;
-			
-			// aapt resource value: 0x7f010066
-			public const int hintAnimationEnabled = 2130772070;
-			
-			// aapt resource value: 0x7f01005f
-			public const int hintEnabled = 2130772063;
+			// aapt resource value: 0x7f01005d
+			public const int actionBarDivider = 2130772061;
 			
 			// aapt resource value: 0x7f01005e
-			public const int hintTextAppearance = 2130772062;
-			
-			// aapt resource value: 0x7f0100bf
-			public const int homeAsUpIndicator = 2130772159;
-			
-			// aapt resource value: 0x7f01007b
-			public const int homeLayout = 2130772091;
-			
-			// aapt resource value: 0x7f010074
-			public const int icon = 2130772084;
-			
-			// aapt resource value: 0x7f010115
-			public const int iconifiedByDefault = 2130772245;
-			
-			// aapt resource value: 0x7f0100cf
-			public const int imageButtonStyle = 2130772175;
-			
-			// aapt resource value: 0x7f01007d
-			public const int indeterminateProgressStyle = 2130772093;
-			
-			// aapt resource value: 0x7f010088
-			public const int initialActivityCount = 2130772104;
-			
-			// aapt resource value: 0x7f01004b
-			public const int insetForeground = 2130772043;
-			
-			// aapt resource value: 0x7f01006d
-			public const int isLightTheme = 2130772077;
-			
-			// aapt resource value: 0x7f010048
-			public const int itemBackground = 2130772040;
-			
-			// aapt resource value: 0x7f010046
-			public const int itemIconTint = 2130772038;
-			
-			// aapt resource value: 0x7f01007f
-			public const int itemPadding = 2130772095;
-			
-			// aapt resource value: 0x7f010049
-			public const int itemTextAppearance = 2130772041;
-			
-			// aapt resource value: 0x7f010047
-			public const int itemTextColor = 2130772039;
-			
-			// aapt resource value: 0x7f010036
-			public const int keylines = 2130772022;
-			
-			// aapt resource value: 0x7f010114
-			public const int layout = 2130772244;
-			
-			// aapt resource value: 0x7f010067
-			public const int layoutManager = 2130772071;
-			
-			// aapt resource value: 0x7f010039
-			public const int layout_anchor = 2130772025;
-			
-			// aapt resource value: 0x7f01003b
-			public const int layout_anchorGravity = 2130772027;
-			
-			// aapt resource value: 0x7f010038
-			public const int layout_behavior = 2130772024;
-			
-			// aapt resource value: 0x7f010027
-			public const int layout_collapseMode = 2130772007;
-			
-			// aapt resource value: 0x7f010028
-			public const int layout_collapseParallaxMultiplier = 2130772008;
-			
-			// aapt resource value: 0x7f01003a
-			public const int layout_keyline = 2130772026;
-			
-			// aapt resource value: 0x7f010023
-			public const int layout_scrollFlags = 2130772003;
-			
-			// aapt resource value: 0x7f010024
-			public const int layout_scrollInterpolator = 2130772004;
-			
-			// aapt resource value: 0x7f0100e0
-			public const int listChoiceBackgroundIndicator = 2130772192;
-			
-			// aapt resource value: 0x7f0100bb
-			public const int listDividerAlertDialog = 2130772155;
-			
-			// aapt resource value: 0x7f01008e
-			public const int listItemLayout = 2130772110;
-			
-			// aapt resource value: 0x7f01008b
-			public const int listLayout = 2130772107;
-			
-			// aapt resource value: 0x7f0100da
-			public const int listPopupWindowStyle = 2130772186;
-			
-			// aapt resource value: 0x7f0100d4
-			public const int listPreferredItemHeight = 2130772180;
-			
-			// aapt resource value: 0x7f0100d6
-			public const int listPreferredItemHeightLarge = 2130772182;
-			
-			// aapt resource value: 0x7f0100d5
-			public const int listPreferredItemHeightSmall = 2130772181;
-			
-			// aapt resource value: 0x7f0100d7
-			public const int listPreferredItemPaddingLeft = 2130772183;
-			
-			// aapt resource value: 0x7f0100d8
-			public const int listPreferredItemPaddingRight = 2130772184;
-			
-			// aapt resource value: 0x7f010075
-			public const int logo = 2130772085;
-			
-			// aapt resource value: 0x7f010134
-			public const int logoDescription = 2130772276;
-			
-			// aapt resource value: 0x7f01004d
-			public const int maxActionInlineWidth = 2130772045;
-			
-			// aapt resource value: 0x7f01012f
-			public const int maxButtonHeight = 2130772271;
-			
-			// aapt resource value: 0x7f01010a
-			public const int measureWithLargestChild = 2130772234;
-			
-			// aapt resource value: 0x7f010001
-			public const int mediaRouteAudioTrackDrawable = 2130771969;
-			
-			// aapt resource value: 0x7f010002
-			public const int mediaRouteBluetoothIconDrawable = 2130771970;
-			
-			// aapt resource value: 0x7f010003
-			public const int mediaRouteButtonStyle = 2130771971;
-			
-			// aapt resource value: 0x7f010004
-			public const int mediaRouteCastDrawable = 2130771972;
-			
-			// aapt resource value: 0x7f010005
-			public const int mediaRouteChooserPrimaryTextStyle = 2130771973;
-			
-			// aapt resource value: 0x7f010006
-			public const int mediaRouteChooserSecondaryTextStyle = 2130771974;
-			
-			// aapt resource value: 0x7f010007
-			public const int mediaRouteCloseDrawable = 2130771975;
-			
-			// aapt resource value: 0x7f010008
-			public const int mediaRouteCollapseGroupDrawable = 2130771976;
-			
-			// aapt resource value: 0x7f010009
-			public const int mediaRouteConnectingDrawable = 2130771977;
-			
-			// aapt resource value: 0x7f01000a
-			public const int mediaRouteControllerPrimaryTextStyle = 2130771978;
-			
-			// aapt resource value: 0x7f01000b
-			public const int mediaRouteControllerSecondaryTextStyle = 2130771979;
-			
-			// aapt resource value: 0x7f01000c
-			public const int mediaRouteControllerTitleTextStyle = 2130771980;
-			
-			// aapt resource value: 0x7f01000d
-			public const int mediaRouteDefaultIconDrawable = 2130771981;
-			
-			// aapt resource value: 0x7f01000e
-			public const int mediaRouteExpandGroupDrawable = 2130771982;
-			
-			// aapt resource value: 0x7f01000f
-			public const int mediaRouteOffDrawable = 2130771983;
-			
-			// aapt resource value: 0x7f010010
-			public const int mediaRouteOnDrawable = 2130771984;
-			
-			// aapt resource value: 0x7f010011
-			public const int mediaRoutePauseDrawable = 2130771985;
-			
-			// aapt resource value: 0x7f010012
-			public const int mediaRoutePlayDrawable = 2130771986;
-			
-			// aapt resource value: 0x7f010013
-			public const int mediaRouteSpeakerGroupIconDrawable = 2130771987;
-			
-			// aapt resource value: 0x7f010014
-			public const int mediaRouteSpeakerIconDrawable = 2130771988;
-			
-			// aapt resource value: 0x7f010015
-			public const int mediaRouteTvIconDrawable = 2130771989;
-			
-			// aapt resource value: 0x7f010045
-			public const int menu = 2130772037;
-			
-			// aapt resource value: 0x7f01008c
-			public const int multiChoiceItemLayout = 2130772108;
-			
-			// aapt resource value: 0x7f010133
-			public const int navigationContentDescription = 2130772275;
-			
-			// aapt resource value: 0x7f010132
-			public const int navigationIcon = 2130772274;
-			
-			// aapt resource value: 0x7f01006f
-			public const int navigationMode = 2130772079;
-			
-			// aapt resource value: 0x7f010112
-			public const int overlapAnchor = 2130772242;
-			
-			// aapt resource value: 0x7f010138
-			public const int paddingEnd = 2130772280;
-			
-			// aapt resource value: 0x7f010137
-			public const int paddingStart = 2130772279;
-			
-			// aapt resource value: 0x7f0100dd
-			public const int panelBackground = 2130772189;
-			
-			// aapt resource value: 0x7f0100df
-			public const int panelMenuListTheme = 2130772191;
-			
-			// aapt resource value: 0x7f0100de
-			public const int panelMenuListWidth = 2130772190;
-			
-			// aapt resource value: 0x7f0100cb
-			public const int popupMenuStyle = 2130772171;
-			
-			// aapt resource value: 0x7f010086
-			public const int popupTheme = 2130772102;
-			
-			// aapt resource value: 0x7f0100cc
-			public const int popupWindowStyle = 2130772172;
-			
-			// aapt resource value: 0x7f010111
-			public const int preserveIconSpacing = 2130772241;
-			
-			// aapt resource value: 0x7f010041
-			public const int pressedTranslationZ = 2130772033;
-			
-			// aapt resource value: 0x7f01007e
-			public const int progressBarPadding = 2130772094;
-			
-			// aapt resource value: 0x7f01007c
-			public const int progressBarStyle = 2130772092;
-			
-			// aapt resource value: 0x7f01011f
-			public const int queryBackground = 2130772255;
-			
-			// aapt resource value: 0x7f010116
-			public const int queryHint = 2130772246;
-			
-			// aapt resource value: 0x7f0100f8
-			public const int radioButtonStyle = 2130772216;
-			
-			// aapt resource value: 0x7f0100f9
-			public const int ratingBarStyle = 2130772217;
-			
-			// aapt resource value: 0x7f0100fa
-			public const int ratingBarStyleIndicator = 2130772218;
-			
-			// aapt resource value: 0x7f0100fb
-			public const int ratingBarStyleSmall = 2130772219;
-			
-			// aapt resource value: 0x7f010069
-			public const int reverseLayout = 2130772073;
-			
-			// aapt resource value: 0x7f01003f
-			public const int rippleColor = 2130772031;
-			
-			// aapt resource value: 0x7f01011b
-			public const int searchHintIcon = 2130772251;
-			
-			// aapt resource value: 0x7f01011a
-			public const int searchIcon = 2130772250;
-			
-			// aapt resource value: 0x7f0100d3
-			public const int searchViewStyle = 2130772179;
-			
-			// aapt resource value: 0x7f0100fc
-			public const int seekBarStyle = 2130772220;
-			
-			// aapt resource value: 0x7f0100c3
-			public const int selectableItemBackground = 2130772163;
-			
-			// aapt resource value: 0x7f0100c4
-			public const int selectableItemBackgroundBorderless = 2130772164;
-			
-			// aapt resource value: 0x7f01010d
-			public const int showAsAction = 2130772237;
-			
-			// aapt resource value: 0x7f01010b
-			public const int showDividers = 2130772235;
-			
-			// aapt resource value: 0x7f010127
-			public const int showText = 2130772263;
-			
-			// aapt resource value: 0x7f01008d
-			public const int singleChoiceItemLayout = 2130772109;
-			
-			// aapt resource value: 0x7f010068
-			public const int spanCount = 2130772072;
-			
-			// aapt resource value: 0x7f010103
-			public const int spinBars = 2130772227;
-			
-			// aapt resource value: 0x7f0100be
-			public const int spinnerDropDownItemStyle = 2130772158;
-			
-			// aapt resource value: 0x7f0100fd
-			public const int spinnerStyle = 2130772221;
-			
-			// aapt resource value: 0x7f010126
-			public const int splitTrack = 2130772262;
-			
-			// aapt resource value: 0x7f01008f
-			public const int srcCompat = 2130772111;
-			
-			// aapt resource value: 0x7f01006a
-			public const int stackFromEnd = 2130772074;
-			
-			// aapt resource value: 0x7f010113
-			public const int state_above_anchor = 2130772243;
-			
-			// aapt resource value: 0x7f010037
-			public const int statusBarBackground = 2130772023;
-			
-			// aapt resource value: 0x7f010031
-			public const int statusBarScrim = 2130772017;
-			
-			// aapt resource value: 0x7f010120
-			public const int submitBackground = 2130772256;
-			
-			// aapt resource value: 0x7f010071
-			public const int subtitle = 2130772081;
-			
-			// aapt resource value: 0x7f010129
-			public const int subtitleTextAppearance = 2130772265;
-			
-			// aapt resource value: 0x7f010136
-			public const int subtitleTextColor = 2130772278;
-			
-			// aapt resource value: 0x7f010073
-			public const int subtitleTextStyle = 2130772083;
-			
-			// aapt resource value: 0x7f01011e
-			public const int suggestionRowLayout = 2130772254;
-			
-			// aapt resource value: 0x7f010124
-			public const int switchMinWidth = 2130772260;
-			
-			// aapt resource value: 0x7f010125
-			public const int switchPadding = 2130772261;
-			
-			// aapt resource value: 0x7f0100fe
-			public const int switchStyle = 2130772222;
-			
-			// aapt resource value: 0x7f010123
-			public const int switchTextAppearance = 2130772259;
-			
-			// aapt resource value: 0x7f010051
-			public const int tabBackground = 2130772049;
-			
-			// aapt resource value: 0x7f010050
-			public const int tabContentStart = 2130772048;
-			
-			// aapt resource value: 0x7f010053
-			public const int tabGravity = 2130772051;
-			
-			// aapt resource value: 0x7f01004e
-			public const int tabIndicatorColor = 2130772046;
-			
-			// aapt resource value: 0x7f01004f
-			public const int tabIndicatorHeight = 2130772047;
-			
-			// aapt resource value: 0x7f010055
-			public const int tabMaxWidth = 2130772053;
-			
-			// aapt resource value: 0x7f010054
-			public const int tabMinWidth = 2130772052;
-			
-			// aapt resource value: 0x7f010052
-			public const int tabMode = 2130772050;
-			
-			// aapt resource value: 0x7f01005d
-			public const int tabPadding = 2130772061;
-			
-			// aapt resource value: 0x7f01005c
-			public const int tabPaddingBottom = 2130772060;
-			
-			// aapt resource value: 0x7f01005b
-			public const int tabPaddingEnd = 2130772059;
-			
-			// aapt resource value: 0x7f010059
-			public const int tabPaddingStart = 2130772057;
-			
-			// aapt resource value: 0x7f01005a
-			public const int tabPaddingTop = 2130772058;
-			
-			// aapt resource value: 0x7f010058
-			public const int tabSelectedTextColor = 2130772056;
-			
-			// aapt resource value: 0x7f010056
-			public const int tabTextAppearance = 2130772054;
+			public const int actionBarItemBackground = 2130772062;
 			
 			// aapt resource value: 0x7f010057
-			public const int tabTextColor = 2130772055;
+			public const int actionBarPopupTheme = 2130772055;
 			
-			// aapt resource value: 0x7f010090
-			public const int textAllCaps = 2130772112;
+			// aapt resource value: 0x7f01005c
+			public const int actionBarSize = 2130772060;
 			
-			// aapt resource value: 0x7f0100b7
-			public const int textAppearanceLargePopupMenu = 2130772151;
+			// aapt resource value: 0x7f010059
+			public const int actionBarSplitStyle = 2130772057;
 			
-			// aapt resource value: 0x7f0100db
-			public const int textAppearanceListItem = 2130772187;
+			// aapt resource value: 0x7f010058
+			public const int actionBarStyle = 2130772056;
 			
-			// aapt resource value: 0x7f0100dc
-			public const int textAppearanceListItemSmall = 2130772188;
+			// aapt resource value: 0x7f010053
+			public const int actionBarTabBarStyle = 2130772051;
 			
-			// aapt resource value: 0x7f0100d1
-			public const int textAppearanceSearchResultSubtitle = 2130772177;
+			// aapt resource value: 0x7f010052
+			public const int actionBarTabStyle = 2130772050;
 			
-			// aapt resource value: 0x7f0100d0
-			public const int textAppearanceSearchResultTitle = 2130772176;
+			// aapt resource value: 0x7f010054
+			public const int actionBarTabTextStyle = 2130772052;
 			
-			// aapt resource value: 0x7f0100b8
-			public const int textAppearanceSmallPopupMenu = 2130772152;
+			// aapt resource value: 0x7f01005a
+			public const int actionBarTheme = 2130772058;
 			
-			// aapt resource value: 0x7f0100ee
-			public const int textColorAlertDialogListItem = 2130772206;
+			// aapt resource value: 0x7f01005b
+			public const int actionBarWidgetTheme = 2130772059;
 			
-			// aapt resource value: 0x7f01003e
-			public const int textColorError = 2130772030;
+			// aapt resource value: 0x7f010078
+			public const int actionButtonStyle = 2130772088;
 			
-			// aapt resource value: 0x7f0100d2
-			public const int textColorSearchUrl = 2130772178;
-			
-			// aapt resource value: 0x7f010139
-			public const int theme = 2130772281;
-			
-			// aapt resource value: 0x7f010109
-			public const int thickness = 2130772233;
-			
-			// aapt resource value: 0x7f010122
-			public const int thumbTextPadding = 2130772258;
-			
-			// aapt resource value: 0x7f01006e
-			public const int title = 2130772078;
-			
-			// aapt resource value: 0x7f010035
-			public const int titleEnabled = 2130772021;
-			
-			// aapt resource value: 0x7f01012e
-			public const int titleMarginBottom = 2130772270;
-			
-			// aapt resource value: 0x7f01012c
-			public const int titleMarginEnd = 2130772268;
-			
-			// aapt resource value: 0x7f01012b
-			public const int titleMarginStart = 2130772267;
-			
-			// aapt resource value: 0x7f01012d
-			public const int titleMarginTop = 2130772269;
-			
-			// aapt resource value: 0x7f01012a
-			public const int titleMargins = 2130772266;
-			
-			// aapt resource value: 0x7f010128
-			public const int titleTextAppearance = 2130772264;
-			
-			// aapt resource value: 0x7f010135
-			public const int titleTextColor = 2130772277;
-			
-			// aapt resource value: 0x7f010072
-			public const int titleTextStyle = 2130772082;
-			
-			// aapt resource value: 0x7f010032
-			public const int toolbarId = 2130772018;
-			
-			// aapt resource value: 0x7f0100ca
-			public const int toolbarNavigationButtonStyle = 2130772170;
+			// aapt resource value: 0x7f010074
+			public const int actionDropDownStyle = 2130772084;
 			
 			// aapt resource value: 0x7f0100c9
-			public const int toolbarStyle = 2130772169;
+			public const int actionLayout = 2130772169;
+			
+			// aapt resource value: 0x7f01005f
+			public const int actionMenuTextAppearance = 2130772063;
+			
+			// aapt resource value: 0x7f010060
+			public const int actionMenuTextColor = 2130772064;
+			
+			// aapt resource value: 0x7f010063
+			public const int actionModeBackground = 2130772067;
+			
+			// aapt resource value: 0x7f010062
+			public const int actionModeCloseButtonStyle = 2130772066;
+			
+			// aapt resource value: 0x7f010065
+			public const int actionModeCloseDrawable = 2130772069;
+			
+			// aapt resource value: 0x7f010067
+			public const int actionModeCopyDrawable = 2130772071;
+			
+			// aapt resource value: 0x7f010066
+			public const int actionModeCutDrawable = 2130772070;
+			
+			// aapt resource value: 0x7f01006b
+			public const int actionModeFindDrawable = 2130772075;
+			
+			// aapt resource value: 0x7f010068
+			public const int actionModePasteDrawable = 2130772072;
+			
+			// aapt resource value: 0x7f01006d
+			public const int actionModePopupWindowStyle = 2130772077;
+			
+			// aapt resource value: 0x7f010069
+			public const int actionModeSelectAllDrawable = 2130772073;
+			
+			// aapt resource value: 0x7f01006a
+			public const int actionModeShareDrawable = 2130772074;
+			
+			// aapt resource value: 0x7f010064
+			public const int actionModeSplitBackground = 2130772068;
+			
+			// aapt resource value: 0x7f010061
+			public const int actionModeStyle = 2130772065;
+			
+			// aapt resource value: 0x7f01006c
+			public const int actionModeWebSearchDrawable = 2130772076;
+			
+			// aapt resource value: 0x7f010055
+			public const int actionOverflowButtonStyle = 2130772053;
+			
+			// aapt resource value: 0x7f010056
+			public const int actionOverflowMenuStyle = 2130772054;
+			
+			// aapt resource value: 0x7f0100cb
+			public const int actionProviderClass = 2130772171;
+			
+			// aapt resource value: 0x7f0100ca
+			public const int actionViewClass = 2130772170;
+			
+			// aapt resource value: 0x7f010080
+			public const int activityChooserViewStyle = 2130772096;
+			
+			// aapt resource value: 0x7f0100a4
+			public const int alertDialogButtonGroupStyle = 2130772132;
+			
+			// aapt resource value: 0x7f0100a5
+			public const int alertDialogCenterButtons = 2130772133;
+			
+			// aapt resource value: 0x7f0100a3
+			public const int alertDialogStyle = 2130772131;
+			
+			// aapt resource value: 0x7f0100a6
+			public const int alertDialogTheme = 2130772134;
+			
+			// aapt resource value: 0x7f0100b9
+			public const int allowStacking = 2130772153;
+			
+			// aapt resource value: 0x7f0100ba
+			public const int alpha = 2130772154;
+			
+			// aapt resource value: 0x7f0100c1
+			public const int arrowHeadLength = 2130772161;
+			
+			// aapt resource value: 0x7f0100c2
+			public const int arrowShaftLength = 2130772162;
+			
+			// aapt resource value: 0x7f0100ab
+			public const int autoCompleteTextViewStyle = 2130772139;
+			
+			// aapt resource value: 0x7f010028
+			public const int background = 2130772008;
+			
+			// aapt resource value: 0x7f01002a
+			public const int backgroundSplit = 2130772010;
+			
+			// aapt resource value: 0x7f010029
+			public const int backgroundStacked = 2130772009;
+			
+			// aapt resource value: 0x7f0100fe
+			public const int backgroundTint = 2130772222;
+			
+			// aapt resource value: 0x7f0100ff
+			public const int backgroundTintMode = 2130772223;
+			
+			// aapt resource value: 0x7f0100c3
+			public const int barLength = 2130772163;
+			
+			// aapt resource value: 0x7f010129
+			public const int behavior_autoHide = 2130772265;
+			
+			// aapt resource value: 0x7f010106
+			public const int behavior_hideable = 2130772230;
+			
+			// aapt resource value: 0x7f010132
+			public const int behavior_overlapTop = 2130772274;
+			
+			// aapt resource value: 0x7f010105
+			public const int behavior_peekHeight = 2130772229;
+			
+			// aapt resource value: 0x7f010107
+			public const int behavior_skipCollapsed = 2130772231;
+			
+			// aapt resource value: 0x7f010127
+			public const int borderWidth = 2130772263;
+			
+			// aapt resource value: 0x7f01007d
+			public const int borderlessButtonStyle = 2130772093;
 			
 			// aapt resource value: 0x7f010121
-			public const int track = 2130772257;
+			public const int bottomSheetDialogTheme = 2130772257;
 			
-			// aapt resource value: 0x7f010043
-			public const int useCompatPadding = 2130772035;
+			// aapt resource value: 0x7f010122
+			public const int bottomSheetStyle = 2130772258;
 			
-			// aapt resource value: 0x7f01011c
-			public const int voiceIcon = 2130772252;
+			// aapt resource value: 0x7f01007a
+			public const int buttonBarButtonStyle = 2130772090;
 			
-			// aapt resource value: 0x7f010091
-			public const int windowActionBar = 2130772113;
+			// aapt resource value: 0x7f0100a9
+			public const int buttonBarNegativeButtonStyle = 2130772137;
 			
-			// aapt resource value: 0x7f010093
-			public const int windowActionBarOverlay = 2130772115;
+			// aapt resource value: 0x7f0100aa
+			public const int buttonBarNeutralButtonStyle = 2130772138;
 			
-			// aapt resource value: 0x7f010094
-			public const int windowActionModeOverlay = 2130772116;
+			// aapt resource value: 0x7f0100a8
+			public const int buttonBarPositiveButtonStyle = 2130772136;
 			
-			// aapt resource value: 0x7f010098
-			public const int windowFixedHeightMajor = 2130772120;
+			// aapt resource value: 0x7f010079
+			public const int buttonBarStyle = 2130772089;
 			
-			// aapt resource value: 0x7f010096
-			public const int windowFixedHeightMinor = 2130772118;
+			// aapt resource value: 0x7f0100f3
+			public const int buttonGravity = 2130772211;
 			
-			// aapt resource value: 0x7f010095
-			public const int windowFixedWidthMajor = 2130772117;
+			// aapt resource value: 0x7f01003d
+			public const int buttonPanelSideLayout = 2130772029;
 			
-			// aapt resource value: 0x7f010097
-			public const int windowFixedWidthMinor = 2130772119;
+			// aapt resource value: 0x7f0100ac
+			public const int buttonStyle = 2130772140;
+			
+			// aapt resource value: 0x7f0100ad
+			public const int buttonStyleSmall = 2130772141;
+			
+			// aapt resource value: 0x7f0100bb
+			public const int buttonTint = 2130772155;
+			
+			// aapt resource value: 0x7f0100bc
+			public const int buttonTintMode = 2130772156;
+			
+			// aapt resource value: 0x7f010011
+			public const int cardBackgroundColor = 2130771985;
+			
+			// aapt resource value: 0x7f010012
+			public const int cardCornerRadius = 2130771986;
+			
+			// aapt resource value: 0x7f010013
+			public const int cardElevation = 2130771987;
+			
+			// aapt resource value: 0x7f010014
+			public const int cardMaxElevation = 2130771988;
+			
+			// aapt resource value: 0x7f010016
+			public const int cardPreventCornerOverlap = 2130771990;
+			
+			// aapt resource value: 0x7f010015
+			public const int cardUseCompatPadding = 2130771989;
+			
+			// aapt resource value: 0x7f0100ae
+			public const int checkboxStyle = 2130772142;
+			
+			// aapt resource value: 0x7f0100af
+			public const int checkedTextViewStyle = 2130772143;
+			
+			// aapt resource value: 0x7f0100d6
+			public const int closeIcon = 2130772182;
+			
+			// aapt resource value: 0x7f01003a
+			public const int closeItemLayout = 2130772026;
+			
+			// aapt resource value: 0x7f0100f5
+			public const int collapseContentDescription = 2130772213;
+			
+			// aapt resource value: 0x7f0100f4
+			public const int collapseIcon = 2130772212;
+			
+			// aapt resource value: 0x7f010114
+			public const int collapsedTitleGravity = 2130772244;
+			
+			// aapt resource value: 0x7f01010e
+			public const int collapsedTitleTextAppearance = 2130772238;
+			
+			// aapt resource value: 0x7f0100bd
+			public const int color = 2130772157;
+			
+			// aapt resource value: 0x7f01009b
+			public const int colorAccent = 2130772123;
+			
+			// aapt resource value: 0x7f0100a2
+			public const int colorBackgroundFloating = 2130772130;
+			
+			// aapt resource value: 0x7f01009f
+			public const int colorButtonNormal = 2130772127;
+			
+			// aapt resource value: 0x7f01009d
+			public const int colorControlActivated = 2130772125;
+			
+			// aapt resource value: 0x7f01009e
+			public const int colorControlHighlight = 2130772126;
+			
+			// aapt resource value: 0x7f01009c
+			public const int colorControlNormal = 2130772124;
 			
 			// aapt resource value: 0x7f010099
-			public const int windowMinWidthMajor = 2130772121;
+			public const int colorPrimary = 2130772121;
 			
 			// aapt resource value: 0x7f01009a
-			public const int windowMinWidthMinor = 2130772122;
+			public const int colorPrimaryDark = 2130772122;
+			
+			// aapt resource value: 0x7f0100a0
+			public const int colorSwitchThumbNormal = 2130772128;
+			
+			// aapt resource value: 0x7f0100db
+			public const int commitIcon = 2130772187;
+			
+			// aapt resource value: 0x7f010033
+			public const int contentInsetEnd = 2130772019;
+			
+			// aapt resource value: 0x7f010037
+			public const int contentInsetEndWithActions = 2130772023;
+			
+			// aapt resource value: 0x7f010034
+			public const int contentInsetLeft = 2130772020;
+			
+			// aapt resource value: 0x7f010035
+			public const int contentInsetRight = 2130772021;
+			
+			// aapt resource value: 0x7f010032
+			public const int contentInsetStart = 2130772018;
+			
+			// aapt resource value: 0x7f010036
+			public const int contentInsetStartWithNavigation = 2130772022;
+			
+			// aapt resource value: 0x7f010017
+			public const int contentPadding = 2130771991;
+			
+			// aapt resource value: 0x7f01001b
+			public const int contentPaddingBottom = 2130771995;
+			
+			// aapt resource value: 0x7f010018
+			public const int contentPaddingLeft = 2130771992;
+			
+			// aapt resource value: 0x7f010019
+			public const int contentPaddingRight = 2130771993;
+			
+			// aapt resource value: 0x7f01001a
+			public const int contentPaddingTop = 2130771994;
+			
+			// aapt resource value: 0x7f01010f
+			public const int contentScrim = 2130772239;
+			
+			// aapt resource value: 0x7f0100a1
+			public const int controlBackground = 2130772129;
+			
+			// aapt resource value: 0x7f010148
+			public const int counterEnabled = 2130772296;
+			
+			// aapt resource value: 0x7f010149
+			public const int counterMaxLength = 2130772297;
+			
+			// aapt resource value: 0x7f01014b
+			public const int counterOverflowTextAppearance = 2130772299;
+			
+			// aapt resource value: 0x7f01014a
+			public const int counterTextAppearance = 2130772298;
+			
+			// aapt resource value: 0x7f01002b
+			public const int customNavigationLayout = 2130772011;
+			
+			// aapt resource value: 0x7f0100d5
+			public const int defaultQueryHint = 2130772181;
+			
+			// aapt resource value: 0x7f010072
+			public const int dialogPreferredPadding = 2130772082;
+			
+			// aapt resource value: 0x7f010071
+			public const int dialogTheme = 2130772081;
+			
+			// aapt resource value: 0x7f010021
+			public const int displayOptions = 2130772001;
+			
+			// aapt resource value: 0x7f010027
+			public const int divider = 2130772007;
+			
+			// aapt resource value: 0x7f01007f
+			public const int dividerHorizontal = 2130772095;
+			
+			// aapt resource value: 0x7f0100c7
+			public const int dividerPadding = 2130772167;
+			
+			// aapt resource value: 0x7f01007e
+			public const int dividerVertical = 2130772094;
+			
+			// aapt resource value: 0x7f0100bf
+			public const int drawableSize = 2130772159;
+			
+			// aapt resource value: 0x7f01001c
+			public const int drawerArrowStyle = 2130771996;
+			
+			// aapt resource value: 0x7f010091
+			public const int dropDownListViewStyle = 2130772113;
+			
+			// aapt resource value: 0x7f010075
+			public const int dropdownListPreferredItemHeight = 2130772085;
+			
+			// aapt resource value: 0x7f010086
+			public const int editTextBackground = 2130772102;
+			
+			// aapt resource value: 0x7f010085
+			public const int editTextColor = 2130772101;
+			
+			// aapt resource value: 0x7f0100b0
+			public const int editTextStyle = 2130772144;
+			
+			// aapt resource value: 0x7f010038
+			public const int elevation = 2130772024;
+			
+			// aapt resource value: 0x7f010146
+			public const int errorEnabled = 2130772294;
+			
+			// aapt resource value: 0x7f010147
+			public const int errorTextAppearance = 2130772295;
+			
+			// aapt resource value: 0x7f01003c
+			public const int expandActivityOverflowButtonDrawable = 2130772028;
+			
+			// aapt resource value: 0x7f010100
+			public const int expanded = 2130772224;
+			
+			// aapt resource value: 0x7f010115
+			public const int expandedTitleGravity = 2130772245;
+			
+			// aapt resource value: 0x7f010108
+			public const int expandedTitleMargin = 2130772232;
+			
+			// aapt resource value: 0x7f01010c
+			public const int expandedTitleMarginBottom = 2130772236;
+			
+			// aapt resource value: 0x7f01010b
+			public const int expandedTitleMarginEnd = 2130772235;
+			
+			// aapt resource value: 0x7f010109
+			public const int expandedTitleMarginStart = 2130772233;
+			
+			// aapt resource value: 0x7f01010a
+			public const int expandedTitleMarginTop = 2130772234;
+			
+			// aapt resource value: 0x7f01010d
+			public const int expandedTitleTextAppearance = 2130772237;
+			
+			// aapt resource value: 0x7f010010
+			public const int externalRouteEnabledDrawable = 2130771984;
+			
+			// aapt resource value: 0x7f010125
+			public const int fabSize = 2130772261;
+			
+			// aapt resource value: 0x7f01012a
+			public const int foregroundInsidePadding = 2130772266;
+			
+			// aapt resource value: 0x7f0100c0
+			public const int gapBetweenBars = 2130772160;
+			
+			// aapt resource value: 0x7f0100d7
+			public const int goIcon = 2130772183;
+			
+			// aapt resource value: 0x7f010130
+			public const int headerLayout = 2130772272;
+			
+			// aapt resource value: 0x7f01001d
+			public const int height = 2130771997;
+			
+			// aapt resource value: 0x7f010031
+			public const int hideOnContentScroll = 2130772017;
+			
+			// aapt resource value: 0x7f01014c
+			public const int hintAnimationEnabled = 2130772300;
+			
+			// aapt resource value: 0x7f010145
+			public const int hintEnabled = 2130772293;
+			
+			// aapt resource value: 0x7f010144
+			public const int hintTextAppearance = 2130772292;
+			
+			// aapt resource value: 0x7f010077
+			public const int homeAsUpIndicator = 2130772087;
+			
+			// aapt resource value: 0x7f01002c
+			public const int homeLayout = 2130772012;
+			
+			// aapt resource value: 0x7f010025
+			public const int icon = 2130772005;
+			
+			// aapt resource value: 0x7f0100d3
+			public const int iconifiedByDefault = 2130772179;
+			
+			// aapt resource value: 0x7f010087
+			public const int imageButtonStyle = 2130772103;
+			
+			// aapt resource value: 0x7f01002e
+			public const int indeterminateProgressStyle = 2130772014;
+			
+			// aapt resource value: 0x7f01003b
+			public const int initialActivityCount = 2130772027;
+			
+			// aapt resource value: 0x7f010131
+			public const int insetForeground = 2130772273;
+			
+			// aapt resource value: 0x7f01001e
+			public const int isLightTheme = 2130771998;
+			
+			// aapt resource value: 0x7f01012e
+			public const int itemBackground = 2130772270;
+			
+			// aapt resource value: 0x7f01012c
+			public const int itemIconTint = 2130772268;
+			
+			// aapt resource value: 0x7f010030
+			public const int itemPadding = 2130772016;
+			
+			// aapt resource value: 0x7f01012f
+			public const int itemTextAppearance = 2130772271;
+			
+			// aapt resource value: 0x7f01012d
+			public const int itemTextColor = 2130772269;
+			
+			// aapt resource value: 0x7f010119
+			public const int keylines = 2130772249;
+			
+			// aapt resource value: 0x7f0100d2
+			public const int layout = 2130772178;
+			
+			// aapt resource value: 0x7f010000
+			public const int layoutManager = 2130771968;
+			
+			// aapt resource value: 0x7f01011c
+			public const int layout_anchor = 2130772252;
+			
+			// aapt resource value: 0x7f01011e
+			public const int layout_anchorGravity = 2130772254;
+			
+			// aapt resource value: 0x7f01011b
+			public const int layout_behavior = 2130772251;
+			
+			// aapt resource value: 0x7f010117
+			public const int layout_collapseMode = 2130772247;
+			
+			// aapt resource value: 0x7f010118
+			public const int layout_collapseParallaxMultiplier = 2130772248;
+			
+			// aapt resource value: 0x7f010120
+			public const int layout_dodgeInsetEdges = 2130772256;
+			
+			// aapt resource value: 0x7f01011f
+			public const int layout_insetEdge = 2130772255;
+			
+			// aapt resource value: 0x7f01011d
+			public const int layout_keyline = 2130772253;
+			
+			// aapt resource value: 0x7f010103
+			public const int layout_scrollFlags = 2130772227;
+			
+			// aapt resource value: 0x7f010104
+			public const int layout_scrollInterpolator = 2130772228;
+			
+			// aapt resource value: 0x7f010098
+			public const int listChoiceBackgroundIndicator = 2130772120;
+			
+			// aapt resource value: 0x7f010073
+			public const int listDividerAlertDialog = 2130772083;
+			
+			// aapt resource value: 0x7f010041
+			public const int listItemLayout = 2130772033;
+			
+			// aapt resource value: 0x7f01003e
+			public const int listLayout = 2130772030;
+			
+			// aapt resource value: 0x7f0100b8
+			public const int listMenuViewStyle = 2130772152;
 			
 			// aapt resource value: 0x7f010092
-			public const int windowNoTitle = 2130772114;
+			public const int listPopupWindowStyle = 2130772114;
+			
+			// aapt resource value: 0x7f01008c
+			public const int listPreferredItemHeight = 2130772108;
+			
+			// aapt resource value: 0x7f01008e
+			public const int listPreferredItemHeightLarge = 2130772110;
+			
+			// aapt resource value: 0x7f01008d
+			public const int listPreferredItemHeightSmall = 2130772109;
+			
+			// aapt resource value: 0x7f01008f
+			public const int listPreferredItemPaddingLeft = 2130772111;
+			
+			// aapt resource value: 0x7f010090
+			public const int listPreferredItemPaddingRight = 2130772112;
+			
+			// aapt resource value: 0x7f010026
+			public const int logo = 2130772006;
+			
+			// aapt resource value: 0x7f0100f8
+			public const int logoDescription = 2130772216;
+			
+			// aapt resource value: 0x7f010133
+			public const int maxActionInlineWidth = 2130772275;
+			
+			// aapt resource value: 0x7f0100f2
+			public const int maxButtonHeight = 2130772210;
+			
+			// aapt resource value: 0x7f0100c5
+			public const int measureWithLargestChild = 2130772165;
+			
+			// aapt resource value: 0x7f010004
+			public const int mediaRouteAudioTrackDrawable = 2130771972;
+			
+			// aapt resource value: 0x7f010005
+			public const int mediaRouteButtonStyle = 2130771973;
+			
+			// aapt resource value: 0x7f010006
+			public const int mediaRouteCloseDrawable = 2130771974;
+			
+			// aapt resource value: 0x7f010007
+			public const int mediaRouteControlPanelThemeOverlay = 2130771975;
+			
+			// aapt resource value: 0x7f010008
+			public const int mediaRouteDefaultIconDrawable = 2130771976;
+			
+			// aapt resource value: 0x7f010009
+			public const int mediaRoutePauseDrawable = 2130771977;
+			
+			// aapt resource value: 0x7f01000a
+			public const int mediaRoutePlayDrawable = 2130771978;
+			
+			// aapt resource value: 0x7f01000b
+			public const int mediaRouteSpeakerGroupIconDrawable = 2130771979;
+			
+			// aapt resource value: 0x7f01000c
+			public const int mediaRouteSpeakerIconDrawable = 2130771980;
+			
+			// aapt resource value: 0x7f01000d
+			public const int mediaRouteStopDrawable = 2130771981;
+			
+			// aapt resource value: 0x7f01000e
+			public const int mediaRouteTheme = 2130771982;
+			
+			// aapt resource value: 0x7f01000f
+			public const int mediaRouteTvIconDrawable = 2130771983;
+			
+			// aapt resource value: 0x7f01012b
+			public const int menu = 2130772267;
+			
+			// aapt resource value: 0x7f01003f
+			public const int multiChoiceItemLayout = 2130772031;
+			
+			// aapt resource value: 0x7f0100f7
+			public const int navigationContentDescription = 2130772215;
+			
+			// aapt resource value: 0x7f0100f6
+			public const int navigationIcon = 2130772214;
+			
+			// aapt resource value: 0x7f010020
+			public const int navigationMode = 2130772000;
+			
+			// aapt resource value: 0x7f0100ce
+			public const int overlapAnchor = 2130772174;
+			
+			// aapt resource value: 0x7f0100d0
+			public const int paddingBottomNoButtons = 2130772176;
+			
+			// aapt resource value: 0x7f0100fc
+			public const int paddingEnd = 2130772220;
+			
+			// aapt resource value: 0x7f0100fb
+			public const int paddingStart = 2130772219;
+			
+			// aapt resource value: 0x7f0100d1
+			public const int paddingTopNoTitle = 2130772177;
+			
+			// aapt resource value: 0x7f010095
+			public const int panelBackground = 2130772117;
+			
+			// aapt resource value: 0x7f010097
+			public const int panelMenuListTheme = 2130772119;
+			
+			// aapt resource value: 0x7f010096
+			public const int panelMenuListWidth = 2130772118;
+			
+			// aapt resource value: 0x7f01014f
+			public const int passwordToggleContentDescription = 2130772303;
+			
+			// aapt resource value: 0x7f01014e
+			public const int passwordToggleDrawable = 2130772302;
+			
+			// aapt resource value: 0x7f01014d
+			public const int passwordToggleEnabled = 2130772301;
+			
+			// aapt resource value: 0x7f010150
+			public const int passwordToggleTint = 2130772304;
+			
+			// aapt resource value: 0x7f010151
+			public const int passwordToggleTintMode = 2130772305;
+			
+			// aapt resource value: 0x7f010083
+			public const int popupMenuStyle = 2130772099;
+			
+			// aapt resource value: 0x7f010039
+			public const int popupTheme = 2130772025;
+			
+			// aapt resource value: 0x7f010084
+			public const int popupWindowStyle = 2130772100;
+			
+			// aapt resource value: 0x7f0100cc
+			public const int preserveIconSpacing = 2130772172;
+			
+			// aapt resource value: 0x7f010126
+			public const int pressedTranslationZ = 2130772262;
+			
+			// aapt resource value: 0x7f01002f
+			public const int progressBarPadding = 2130772015;
+			
+			// aapt resource value: 0x7f01002d
+			public const int progressBarStyle = 2130772013;
+			
+			// aapt resource value: 0x7f0100dd
+			public const int queryBackground = 2130772189;
+			
+			// aapt resource value: 0x7f0100d4
+			public const int queryHint = 2130772180;
+			
+			// aapt resource value: 0x7f0100b1
+			public const int radioButtonStyle = 2130772145;
+			
+			// aapt resource value: 0x7f0100b2
+			public const int ratingBarStyle = 2130772146;
+			
+			// aapt resource value: 0x7f0100b3
+			public const int ratingBarStyleIndicator = 2130772147;
+			
+			// aapt resource value: 0x7f0100b4
+			public const int ratingBarStyleSmall = 2130772148;
+			
+			// aapt resource value: 0x7f010002
+			public const int reverseLayout = 2130771970;
+			
+			// aapt resource value: 0x7f010124
+			public const int rippleColor = 2130772260;
+			
+			// aapt resource value: 0x7f010113
+			public const int scrimAnimationDuration = 2130772243;
+			
+			// aapt resource value: 0x7f010112
+			public const int scrimVisibleHeightTrigger = 2130772242;
+			
+			// aapt resource value: 0x7f0100d9
+			public const int searchHintIcon = 2130772185;
+			
+			// aapt resource value: 0x7f0100d8
+			public const int searchIcon = 2130772184;
+			
+			// aapt resource value: 0x7f01008b
+			public const int searchViewStyle = 2130772107;
+			
+			// aapt resource value: 0x7f0100b5
+			public const int seekBarStyle = 2130772149;
+			
+			// aapt resource value: 0x7f01007b
+			public const int selectableItemBackground = 2130772091;
+			
+			// aapt resource value: 0x7f01007c
+			public const int selectableItemBackgroundBorderless = 2130772092;
+			
+			// aapt resource value: 0x7f0100c8
+			public const int showAsAction = 2130772168;
+			
+			// aapt resource value: 0x7f0100c6
+			public const int showDividers = 2130772166;
+			
+			// aapt resource value: 0x7f0100e9
+			public const int showText = 2130772201;
+			
+			// aapt resource value: 0x7f010042
+			public const int showTitle = 2130772034;
+			
+			// aapt resource value: 0x7f010040
+			public const int singleChoiceItemLayout = 2130772032;
+			
+			// aapt resource value: 0x7f010001
+			public const int spanCount = 2130771969;
+			
+			// aapt resource value: 0x7f0100be
+			public const int spinBars = 2130772158;
+			
+			// aapt resource value: 0x7f010076
+			public const int spinnerDropDownItemStyle = 2130772086;
+			
+			// aapt resource value: 0x7f0100b6
+			public const int spinnerStyle = 2130772150;
+			
+			// aapt resource value: 0x7f0100e8
+			public const int splitTrack = 2130772200;
+			
+			// aapt resource value: 0x7f010043
+			public const int srcCompat = 2130772035;
+			
+			// aapt resource value: 0x7f010003
+			public const int stackFromEnd = 2130771971;
+			
+			// aapt resource value: 0x7f0100cf
+			public const int state_above_anchor = 2130772175;
+			
+			// aapt resource value: 0x7f010101
+			public const int state_collapsed = 2130772225;
+			
+			// aapt resource value: 0x7f010102
+			public const int state_collapsible = 2130772226;
+			
+			// aapt resource value: 0x7f01011a
+			public const int statusBarBackground = 2130772250;
+			
+			// aapt resource value: 0x7f010110
+			public const int statusBarScrim = 2130772240;
+			
+			// aapt resource value: 0x7f0100cd
+			public const int subMenuArrow = 2130772173;
+			
+			// aapt resource value: 0x7f0100de
+			public const int submitBackground = 2130772190;
+			
+			// aapt resource value: 0x7f010022
+			public const int subtitle = 2130772002;
+			
+			// aapt resource value: 0x7f0100eb
+			public const int subtitleTextAppearance = 2130772203;
+			
+			// aapt resource value: 0x7f0100fa
+			public const int subtitleTextColor = 2130772218;
+			
+			// aapt resource value: 0x7f010024
+			public const int subtitleTextStyle = 2130772004;
+			
+			// aapt resource value: 0x7f0100dc
+			public const int suggestionRowLayout = 2130772188;
+			
+			// aapt resource value: 0x7f0100e6
+			public const int switchMinWidth = 2130772198;
+			
+			// aapt resource value: 0x7f0100e7
+			public const int switchPadding = 2130772199;
+			
+			// aapt resource value: 0x7f0100b7
+			public const int switchStyle = 2130772151;
+			
+			// aapt resource value: 0x7f0100e5
+			public const int switchTextAppearance = 2130772197;
+			
+			// aapt resource value: 0x7f010137
+			public const int tabBackground = 2130772279;
+			
+			// aapt resource value: 0x7f010136
+			public const int tabContentStart = 2130772278;
+			
+			// aapt resource value: 0x7f010139
+			public const int tabGravity = 2130772281;
+			
+			// aapt resource value: 0x7f010134
+			public const int tabIndicatorColor = 2130772276;
+			
+			// aapt resource value: 0x7f010135
+			public const int tabIndicatorHeight = 2130772277;
+			
+			// aapt resource value: 0x7f01013b
+			public const int tabMaxWidth = 2130772283;
+			
+			// aapt resource value: 0x7f01013a
+			public const int tabMinWidth = 2130772282;
+			
+			// aapt resource value: 0x7f010138
+			public const int tabMode = 2130772280;
+			
+			// aapt resource value: 0x7f010143
+			public const int tabPadding = 2130772291;
+			
+			// aapt resource value: 0x7f010142
+			public const int tabPaddingBottom = 2130772290;
+			
+			// aapt resource value: 0x7f010141
+			public const int tabPaddingEnd = 2130772289;
+			
+			// aapt resource value: 0x7f01013f
+			public const int tabPaddingStart = 2130772287;
+			
+			// aapt resource value: 0x7f010140
+			public const int tabPaddingTop = 2130772288;
+			
+			// aapt resource value: 0x7f01013e
+			public const int tabSelectedTextColor = 2130772286;
+			
+			// aapt resource value: 0x7f01013c
+			public const int tabTextAppearance = 2130772284;
+			
+			// aapt resource value: 0x7f01013d
+			public const int tabTextColor = 2130772285;
+			
+			// aapt resource value: 0x7f010047
+			public const int textAllCaps = 2130772039;
+			
+			// aapt resource value: 0x7f01006e
+			public const int textAppearanceLargePopupMenu = 2130772078;
+			
+			// aapt resource value: 0x7f010093
+			public const int textAppearanceListItem = 2130772115;
+			
+			// aapt resource value: 0x7f010094
+			public const int textAppearanceListItemSmall = 2130772116;
+			
+			// aapt resource value: 0x7f010070
+			public const int textAppearancePopupMenuHeader = 2130772080;
+			
+			// aapt resource value: 0x7f010089
+			public const int textAppearanceSearchResultSubtitle = 2130772105;
+			
+			// aapt resource value: 0x7f010088
+			public const int textAppearanceSearchResultTitle = 2130772104;
+			
+			// aapt resource value: 0x7f01006f
+			public const int textAppearanceSmallPopupMenu = 2130772079;
+			
+			// aapt resource value: 0x7f0100a7
+			public const int textColorAlertDialogListItem = 2130772135;
+			
+			// aapt resource value: 0x7f010123
+			public const int textColorError = 2130772259;
+			
+			// aapt resource value: 0x7f01008a
+			public const int textColorSearchUrl = 2130772106;
+			
+			// aapt resource value: 0x7f0100fd
+			public const int theme = 2130772221;
+			
+			// aapt resource value: 0x7f0100c4
+			public const int thickness = 2130772164;
+			
+			// aapt resource value: 0x7f0100e4
+			public const int thumbTextPadding = 2130772196;
+			
+			// aapt resource value: 0x7f0100df
+			public const int thumbTint = 2130772191;
+			
+			// aapt resource value: 0x7f0100e0
+			public const int thumbTintMode = 2130772192;
+			
+			// aapt resource value: 0x7f010044
+			public const int tickMark = 2130772036;
+			
+			// aapt resource value: 0x7f010045
+			public const int tickMarkTint = 2130772037;
+			
+			// aapt resource value: 0x7f010046
+			public const int tickMarkTintMode = 2130772038;
+			
+			// aapt resource value: 0x7f01001f
+			public const int title = 2130771999;
+			
+			// aapt resource value: 0x7f010116
+			public const int titleEnabled = 2130772246;
+			
+			// aapt resource value: 0x7f0100ec
+			public const int titleMargin = 2130772204;
+			
+			// aapt resource value: 0x7f0100f0
+			public const int titleMarginBottom = 2130772208;
+			
+			// aapt resource value: 0x7f0100ee
+			public const int titleMarginEnd = 2130772206;
+			
+			// aapt resource value: 0x7f0100ed
+			public const int titleMarginStart = 2130772205;
+			
+			// aapt resource value: 0x7f0100ef
+			public const int titleMarginTop = 2130772207;
+			
+			// aapt resource value: 0x7f0100f1
+			public const int titleMargins = 2130772209;
+			
+			// aapt resource value: 0x7f0100ea
+			public const int titleTextAppearance = 2130772202;
+			
+			// aapt resource value: 0x7f0100f9
+			public const int titleTextColor = 2130772217;
+			
+			// aapt resource value: 0x7f010023
+			public const int titleTextStyle = 2130772003;
+			
+			// aapt resource value: 0x7f010111
+			public const int toolbarId = 2130772241;
+			
+			// aapt resource value: 0x7f010082
+			public const int toolbarNavigationButtonStyle = 2130772098;
+			
+			// aapt resource value: 0x7f010081
+			public const int toolbarStyle = 2130772097;
+			
+			// aapt resource value: 0x7f0100e1
+			public const int track = 2130772193;
+			
+			// aapt resource value: 0x7f0100e2
+			public const int trackTint = 2130772194;
+			
+			// aapt resource value: 0x7f0100e3
+			public const int trackTintMode = 2130772195;
+			
+			// aapt resource value: 0x7f010128
+			public const int useCompatPadding = 2130772264;
+			
+			// aapt resource value: 0x7f0100da
+			public const int voiceIcon = 2130772186;
+			
+			// aapt resource value: 0x7f010048
+			public const int windowActionBar = 2130772040;
+			
+			// aapt resource value: 0x7f01004a
+			public const int windowActionBarOverlay = 2130772042;
+			
+			// aapt resource value: 0x7f01004b
+			public const int windowActionModeOverlay = 2130772043;
+			
+			// aapt resource value: 0x7f01004f
+			public const int windowFixedHeightMajor = 2130772047;
+			
+			// aapt resource value: 0x7f01004d
+			public const int windowFixedHeightMinor = 2130772045;
+			
+			// aapt resource value: 0x7f01004c
+			public const int windowFixedWidthMajor = 2130772044;
+			
+			// aapt resource value: 0x7f01004e
+			public const int windowFixedWidthMinor = 2130772046;
+			
+			// aapt resource value: 0x7f010050
+			public const int windowMinWidthMajor = 2130772048;
+			
+			// aapt resource value: 0x7f010051
+			public const int windowMinWidthMinor = 2130772049;
+			
+			// aapt resource value: 0x7f010049
+			public const int windowNoTitle = 2130772041;
 			
 			static Attribute()
 			{
@@ -2839,29 +3248,20 @@ namespace XFGlossSample.Droid
 		public partial class Boolean
 		{
 			
-			// aapt resource value: 0x7f0c0003
-			public const int abc_action_bar_embed_tabs = 2131492867;
+			// aapt resource value: 0x7f0d0000
+			public const int abc_action_bar_embed_tabs = 2131558400;
 			
-			// aapt resource value: 0x7f0c0001
-			public const int abc_action_bar_embed_tabs_pre_jb = 2131492865;
+			// aapt resource value: 0x7f0d0001
+			public const int abc_allow_stacked_button_bar = 2131558401;
 			
-			// aapt resource value: 0x7f0c0004
-			public const int abc_action_bar_expanded_action_views_exclusive = 2131492868;
+			// aapt resource value: 0x7f0d0002
+			public const int abc_config_actionMenuItemAllCaps = 2131558402;
 			
-			// aapt resource value: 0x7f0c0000
-			public const int abc_allow_stacked_button_bar = 2131492864;
+			// aapt resource value: 0x7f0d0003
+			public const int abc_config_closeDialogWhenTouchOutside = 2131558403;
 			
-			// aapt resource value: 0x7f0c0005
-			public const int abc_config_actionMenuItemAllCaps = 2131492869;
-			
-			// aapt resource value: 0x7f0c0002
-			public const int abc_config_allowActionMenuItemTextWithIcon = 2131492866;
-			
-			// aapt resource value: 0x7f0c0006
-			public const int abc_config_closeDialogWhenTouchOutside = 2131492870;
-			
-			// aapt resource value: 0x7f0c0007
-			public const int abc_config_showMenuShortcutsWhenKeyboardPresent = 2131492871;
+			// aapt resource value: 0x7f0d0004
+			public const int abc_config_showMenuShortcutsWhenKeyboardPresent = 2131558404;
 			
 			static Boolean()
 			{
@@ -2876,257 +3276,302 @@ namespace XFGlossSample.Droid
 		public partial class Color
 		{
 			
-			// aapt resource value: 0x7f0a0048
-			public const int abc_background_cache_hint_selector_material_dark = 2131361864;
+			// aapt resource value: 0x7f0c004a
+			public const int abc_background_cache_hint_selector_material_dark = 2131492938;
 			
-			// aapt resource value: 0x7f0a0049
-			public const int abc_background_cache_hint_selector_material_light = 2131361865;
+			// aapt resource value: 0x7f0c004b
+			public const int abc_background_cache_hint_selector_material_light = 2131492939;
 			
-			// aapt resource value: 0x7f0a004a
-			public const int abc_color_highlight_material = 2131361866;
+			// aapt resource value: 0x7f0c004c
+			public const int abc_btn_colored_borderless_text_material = 2131492940;
 			
-			// aapt resource value: 0x7f0a000e
-			public const int abc_input_method_navigation_guard = 2131361806;
+			// aapt resource value: 0x7f0c004d
+			public const int abc_btn_colored_text_material = 2131492941;
 			
-			// aapt resource value: 0x7f0a004b
-			public const int abc_primary_text_disable_only_material_dark = 2131361867;
+			// aapt resource value: 0x7f0c004e
+			public const int abc_color_highlight_material = 2131492942;
 			
-			// aapt resource value: 0x7f0a004c
-			public const int abc_primary_text_disable_only_material_light = 2131361868;
+			// aapt resource value: 0x7f0c004f
+			public const int abc_hint_foreground_material_dark = 2131492943;
 			
-			// aapt resource value: 0x7f0a004d
-			public const int abc_primary_text_material_dark = 2131361869;
+			// aapt resource value: 0x7f0c0050
+			public const int abc_hint_foreground_material_light = 2131492944;
 			
-			// aapt resource value: 0x7f0a004e
-			public const int abc_primary_text_material_light = 2131361870;
+			// aapt resource value: 0x7f0c0005
+			public const int abc_input_method_navigation_guard = 2131492869;
 			
-			// aapt resource value: 0x7f0a004f
-			public const int abc_search_url_text = 2131361871;
+			// aapt resource value: 0x7f0c0051
+			public const int abc_primary_text_disable_only_material_dark = 2131492945;
 			
-			// aapt resource value: 0x7f0a000f
-			public const int abc_search_url_text_normal = 2131361807;
+			// aapt resource value: 0x7f0c0052
+			public const int abc_primary_text_disable_only_material_light = 2131492946;
 			
-			// aapt resource value: 0x7f0a0010
-			public const int abc_search_url_text_pressed = 2131361808;
+			// aapt resource value: 0x7f0c0053
+			public const int abc_primary_text_material_dark = 2131492947;
 			
-			// aapt resource value: 0x7f0a0011
-			public const int abc_search_url_text_selected = 2131361809;
+			// aapt resource value: 0x7f0c0054
+			public const int abc_primary_text_material_light = 2131492948;
 			
-			// aapt resource value: 0x7f0a0050
-			public const int abc_secondary_text_material_dark = 2131361872;
+			// aapt resource value: 0x7f0c0055
+			public const int abc_search_url_text = 2131492949;
 			
-			// aapt resource value: 0x7f0a0051
-			public const int abc_secondary_text_material_light = 2131361873;
+			// aapt resource value: 0x7f0c0006
+			public const int abc_search_url_text_normal = 2131492870;
 			
-			// aapt resource value: 0x7f0a0012
-			public const int accent_material_dark = 2131361810;
+			// aapt resource value: 0x7f0c0007
+			public const int abc_search_url_text_pressed = 2131492871;
 			
-			// aapt resource value: 0x7f0a0013
-			public const int accent_material_light = 2131361811;
+			// aapt resource value: 0x7f0c0008
+			public const int abc_search_url_text_selected = 2131492872;
 			
-			// aapt resource value: 0x7f0a0014
-			public const int background_floating_material_dark = 2131361812;
+			// aapt resource value: 0x7f0c0056
+			public const int abc_secondary_text_material_dark = 2131492950;
 			
-			// aapt resource value: 0x7f0a0015
-			public const int background_floating_material_light = 2131361813;
+			// aapt resource value: 0x7f0c0057
+			public const int abc_secondary_text_material_light = 2131492951;
 			
-			// aapt resource value: 0x7f0a0016
-			public const int background_material_dark = 2131361814;
+			// aapt resource value: 0x7f0c0058
+			public const int abc_tint_btn_checkable = 2131492952;
 			
-			// aapt resource value: 0x7f0a0017
-			public const int background_material_light = 2131361815;
+			// aapt resource value: 0x7f0c0059
+			public const int abc_tint_default = 2131492953;
 			
-			// aapt resource value: 0x7f0a0018
-			public const int bright_foreground_disabled_material_dark = 2131361816;
+			// aapt resource value: 0x7f0c005a
+			public const int abc_tint_edittext = 2131492954;
 			
-			// aapt resource value: 0x7f0a0019
-			public const int bright_foreground_disabled_material_light = 2131361817;
+			// aapt resource value: 0x7f0c005b
+			public const int abc_tint_seek_thumb = 2131492955;
 			
-			// aapt resource value: 0x7f0a001a
-			public const int bright_foreground_inverse_material_dark = 2131361818;
+			// aapt resource value: 0x7f0c005c
+			public const int abc_tint_spinner = 2131492956;
 			
-			// aapt resource value: 0x7f0a001b
-			public const int bright_foreground_inverse_material_light = 2131361819;
+			// aapt resource value: 0x7f0c005d
+			public const int abc_tint_switch_thumb = 2131492957;
 			
-			// aapt resource value: 0x7f0a001c
-			public const int bright_foreground_material_dark = 2131361820;
+			// aapt resource value: 0x7f0c005e
+			public const int abc_tint_switch_track = 2131492958;
 			
-			// aapt resource value: 0x7f0a001d
-			public const int bright_foreground_material_light = 2131361821;
+			// aapt resource value: 0x7f0c0009
+			public const int accent_material_dark = 2131492873;
 			
-			// aapt resource value: 0x7f0a001e
-			public const int button_material_dark = 2131361822;
+			// aapt resource value: 0x7f0c000a
+			public const int accent_material_light = 2131492874;
 			
-			// aapt resource value: 0x7f0a001f
-			public const int button_material_light = 2131361823;
+			// aapt resource value: 0x7f0c000b
+			public const int background_floating_material_dark = 2131492875;
 			
-			// aapt resource value: 0x7f0a0000
-			public const int cardview_dark_background = 2131361792;
+			// aapt resource value: 0x7f0c000c
+			public const int background_floating_material_light = 2131492876;
 			
-			// aapt resource value: 0x7f0a0001
-			public const int cardview_light_background = 2131361793;
+			// aapt resource value: 0x7f0c000d
+			public const int background_material_dark = 2131492877;
 			
-			// aapt resource value: 0x7f0a0002
-			public const int cardview_shadow_end_color = 2131361794;
+			// aapt resource value: 0x7f0c000e
+			public const int background_material_light = 2131492878;
 			
-			// aapt resource value: 0x7f0a0003
-			public const int cardview_shadow_start_color = 2131361795;
+			// aapt resource value: 0x7f0c000f
+			public const int bright_foreground_disabled_material_dark = 2131492879;
 			
-			// aapt resource value: 0x7f0a0004
-			public const int design_fab_shadow_end_color = 2131361796;
+			// aapt resource value: 0x7f0c0010
+			public const int bright_foreground_disabled_material_light = 2131492880;
 			
-			// aapt resource value: 0x7f0a0005
-			public const int design_fab_shadow_mid_color = 2131361797;
+			// aapt resource value: 0x7f0c0011
+			public const int bright_foreground_inverse_material_dark = 2131492881;
 			
-			// aapt resource value: 0x7f0a0006
-			public const int design_fab_shadow_start_color = 2131361798;
+			// aapt resource value: 0x7f0c0012
+			public const int bright_foreground_inverse_material_light = 2131492882;
 			
-			// aapt resource value: 0x7f0a0007
-			public const int design_fab_stroke_end_inner_color = 2131361799;
+			// aapt resource value: 0x7f0c0013
+			public const int bright_foreground_material_dark = 2131492883;
 			
-			// aapt resource value: 0x7f0a0008
-			public const int design_fab_stroke_end_outer_color = 2131361800;
+			// aapt resource value: 0x7f0c0014
+			public const int bright_foreground_material_light = 2131492884;
 			
-			// aapt resource value: 0x7f0a0009
-			public const int design_fab_stroke_top_inner_color = 2131361801;
+			// aapt resource value: 0x7f0c0015
+			public const int button_material_dark = 2131492885;
 			
-			// aapt resource value: 0x7f0a000a
-			public const int design_fab_stroke_top_outer_color = 2131361802;
+			// aapt resource value: 0x7f0c0016
+			public const int button_material_light = 2131492886;
 			
-			// aapt resource value: 0x7f0a000b
-			public const int design_snackbar_background_color = 2131361803;
+			// aapt resource value: 0x7f0c0000
+			public const int cardview_dark_background = 2131492864;
 			
-			// aapt resource value: 0x7f0a000c
-			public const int design_textinput_error_color_dark = 2131361804;
+			// aapt resource value: 0x7f0c0001
+			public const int cardview_light_background = 2131492865;
 			
-			// aapt resource value: 0x7f0a000d
-			public const int design_textinput_error_color_light = 2131361805;
+			// aapt resource value: 0x7f0c0002
+			public const int cardview_shadow_end_color = 2131492866;
 			
-			// aapt resource value: 0x7f0a0020
-			public const int dim_foreground_disabled_material_dark = 2131361824;
+			// aapt resource value: 0x7f0c0003
+			public const int cardview_shadow_start_color = 2131492867;
 			
-			// aapt resource value: 0x7f0a0021
-			public const int dim_foreground_disabled_material_light = 2131361825;
+			// aapt resource value: 0x7f0c003f
+			public const int design_bottom_navigation_shadow_color = 2131492927;
 			
-			// aapt resource value: 0x7f0a0022
-			public const int dim_foreground_material_dark = 2131361826;
+			// aapt resource value: 0x7f0c005f
+			public const int design_error = 2131492959;
 			
-			// aapt resource value: 0x7f0a0023
-			public const int dim_foreground_material_light = 2131361827;
+			// aapt resource value: 0x7f0c0040
+			public const int design_fab_shadow_end_color = 2131492928;
 			
-			// aapt resource value: 0x7f0a0024
-			public const int foreground_material_dark = 2131361828;
+			// aapt resource value: 0x7f0c0041
+			public const int design_fab_shadow_mid_color = 2131492929;
 			
-			// aapt resource value: 0x7f0a0025
-			public const int foreground_material_light = 2131361829;
+			// aapt resource value: 0x7f0c0042
+			public const int design_fab_shadow_start_color = 2131492930;
 			
-			// aapt resource value: 0x7f0a0026
-			public const int highlighted_text_material_dark = 2131361830;
+			// aapt resource value: 0x7f0c0043
+			public const int design_fab_stroke_end_inner_color = 2131492931;
 			
-			// aapt resource value: 0x7f0a0027
-			public const int highlighted_text_material_light = 2131361831;
+			// aapt resource value: 0x7f0c0044
+			public const int design_fab_stroke_end_outer_color = 2131492932;
 			
-			// aapt resource value: 0x7f0a0028
-			public const int hint_foreground_material_dark = 2131361832;
+			// aapt resource value: 0x7f0c0045
+			public const int design_fab_stroke_top_inner_color = 2131492933;
 			
-			// aapt resource value: 0x7f0a0029
-			public const int hint_foreground_material_light = 2131361833;
+			// aapt resource value: 0x7f0c0046
+			public const int design_fab_stroke_top_outer_color = 2131492934;
 			
-			// aapt resource value: 0x7f0a002a
-			public const int material_blue_grey_800 = 2131361834;
+			// aapt resource value: 0x7f0c0047
+			public const int design_snackbar_background_color = 2131492935;
 			
-			// aapt resource value: 0x7f0a002b
-			public const int material_blue_grey_900 = 2131361835;
+			// aapt resource value: 0x7f0c0048
+			public const int design_textinput_error_color_dark = 2131492936;
 			
-			// aapt resource value: 0x7f0a002c
-			public const int material_blue_grey_950 = 2131361836;
+			// aapt resource value: 0x7f0c0049
+			public const int design_textinput_error_color_light = 2131492937;
 			
-			// aapt resource value: 0x7f0a002d
-			public const int material_deep_teal_200 = 2131361837;
+			// aapt resource value: 0x7f0c0060
+			public const int design_tint_password_toggle = 2131492960;
 			
-			// aapt resource value: 0x7f0a002e
-			public const int material_deep_teal_500 = 2131361838;
+			// aapt resource value: 0x7f0c0017
+			public const int dim_foreground_disabled_material_dark = 2131492887;
 			
-			// aapt resource value: 0x7f0a002f
-			public const int material_grey_100 = 2131361839;
+			// aapt resource value: 0x7f0c0018
+			public const int dim_foreground_disabled_material_light = 2131492888;
 			
-			// aapt resource value: 0x7f0a0030
-			public const int material_grey_300 = 2131361840;
+			// aapt resource value: 0x7f0c0019
+			public const int dim_foreground_material_dark = 2131492889;
 			
-			// aapt resource value: 0x7f0a0031
-			public const int material_grey_50 = 2131361841;
+			// aapt resource value: 0x7f0c001a
+			public const int dim_foreground_material_light = 2131492890;
 			
-			// aapt resource value: 0x7f0a0032
-			public const int material_grey_600 = 2131361842;
+			// aapt resource value: 0x7f0c001b
+			public const int foreground_material_dark = 2131492891;
 			
-			// aapt resource value: 0x7f0a0033
-			public const int material_grey_800 = 2131361843;
+			// aapt resource value: 0x7f0c001c
+			public const int foreground_material_light = 2131492892;
 			
-			// aapt resource value: 0x7f0a0034
-			public const int material_grey_850 = 2131361844;
+			// aapt resource value: 0x7f0c001d
+			public const int highlighted_text_material_dark = 2131492893;
 			
-			// aapt resource value: 0x7f0a0035
-			public const int material_grey_900 = 2131361845;
+			// aapt resource value: 0x7f0c001e
+			public const int highlighted_text_material_light = 2131492894;
 			
-			// aapt resource value: 0x7f0a0036
-			public const int primary_dark_material_dark = 2131361846;
+			// aapt resource value: 0x7f0c001f
+			public const int material_blue_grey_800 = 2131492895;
 			
-			// aapt resource value: 0x7f0a0037
-			public const int primary_dark_material_light = 2131361847;
+			// aapt resource value: 0x7f0c0020
+			public const int material_blue_grey_900 = 2131492896;
 			
-			// aapt resource value: 0x7f0a0038
-			public const int primary_material_dark = 2131361848;
+			// aapt resource value: 0x7f0c0021
+			public const int material_blue_grey_950 = 2131492897;
 			
-			// aapt resource value: 0x7f0a0039
-			public const int primary_material_light = 2131361849;
+			// aapt resource value: 0x7f0c0022
+			public const int material_deep_teal_200 = 2131492898;
 			
-			// aapt resource value: 0x7f0a003a
-			public const int primary_text_default_material_dark = 2131361850;
+			// aapt resource value: 0x7f0c0023
+			public const int material_deep_teal_500 = 2131492899;
 			
-			// aapt resource value: 0x7f0a003b
-			public const int primary_text_default_material_light = 2131361851;
+			// aapt resource value: 0x7f0c0024
+			public const int material_grey_100 = 2131492900;
 			
-			// aapt resource value: 0x7f0a003c
-			public const int primary_text_disabled_material_dark = 2131361852;
+			// aapt resource value: 0x7f0c0025
+			public const int material_grey_300 = 2131492901;
 			
-			// aapt resource value: 0x7f0a003d
-			public const int primary_text_disabled_material_light = 2131361853;
+			// aapt resource value: 0x7f0c0026
+			public const int material_grey_50 = 2131492902;
 			
-			// aapt resource value: 0x7f0a003e
-			public const int ripple_material_dark = 2131361854;
+			// aapt resource value: 0x7f0c0027
+			public const int material_grey_600 = 2131492903;
 			
-			// aapt resource value: 0x7f0a003f
-			public const int ripple_material_light = 2131361855;
+			// aapt resource value: 0x7f0c0028
+			public const int material_grey_800 = 2131492904;
 			
-			// aapt resource value: 0x7f0a0040
-			public const int secondary_text_default_material_dark = 2131361856;
+			// aapt resource value: 0x7f0c0029
+			public const int material_grey_850 = 2131492905;
 			
-			// aapt resource value: 0x7f0a0041
-			public const int secondary_text_default_material_light = 2131361857;
+			// aapt resource value: 0x7f0c002a
+			public const int material_grey_900 = 2131492906;
 			
-			// aapt resource value: 0x7f0a0042
-			public const int secondary_text_disabled_material_dark = 2131361858;
+			// aapt resource value: 0x7f0c0004
+			public const int notification_action_color_filter = 2131492868;
 			
-			// aapt resource value: 0x7f0a0043
-			public const int secondary_text_disabled_material_light = 2131361859;
+			// aapt resource value: 0x7f0c002b
+			public const int notification_icon_bg_color = 2131492907;
 			
-			// aapt resource value: 0x7f0a0044
-			public const int switch_thumb_disabled_material_dark = 2131361860;
+			// aapt resource value: 0x7f0c002c
+			public const int notification_material_background_media_default_color = 2131492908;
 			
-			// aapt resource value: 0x7f0a0045
-			public const int switch_thumb_disabled_material_light = 2131361861;
+			// aapt resource value: 0x7f0c002d
+			public const int primary_dark_material_dark = 2131492909;
 			
-			// aapt resource value: 0x7f0a0052
-			public const int switch_thumb_material_dark = 2131361874;
+			// aapt resource value: 0x7f0c002e
+			public const int primary_dark_material_light = 2131492910;
 			
-			// aapt resource value: 0x7f0a0053
-			public const int switch_thumb_material_light = 2131361875;
+			// aapt resource value: 0x7f0c002f
+			public const int primary_material_dark = 2131492911;
 			
-			// aapt resource value: 0x7f0a0046
-			public const int switch_thumb_normal_material_dark = 2131361862;
+			// aapt resource value: 0x7f0c0030
+			public const int primary_material_light = 2131492912;
 			
-			// aapt resource value: 0x7f0a0047
-			public const int switch_thumb_normal_material_light = 2131361863;
+			// aapt resource value: 0x7f0c0031
+			public const int primary_text_default_material_dark = 2131492913;
+			
+			// aapt resource value: 0x7f0c0032
+			public const int primary_text_default_material_light = 2131492914;
+			
+			// aapt resource value: 0x7f0c0033
+			public const int primary_text_disabled_material_dark = 2131492915;
+			
+			// aapt resource value: 0x7f0c0034
+			public const int primary_text_disabled_material_light = 2131492916;
+			
+			// aapt resource value: 0x7f0c0035
+			public const int ripple_material_dark = 2131492917;
+			
+			// aapt resource value: 0x7f0c0036
+			public const int ripple_material_light = 2131492918;
+			
+			// aapt resource value: 0x7f0c0037
+			public const int secondary_text_default_material_dark = 2131492919;
+			
+			// aapt resource value: 0x7f0c0038
+			public const int secondary_text_default_material_light = 2131492920;
+			
+			// aapt resource value: 0x7f0c0039
+			public const int secondary_text_disabled_material_dark = 2131492921;
+			
+			// aapt resource value: 0x7f0c003a
+			public const int secondary_text_disabled_material_light = 2131492922;
+			
+			// aapt resource value: 0x7f0c003b
+			public const int switch_thumb_disabled_material_dark = 2131492923;
+			
+			// aapt resource value: 0x7f0c003c
+			public const int switch_thumb_disabled_material_light = 2131492924;
+			
+			// aapt resource value: 0x7f0c0061
+			public const int switch_thumb_material_dark = 2131492961;
+			
+			// aapt resource value: 0x7f0c0062
+			public const int switch_thumb_material_light = 2131492962;
+			
+			// aapt resource value: 0x7f0c003d
+			public const int switch_thumb_normal_material_dark = 2131492925;
+			
+			// aapt resource value: 0x7f0c003e
+			public const int switch_thumb_normal_material_light = 2131492926;
 			
 			static Color()
 			{
@@ -3141,353 +3586,449 @@ namespace XFGlossSample.Droid
 		public partial class Dimension
 		{
 			
-			// aapt resource value: 0x7f070036
-			public const int abc_action_bar_content_inset_material = 2131165238;
+			// aapt resource value: 0x7f080018
+			public const int abc_action_bar_content_inset_material = 2131230744;
 			
-			// aapt resource value: 0x7f07002a
-			public const int abc_action_bar_default_height_material = 2131165226;
+			// aapt resource value: 0x7f080019
+			public const int abc_action_bar_content_inset_with_nav = 2131230745;
 			
-			// aapt resource value: 0x7f070037
-			public const int abc_action_bar_default_padding_end_material = 2131165239;
+			// aapt resource value: 0x7f08000d
+			public const int abc_action_bar_default_height_material = 2131230733;
 			
-			// aapt resource value: 0x7f070038
-			public const int abc_action_bar_default_padding_start_material = 2131165240;
+			// aapt resource value: 0x7f08001a
+			public const int abc_action_bar_default_padding_end_material = 2131230746;
 			
-			// aapt resource value: 0x7f07003a
-			public const int abc_action_bar_icon_vertical_padding_material = 2131165242;
+			// aapt resource value: 0x7f08001b
+			public const int abc_action_bar_default_padding_start_material = 2131230747;
 			
-			// aapt resource value: 0x7f07003b
-			public const int abc_action_bar_overflow_padding_end_material = 2131165243;
+			// aapt resource value: 0x7f080021
+			public const int abc_action_bar_elevation_material = 2131230753;
 			
-			// aapt resource value: 0x7f07003c
-			public const int abc_action_bar_overflow_padding_start_material = 2131165244;
+			// aapt resource value: 0x7f080022
+			public const int abc_action_bar_icon_vertical_padding_material = 2131230754;
 			
-			// aapt resource value: 0x7f07002b
-			public const int abc_action_bar_progress_bar_size = 2131165227;
+			// aapt resource value: 0x7f080023
+			public const int abc_action_bar_overflow_padding_end_material = 2131230755;
 			
-			// aapt resource value: 0x7f07003d
-			public const int abc_action_bar_stacked_max_height = 2131165245;
+			// aapt resource value: 0x7f080024
+			public const int abc_action_bar_overflow_padding_start_material = 2131230756;
 			
-			// aapt resource value: 0x7f07003e
-			public const int abc_action_bar_stacked_tab_max_width = 2131165246;
+			// aapt resource value: 0x7f08000e
+			public const int abc_action_bar_progress_bar_size = 2131230734;
 			
-			// aapt resource value: 0x7f07003f
-			public const int abc_action_bar_subtitle_bottom_margin_material = 2131165247;
+			// aapt resource value: 0x7f080025
+			public const int abc_action_bar_stacked_max_height = 2131230757;
 			
-			// aapt resource value: 0x7f070040
-			public const int abc_action_bar_subtitle_top_margin_material = 2131165248;
+			// aapt resource value: 0x7f080026
+			public const int abc_action_bar_stacked_tab_max_width = 2131230758;
 			
-			// aapt resource value: 0x7f070041
-			public const int abc_action_button_min_height_material = 2131165249;
+			// aapt resource value: 0x7f080027
+			public const int abc_action_bar_subtitle_bottom_margin_material = 2131230759;
 			
-			// aapt resource value: 0x7f070042
-			public const int abc_action_button_min_width_material = 2131165250;
+			// aapt resource value: 0x7f080028
+			public const int abc_action_bar_subtitle_top_margin_material = 2131230760;
 			
-			// aapt resource value: 0x7f070043
-			public const int abc_action_button_min_width_overflow_material = 2131165251;
+			// aapt resource value: 0x7f080029
+			public const int abc_action_button_min_height_material = 2131230761;
 			
-			// aapt resource value: 0x7f070029
-			public const int abc_alert_dialog_button_bar_height = 2131165225;
+			// aapt resource value: 0x7f08002a
+			public const int abc_action_button_min_width_material = 2131230762;
 			
-			// aapt resource value: 0x7f070044
-			public const int abc_button_inset_horizontal_material = 2131165252;
+			// aapt resource value: 0x7f08002b
+			public const int abc_action_button_min_width_overflow_material = 2131230763;
 			
-			// aapt resource value: 0x7f070045
-			public const int abc_button_inset_vertical_material = 2131165253;
+			// aapt resource value: 0x7f08000c
+			public const int abc_alert_dialog_button_bar_height = 2131230732;
 			
-			// aapt resource value: 0x7f070046
-			public const int abc_button_padding_horizontal_material = 2131165254;
+			// aapt resource value: 0x7f08002c
+			public const int abc_button_inset_horizontal_material = 2131230764;
 			
-			// aapt resource value: 0x7f070047
-			public const int abc_button_padding_vertical_material = 2131165255;
+			// aapt resource value: 0x7f08002d
+			public const int abc_button_inset_vertical_material = 2131230765;
 			
-			// aapt resource value: 0x7f07002e
-			public const int abc_config_prefDialogWidth = 2131165230;
+			// aapt resource value: 0x7f08002e
+			public const int abc_button_padding_horizontal_material = 2131230766;
 			
-			// aapt resource value: 0x7f070048
-			public const int abc_control_corner_material = 2131165256;
+			// aapt resource value: 0x7f08002f
+			public const int abc_button_padding_vertical_material = 2131230767;
 			
-			// aapt resource value: 0x7f070049
-			public const int abc_control_inset_material = 2131165257;
+			// aapt resource value: 0x7f080030
+			public const int abc_cascading_menus_min_smallest_width = 2131230768;
 			
-			// aapt resource value: 0x7f07004a
-			public const int abc_control_padding_material = 2131165258;
+			// aapt resource value: 0x7f080011
+			public const int abc_config_prefDialogWidth = 2131230737;
 			
-			// aapt resource value: 0x7f07002f
-			public const int abc_dialog_fixed_height_major = 2131165231;
+			// aapt resource value: 0x7f080031
+			public const int abc_control_corner_material = 2131230769;
 			
-			// aapt resource value: 0x7f070030
-			public const int abc_dialog_fixed_height_minor = 2131165232;
+			// aapt resource value: 0x7f080032
+			public const int abc_control_inset_material = 2131230770;
 			
-			// aapt resource value: 0x7f070031
-			public const int abc_dialog_fixed_width_major = 2131165233;
+			// aapt resource value: 0x7f080033
+			public const int abc_control_padding_material = 2131230771;
 			
-			// aapt resource value: 0x7f070032
-			public const int abc_dialog_fixed_width_minor = 2131165234;
+			// aapt resource value: 0x7f080012
+			public const int abc_dialog_fixed_height_major = 2131230738;
 			
-			// aapt resource value: 0x7f07004b
-			public const int abc_dialog_list_padding_vertical_material = 2131165259;
+			// aapt resource value: 0x7f080013
+			public const int abc_dialog_fixed_height_minor = 2131230739;
 			
-			// aapt resource value: 0x7f070033
-			public const int abc_dialog_min_width_major = 2131165235;
+			// aapt resource value: 0x7f080014
+			public const int abc_dialog_fixed_width_major = 2131230740;
 			
-			// aapt resource value: 0x7f070034
-			public const int abc_dialog_min_width_minor = 2131165236;
+			// aapt resource value: 0x7f080015
+			public const int abc_dialog_fixed_width_minor = 2131230741;
 			
-			// aapt resource value: 0x7f07004c
-			public const int abc_dialog_padding_material = 2131165260;
+			// aapt resource value: 0x7f080034
+			public const int abc_dialog_list_padding_bottom_no_buttons = 2131230772;
 			
-			// aapt resource value: 0x7f07004d
-			public const int abc_dialog_padding_top_material = 2131165261;
+			// aapt resource value: 0x7f080035
+			public const int abc_dialog_list_padding_top_no_title = 2131230773;
 			
-			// aapt resource value: 0x7f07004e
-			public const int abc_disabled_alpha_material_dark = 2131165262;
+			// aapt resource value: 0x7f080016
+			public const int abc_dialog_min_width_major = 2131230742;
 			
-			// aapt resource value: 0x7f07004f
-			public const int abc_disabled_alpha_material_light = 2131165263;
+			// aapt resource value: 0x7f080017
+			public const int abc_dialog_min_width_minor = 2131230743;
 			
-			// aapt resource value: 0x7f070050
-			public const int abc_dropdownitem_icon_width = 2131165264;
+			// aapt resource value: 0x7f080036
+			public const int abc_dialog_padding_material = 2131230774;
 			
-			// aapt resource value: 0x7f070051
-			public const int abc_dropdownitem_text_padding_left = 2131165265;
+			// aapt resource value: 0x7f080037
+			public const int abc_dialog_padding_top_material = 2131230775;
 			
-			// aapt resource value: 0x7f070052
-			public const int abc_dropdownitem_text_padding_right = 2131165266;
+			// aapt resource value: 0x7f080038
+			public const int abc_dialog_title_divider_material = 2131230776;
 			
-			// aapt resource value: 0x7f070053
-			public const int abc_edit_text_inset_bottom_material = 2131165267;
+			// aapt resource value: 0x7f080039
+			public const int abc_disabled_alpha_material_dark = 2131230777;
 			
-			// aapt resource value: 0x7f070054
-			public const int abc_edit_text_inset_horizontal_material = 2131165268;
+			// aapt resource value: 0x7f08003a
+			public const int abc_disabled_alpha_material_light = 2131230778;
 			
-			// aapt resource value: 0x7f070055
-			public const int abc_edit_text_inset_top_material = 2131165269;
+			// aapt resource value: 0x7f08003b
+			public const int abc_dropdownitem_icon_width = 2131230779;
 			
-			// aapt resource value: 0x7f070056
-			public const int abc_floating_window_z = 2131165270;
+			// aapt resource value: 0x7f08003c
+			public const int abc_dropdownitem_text_padding_left = 2131230780;
 			
-			// aapt resource value: 0x7f070057
-			public const int abc_list_item_padding_horizontal_material = 2131165271;
+			// aapt resource value: 0x7f08003d
+			public const int abc_dropdownitem_text_padding_right = 2131230781;
 			
-			// aapt resource value: 0x7f070058
-			public const int abc_panel_menu_list_width = 2131165272;
+			// aapt resource value: 0x7f08003e
+			public const int abc_edit_text_inset_bottom_material = 2131230782;
 			
-			// aapt resource value: 0x7f070059
-			public const int abc_search_view_preferred_width = 2131165273;
+			// aapt resource value: 0x7f08003f
+			public const int abc_edit_text_inset_horizontal_material = 2131230783;
 			
-			// aapt resource value: 0x7f070035
-			public const int abc_search_view_text_min_width = 2131165237;
+			// aapt resource value: 0x7f080040
+			public const int abc_edit_text_inset_top_material = 2131230784;
 			
-			// aapt resource value: 0x7f07005a
-			public const int abc_seekbar_track_background_height_material = 2131165274;
+			// aapt resource value: 0x7f080041
+			public const int abc_floating_window_z = 2131230785;
 			
-			// aapt resource value: 0x7f07005b
-			public const int abc_seekbar_track_progress_height_material = 2131165275;
+			// aapt resource value: 0x7f080042
+			public const int abc_list_item_padding_horizontal_material = 2131230786;
 			
-			// aapt resource value: 0x7f07005c
-			public const int abc_select_dialog_padding_start_material = 2131165276;
+			// aapt resource value: 0x7f080043
+			public const int abc_panel_menu_list_width = 2131230787;
 			
-			// aapt resource value: 0x7f070039
-			public const int abc_switch_padding = 2131165241;
+			// aapt resource value: 0x7f080044
+			public const int abc_progress_bar_height_material = 2131230788;
 			
-			// aapt resource value: 0x7f07005d
-			public const int abc_text_size_body_1_material = 2131165277;
+			// aapt resource value: 0x7f080045
+			public const int abc_search_view_preferred_height = 2131230789;
 			
-			// aapt resource value: 0x7f07005e
-			public const int abc_text_size_body_2_material = 2131165278;
+			// aapt resource value: 0x7f080046
+			public const int abc_search_view_preferred_width = 2131230790;
 			
-			// aapt resource value: 0x7f07005f
-			public const int abc_text_size_button_material = 2131165279;
+			// aapt resource value: 0x7f080047
+			public const int abc_seekbar_track_background_height_material = 2131230791;
 			
-			// aapt resource value: 0x7f070060
-			public const int abc_text_size_caption_material = 2131165280;
+			// aapt resource value: 0x7f080048
+			public const int abc_seekbar_track_progress_height_material = 2131230792;
 			
-			// aapt resource value: 0x7f070061
-			public const int abc_text_size_display_1_material = 2131165281;
+			// aapt resource value: 0x7f080049
+			public const int abc_select_dialog_padding_start_material = 2131230793;
 			
-			// aapt resource value: 0x7f070062
-			public const int abc_text_size_display_2_material = 2131165282;
+			// aapt resource value: 0x7f08001d
+			public const int abc_switch_padding = 2131230749;
 			
-			// aapt resource value: 0x7f070063
-			public const int abc_text_size_display_3_material = 2131165283;
+			// aapt resource value: 0x7f08004a
+			public const int abc_text_size_body_1_material = 2131230794;
 			
-			// aapt resource value: 0x7f070064
-			public const int abc_text_size_display_4_material = 2131165284;
+			// aapt resource value: 0x7f08004b
+			public const int abc_text_size_body_2_material = 2131230795;
 			
-			// aapt resource value: 0x7f070065
-			public const int abc_text_size_headline_material = 2131165285;
+			// aapt resource value: 0x7f08004c
+			public const int abc_text_size_button_material = 2131230796;
 			
-			// aapt resource value: 0x7f070066
-			public const int abc_text_size_large_material = 2131165286;
+			// aapt resource value: 0x7f08004d
+			public const int abc_text_size_caption_material = 2131230797;
 			
-			// aapt resource value: 0x7f070067
-			public const int abc_text_size_medium_material = 2131165287;
+			// aapt resource value: 0x7f08004e
+			public const int abc_text_size_display_1_material = 2131230798;
 			
-			// aapt resource value: 0x7f070068
-			public const int abc_text_size_menu_material = 2131165288;
+			// aapt resource value: 0x7f08004f
+			public const int abc_text_size_display_2_material = 2131230799;
 			
-			// aapt resource value: 0x7f070069
-			public const int abc_text_size_small_material = 2131165289;
+			// aapt resource value: 0x7f080050
+			public const int abc_text_size_display_3_material = 2131230800;
 			
-			// aapt resource value: 0x7f07006a
-			public const int abc_text_size_subhead_material = 2131165290;
+			// aapt resource value: 0x7f080051
+			public const int abc_text_size_display_4_material = 2131230801;
 			
-			// aapt resource value: 0x7f07002c
-			public const int abc_text_size_subtitle_material_toolbar = 2131165228;
+			// aapt resource value: 0x7f080052
+			public const int abc_text_size_headline_material = 2131230802;
 			
-			// aapt resource value: 0x7f07006b
-			public const int abc_text_size_title_material = 2131165291;
+			// aapt resource value: 0x7f080053
+			public const int abc_text_size_large_material = 2131230803;
 			
-			// aapt resource value: 0x7f07002d
-			public const int abc_text_size_title_material_toolbar = 2131165229;
+			// aapt resource value: 0x7f080054
+			public const int abc_text_size_medium_material = 2131230804;
 			
-			// aapt resource value: 0x7f070006
-			public const int cardview_compat_inset_shadow = 2131165190;
+			// aapt resource value: 0x7f080055
+			public const int abc_text_size_menu_header_material = 2131230805;
 			
-			// aapt resource value: 0x7f070007
-			public const int cardview_default_elevation = 2131165191;
+			// aapt resource value: 0x7f080056
+			public const int abc_text_size_menu_material = 2131230806;
 			
-			// aapt resource value: 0x7f070008
-			public const int cardview_default_radius = 2131165192;
+			// aapt resource value: 0x7f080057
+			public const int abc_text_size_small_material = 2131230807;
 			
-			// aapt resource value: 0x7f070011
-			public const int design_appbar_elevation = 2131165201;
+			// aapt resource value: 0x7f080058
+			public const int abc_text_size_subhead_material = 2131230808;
 			
-			// aapt resource value: 0x7f070012
-			public const int design_bottom_sheet_modal_elevation = 2131165202;
+			// aapt resource value: 0x7f08000f
+			public const int abc_text_size_subtitle_material_toolbar = 2131230735;
 			
-			// aapt resource value: 0x7f070013
-			public const int design_bottom_sheet_modal_peek_height = 2131165203;
+			// aapt resource value: 0x7f080059
+			public const int abc_text_size_title_material = 2131230809;
 			
-			// aapt resource value: 0x7f070014
-			public const int design_fab_border_width = 2131165204;
+			// aapt resource value: 0x7f080010
+			public const int abc_text_size_title_material_toolbar = 2131230736;
 			
-			// aapt resource value: 0x7f070015
-			public const int design_fab_elevation = 2131165205;
+			// aapt resource value: 0x7f080009
+			public const int cardview_compat_inset_shadow = 2131230729;
 			
-			// aapt resource value: 0x7f070016
-			public const int design_fab_image_size = 2131165206;
+			// aapt resource value: 0x7f08000a
+			public const int cardview_default_elevation = 2131230730;
 			
-			// aapt resource value: 0x7f070017
-			public const int design_fab_size_mini = 2131165207;
+			// aapt resource value: 0x7f08000b
+			public const int cardview_default_radius = 2131230731;
 			
-			// aapt resource value: 0x7f070018
-			public const int design_fab_size_normal = 2131165208;
+			// aapt resource value: 0x7f080076
+			public const int design_appbar_elevation = 2131230838;
 			
-			// aapt resource value: 0x7f070019
-			public const int design_fab_translation_z_pressed = 2131165209;
+			// aapt resource value: 0x7f080077
+			public const int design_bottom_navigation_active_item_max_width = 2131230839;
 			
-			// aapt resource value: 0x7f07001a
-			public const int design_navigation_elevation = 2131165210;
+			// aapt resource value: 0x7f080078
+			public const int design_bottom_navigation_active_text_size = 2131230840;
 			
-			// aapt resource value: 0x7f07001b
-			public const int design_navigation_icon_padding = 2131165211;
+			// aapt resource value: 0x7f080079
+			public const int design_bottom_navigation_elevation = 2131230841;
 			
-			// aapt resource value: 0x7f07001c
-			public const int design_navigation_icon_size = 2131165212;
+			// aapt resource value: 0x7f08007a
+			public const int design_bottom_navigation_height = 2131230842;
 			
-			// aapt resource value: 0x7f070009
-			public const int design_navigation_max_width = 2131165193;
+			// aapt resource value: 0x7f08007b
+			public const int design_bottom_navigation_item_max_width = 2131230843;
 			
-			// aapt resource value: 0x7f07001d
-			public const int design_navigation_padding_bottom = 2131165213;
+			// aapt resource value: 0x7f08007c
+			public const int design_bottom_navigation_item_min_width = 2131230844;
 			
-			// aapt resource value: 0x7f07001e
-			public const int design_navigation_separator_vertical_padding = 2131165214;
+			// aapt resource value: 0x7f08007d
+			public const int design_bottom_navigation_margin = 2131230845;
 			
-			// aapt resource value: 0x7f07000a
-			public const int design_snackbar_action_inline_max_width = 2131165194;
+			// aapt resource value: 0x7f08007e
+			public const int design_bottom_navigation_shadow_height = 2131230846;
 			
-			// aapt resource value: 0x7f07000b
-			public const int design_snackbar_background_corner_radius = 2131165195;
+			// aapt resource value: 0x7f08007f
+			public const int design_bottom_navigation_text_size = 2131230847;
 			
-			// aapt resource value: 0x7f07001f
-			public const int design_snackbar_elevation = 2131165215;
+			// aapt resource value: 0x7f080080
+			public const int design_bottom_sheet_modal_elevation = 2131230848;
 			
-			// aapt resource value: 0x7f07000c
-			public const int design_snackbar_extra_spacing_horizontal = 2131165196;
+			// aapt resource value: 0x7f080081
+			public const int design_bottom_sheet_peek_height_min = 2131230849;
 			
-			// aapt resource value: 0x7f07000d
-			public const int design_snackbar_max_width = 2131165197;
+			// aapt resource value: 0x7f080082
+			public const int design_fab_border_width = 2131230850;
 			
-			// aapt resource value: 0x7f07000e
-			public const int design_snackbar_min_width = 2131165198;
+			// aapt resource value: 0x7f080083
+			public const int design_fab_elevation = 2131230851;
 			
-			// aapt resource value: 0x7f070020
-			public const int design_snackbar_padding_horizontal = 2131165216;
+			// aapt resource value: 0x7f080084
+			public const int design_fab_image_size = 2131230852;
 			
-			// aapt resource value: 0x7f070021
-			public const int design_snackbar_padding_vertical = 2131165217;
+			// aapt resource value: 0x7f080085
+			public const int design_fab_size_mini = 2131230853;
 			
-			// aapt resource value: 0x7f07000f
-			public const int design_snackbar_padding_vertical_2lines = 2131165199;
+			// aapt resource value: 0x7f080086
+			public const int design_fab_size_normal = 2131230854;
 			
-			// aapt resource value: 0x7f070022
-			public const int design_snackbar_text_size = 2131165218;
+			// aapt resource value: 0x7f080087
+			public const int design_fab_translation_z_pressed = 2131230855;
 			
-			// aapt resource value: 0x7f070023
-			public const int design_tab_max_width = 2131165219;
+			// aapt resource value: 0x7f080088
+			public const int design_navigation_elevation = 2131230856;
 			
-			// aapt resource value: 0x7f070010
-			public const int design_tab_scrollable_min_width = 2131165200;
+			// aapt resource value: 0x7f080089
+			public const int design_navigation_icon_padding = 2131230857;
 			
-			// aapt resource value: 0x7f070024
-			public const int design_tab_text_size = 2131165220;
+			// aapt resource value: 0x7f08008a
+			public const int design_navigation_icon_size = 2131230858;
 			
-			// aapt resource value: 0x7f070025
-			public const int design_tab_text_size_2line = 2131165221;
+			// aapt resource value: 0x7f08006e
+			public const int design_navigation_max_width = 2131230830;
 			
-			// aapt resource value: 0x7f07006c
-			public const int disabled_alpha_material_dark = 2131165292;
+			// aapt resource value: 0x7f08008b
+			public const int design_navigation_padding_bottom = 2131230859;
 			
-			// aapt resource value: 0x7f07006d
-			public const int disabled_alpha_material_light = 2131165293;
+			// aapt resource value: 0x7f08008c
+			public const int design_navigation_separator_vertical_padding = 2131230860;
 			
-			// aapt resource value: 0x7f07006e
-			public const int highlight_alpha_material_colored = 2131165294;
+			// aapt resource value: 0x7f08006f
+			public const int design_snackbar_action_inline_max_width = 2131230831;
 			
-			// aapt resource value: 0x7f07006f
-			public const int highlight_alpha_material_dark = 2131165295;
+			// aapt resource value: 0x7f080070
+			public const int design_snackbar_background_corner_radius = 2131230832;
 			
-			// aapt resource value: 0x7f070070
-			public const int highlight_alpha_material_light = 2131165296;
+			// aapt resource value: 0x7f08008d
+			public const int design_snackbar_elevation = 2131230861;
 			
-			// aapt resource value: 0x7f070026
-			public const int item_touch_helper_max_drag_scroll_per_frame = 2131165222;
+			// aapt resource value: 0x7f080071
+			public const int design_snackbar_extra_spacing_horizontal = 2131230833;
 			
-			// aapt resource value: 0x7f070027
-			public const int item_touch_helper_swipe_escape_max_velocity = 2131165223;
+			// aapt resource value: 0x7f080072
+			public const int design_snackbar_max_width = 2131230834;
 			
-			// aapt resource value: 0x7f070028
-			public const int item_touch_helper_swipe_escape_velocity = 2131165224;
+			// aapt resource value: 0x7f080073
+			public const int design_snackbar_min_width = 2131230835;
 			
-			// aapt resource value: 0x7f070000
-			public const int mr_controller_volume_group_list_item_height = 2131165184;
+			// aapt resource value: 0x7f08008e
+			public const int design_snackbar_padding_horizontal = 2131230862;
 			
-			// aapt resource value: 0x7f070001
-			public const int mr_controller_volume_group_list_item_icon_size = 2131165185;
+			// aapt resource value: 0x7f08008f
+			public const int design_snackbar_padding_vertical = 2131230863;
 			
-			// aapt resource value: 0x7f070002
-			public const int mr_controller_volume_group_list_max_height = 2131165186;
+			// aapt resource value: 0x7f080074
+			public const int design_snackbar_padding_vertical_2lines = 2131230836;
 			
-			// aapt resource value: 0x7f070005
-			public const int mr_controller_volume_group_list_padding_top = 2131165189;
+			// aapt resource value: 0x7f080090
+			public const int design_snackbar_text_size = 2131230864;
 			
-			// aapt resource value: 0x7f070003
-			public const int mr_dialog_fixed_width_major = 2131165187;
+			// aapt resource value: 0x7f080091
+			public const int design_tab_max_width = 2131230865;
 			
-			// aapt resource value: 0x7f070004
-			public const int mr_dialog_fixed_width_minor = 2131165188;
+			// aapt resource value: 0x7f080075
+			public const int design_tab_scrollable_min_width = 2131230837;
 			
-			// aapt resource value: 0x7f070071
-			public const int notification_large_icon_height = 2131165297;
+			// aapt resource value: 0x7f080092
+			public const int design_tab_text_size = 2131230866;
 			
-			// aapt resource value: 0x7f070072
-			public const int notification_large_icon_width = 2131165298;
+			// aapt resource value: 0x7f080093
+			public const int design_tab_text_size_2line = 2131230867;
 			
-			// aapt resource value: 0x7f070073
-			public const int notification_subtext_size = 2131165299;
+			// aapt resource value: 0x7f08005a
+			public const int disabled_alpha_material_dark = 2131230810;
+			
+			// aapt resource value: 0x7f08005b
+			public const int disabled_alpha_material_light = 2131230811;
+			
+			// aapt resource value: 0x7f08005c
+			public const int highlight_alpha_material_colored = 2131230812;
+			
+			// aapt resource value: 0x7f08005d
+			public const int highlight_alpha_material_dark = 2131230813;
+			
+			// aapt resource value: 0x7f08005e
+			public const int highlight_alpha_material_light = 2131230814;
+			
+			// aapt resource value: 0x7f08005f
+			public const int hint_alpha_material_dark = 2131230815;
+			
+			// aapt resource value: 0x7f080060
+			public const int hint_alpha_material_light = 2131230816;
+			
+			// aapt resource value: 0x7f080061
+			public const int hint_pressed_alpha_material_dark = 2131230817;
+			
+			// aapt resource value: 0x7f080062
+			public const int hint_pressed_alpha_material_light = 2131230818;
+			
+			// aapt resource value: 0x7f080000
+			public const int item_touch_helper_max_drag_scroll_per_frame = 2131230720;
+			
+			// aapt resource value: 0x7f080001
+			public const int item_touch_helper_swipe_escape_max_velocity = 2131230721;
+			
+			// aapt resource value: 0x7f080002
+			public const int item_touch_helper_swipe_escape_velocity = 2131230722;
+			
+			// aapt resource value: 0x7f080003
+			public const int mr_controller_volume_group_list_item_height = 2131230723;
+			
+			// aapt resource value: 0x7f080004
+			public const int mr_controller_volume_group_list_item_icon_size = 2131230724;
+			
+			// aapt resource value: 0x7f080005
+			public const int mr_controller_volume_group_list_max_height = 2131230725;
+			
+			// aapt resource value: 0x7f080008
+			public const int mr_controller_volume_group_list_padding_top = 2131230728;
+			
+			// aapt resource value: 0x7f080006
+			public const int mr_dialog_fixed_width_major = 2131230726;
+			
+			// aapt resource value: 0x7f080007
+			public const int mr_dialog_fixed_width_minor = 2131230727;
+			
+			// aapt resource value: 0x7f080063
+			public const int notification_action_icon_size = 2131230819;
+			
+			// aapt resource value: 0x7f080064
+			public const int notification_action_text_size = 2131230820;
+			
+			// aapt resource value: 0x7f080065
+			public const int notification_big_circle_margin = 2131230821;
+			
+			// aapt resource value: 0x7f08001e
+			public const int notification_content_margin_start = 2131230750;
+			
+			// aapt resource value: 0x7f080066
+			public const int notification_large_icon_height = 2131230822;
+			
+			// aapt resource value: 0x7f080067
+			public const int notification_large_icon_width = 2131230823;
+			
+			// aapt resource value: 0x7f08001f
+			public const int notification_main_column_padding_top = 2131230751;
+			
+			// aapt resource value: 0x7f080020
+			public const int notification_media_narrow_margin = 2131230752;
+			
+			// aapt resource value: 0x7f080068
+			public const int notification_right_icon_size = 2131230824;
+			
+			// aapt resource value: 0x7f08001c
+			public const int notification_right_side_padding_top = 2131230748;
+			
+			// aapt resource value: 0x7f080069
+			public const int notification_small_icon_background_padding = 2131230825;
+			
+			// aapt resource value: 0x7f08006a
+			public const int notification_small_icon_size_as_large = 2131230826;
+			
+			// aapt resource value: 0x7f08006b
+			public const int notification_subtext_size = 2131230827;
+			
+			// aapt resource value: 0x7f08006c
+			public const int notification_top_pad = 2131230828;
+			
+			// aapt resource value: 0x7f08006d
+			public const int notification_top_pad_large_text = 2131230829;
 			
 			static Dimension()
 			{
@@ -3536,85 +4077,85 @@ namespace XFGlossSample.Droid
 			public const int abc_btn_radio_to_on_mtrl_015 = 2130837514;
 			
 			// aapt resource value: 0x7f02000b
-			public const int abc_btn_rating_star_off_mtrl_alpha = 2130837515;
+			public const int abc_btn_switch_to_on_mtrl_00001 = 2130837515;
 			
 			// aapt resource value: 0x7f02000c
-			public const int abc_btn_rating_star_on_mtrl_alpha = 2130837516;
+			public const int abc_btn_switch_to_on_mtrl_00012 = 2130837516;
 			
 			// aapt resource value: 0x7f02000d
-			public const int abc_btn_switch_to_on_mtrl_00001 = 2130837517;
+			public const int abc_cab_background_internal_bg = 2130837517;
 			
 			// aapt resource value: 0x7f02000e
-			public const int abc_btn_switch_to_on_mtrl_00012 = 2130837518;
+			public const int abc_cab_background_top_material = 2130837518;
 			
 			// aapt resource value: 0x7f02000f
-			public const int abc_cab_background_internal_bg = 2130837519;
+			public const int abc_cab_background_top_mtrl_alpha = 2130837519;
 			
 			// aapt resource value: 0x7f020010
-			public const int abc_cab_background_top_material = 2130837520;
+			public const int abc_control_background_material = 2130837520;
 			
 			// aapt resource value: 0x7f020011
-			public const int abc_cab_background_top_mtrl_alpha = 2130837521;
+			public const int abc_dialog_material_background = 2130837521;
 			
 			// aapt resource value: 0x7f020012
-			public const int abc_control_background_material = 2130837522;
+			public const int abc_edit_text_material = 2130837522;
 			
 			// aapt resource value: 0x7f020013
-			public const int abc_dialog_material_background_dark = 2130837523;
+			public const int abc_ic_ab_back_material = 2130837523;
 			
 			// aapt resource value: 0x7f020014
-			public const int abc_dialog_material_background_light = 2130837524;
+			public const int abc_ic_arrow_drop_right_black_24dp = 2130837524;
 			
 			// aapt resource value: 0x7f020015
-			public const int abc_edit_text_material = 2130837525;
+			public const int abc_ic_clear_material = 2130837525;
 			
 			// aapt resource value: 0x7f020016
-			public const int abc_ic_ab_back_mtrl_am_alpha = 2130837526;
+			public const int abc_ic_commit_search_api_mtrl_alpha = 2130837526;
 			
 			// aapt resource value: 0x7f020017
-			public const int abc_ic_clear_mtrl_alpha = 2130837527;
+			public const int abc_ic_go_search_api_material = 2130837527;
 			
 			// aapt resource value: 0x7f020018
-			public const int abc_ic_commit_search_api_mtrl_alpha = 2130837528;
+			public const int abc_ic_menu_copy_mtrl_am_alpha = 2130837528;
 			
 			// aapt resource value: 0x7f020019
-			public const int abc_ic_go_search_api_mtrl_alpha = 2130837529;
+			public const int abc_ic_menu_cut_mtrl_alpha = 2130837529;
 			
 			// aapt resource value: 0x7f02001a
-			public const int abc_ic_menu_copy_mtrl_am_alpha = 2130837530;
+			public const int abc_ic_menu_overflow_material = 2130837530;
 			
 			// aapt resource value: 0x7f02001b
-			public const int abc_ic_menu_cut_mtrl_alpha = 2130837531;
+			public const int abc_ic_menu_paste_mtrl_am_alpha = 2130837531;
 			
 			// aapt resource value: 0x7f02001c
-			public const int abc_ic_menu_moreoverflow_mtrl_alpha = 2130837532;
+			public const int abc_ic_menu_selectall_mtrl_alpha = 2130837532;
 			
 			// aapt resource value: 0x7f02001d
-			public const int abc_ic_menu_paste_mtrl_am_alpha = 2130837533;
+			public const int abc_ic_menu_share_mtrl_alpha = 2130837533;
 			
 			// aapt resource value: 0x7f02001e
-			public const int abc_ic_menu_selectall_mtrl_alpha = 2130837534;
+			public const int abc_ic_search_api_material = 2130837534;
 			
 			// aapt resource value: 0x7f02001f
-			public const int abc_ic_menu_share_mtrl_alpha = 2130837535;
+			public const int abc_ic_star_black_16dp = 2130837535;
 			
 			// aapt resource value: 0x7f020020
-			public const int abc_ic_search_api_mtrl_alpha = 2130837536;
+			public const int abc_ic_star_black_36dp = 2130837536;
 			
 			// aapt resource value: 0x7f020021
-			public const int abc_ic_star_black_16dp = 2130837537;
+			public const int abc_ic_star_black_48dp = 2130837537;
 			
 			// aapt resource value: 0x7f020022
-			public const int abc_ic_star_black_36dp = 2130837538;
+			public const int abc_ic_star_half_black_16dp = 2130837538;
 			
 			// aapt resource value: 0x7f020023
-			public const int abc_ic_star_half_black_16dp = 2130837539;
+			public const int abc_ic_star_half_black_36dp = 2130837539;
 			
 			// aapt resource value: 0x7f020024
-			public const int abc_ic_star_half_black_36dp = 2130837540;
+			public const int abc_ic_star_half_black_48dp = 2130837540;
 			
 			// aapt resource value: 0x7f020025
-			public const int abc_ic_voice_search_api_mtrl_alpha = 2130837541;
+			public const int abc_ic_voice_search_api_material = 2130837541;
 			
 			// aapt resource value: 0x7f020026
 			public const int abc_item_background_holo_dark = 2130837542;
@@ -3662,10 +4203,10 @@ namespace XFGlossSample.Droid
 			public const int abc_popup_background_mtrl_mult = 2130837556;
 			
 			// aapt resource value: 0x7f020035
-			public const int abc_ratingbar_full_material = 2130837557;
+			public const int abc_ratingbar_indicator_material = 2130837557;
 			
 			// aapt resource value: 0x7f020036
-			public const int abc_ratingbar_indicator_material = 2130837558;
+			public const int abc_ratingbar_material = 2130837558;
 			
 			// aapt resource value: 0x7f020037
 			public const int abc_ratingbar_small_material = 2130837559;
@@ -3689,310 +4230,652 @@ namespace XFGlossSample.Droid
 			public const int abc_seekbar_thumb_material = 2130837565;
 			
 			// aapt resource value: 0x7f02003e
-			public const int abc_seekbar_track_material = 2130837566;
+			public const int abc_seekbar_tick_mark_material = 2130837566;
 			
 			// aapt resource value: 0x7f02003f
-			public const int abc_spinner_mtrl_am_alpha = 2130837567;
+			public const int abc_seekbar_track_material = 2130837567;
 			
 			// aapt resource value: 0x7f020040
-			public const int abc_spinner_textfield_background_material = 2130837568;
+			public const int abc_spinner_mtrl_am_alpha = 2130837568;
 			
 			// aapt resource value: 0x7f020041
-			public const int abc_switch_thumb_material = 2130837569;
+			public const int abc_spinner_textfield_background_material = 2130837569;
 			
 			// aapt resource value: 0x7f020042
-			public const int abc_switch_track_mtrl_alpha = 2130837570;
+			public const int abc_switch_thumb_material = 2130837570;
 			
 			// aapt resource value: 0x7f020043
-			public const int abc_tab_indicator_material = 2130837571;
+			public const int abc_switch_track_mtrl_alpha = 2130837571;
 			
 			// aapt resource value: 0x7f020044
-			public const int abc_tab_indicator_mtrl_alpha = 2130837572;
+			public const int abc_tab_indicator_material = 2130837572;
 			
 			// aapt resource value: 0x7f020045
-			public const int abc_text_cursor_material = 2130837573;
+			public const int abc_tab_indicator_mtrl_alpha = 2130837573;
 			
 			// aapt resource value: 0x7f020046
-			public const int abc_textfield_activated_mtrl_alpha = 2130837574;
+			public const int abc_text_cursor_material = 2130837574;
 			
 			// aapt resource value: 0x7f020047
-			public const int abc_textfield_default_mtrl_alpha = 2130837575;
+			public const int abc_text_select_handle_left_mtrl_dark = 2130837575;
 			
 			// aapt resource value: 0x7f020048
-			public const int abc_textfield_search_activated_mtrl_alpha = 2130837576;
+			public const int abc_text_select_handle_left_mtrl_light = 2130837576;
 			
 			// aapt resource value: 0x7f020049
-			public const int abc_textfield_search_default_mtrl_alpha = 2130837577;
+			public const int abc_text_select_handle_middle_mtrl_dark = 2130837577;
 			
 			// aapt resource value: 0x7f02004a
-			public const int abc_textfield_search_material = 2130837578;
+			public const int abc_text_select_handle_middle_mtrl_light = 2130837578;
 			
 			// aapt resource value: 0x7f02004b
-			public const int design_fab_background = 2130837579;
+			public const int abc_text_select_handle_right_mtrl_dark = 2130837579;
 			
 			// aapt resource value: 0x7f02004c
-			public const int design_snackbar_background = 2130837580;
+			public const int abc_text_select_handle_right_mtrl_light = 2130837580;
 			
 			// aapt resource value: 0x7f02004d
-			public const int ic_audiotrack = 2130837581;
+			public const int abc_textfield_activated_mtrl_alpha = 2130837581;
 			
 			// aapt resource value: 0x7f02004e
-			public const int ic_audiotrack_light = 2130837582;
+			public const int abc_textfield_default_mtrl_alpha = 2130837582;
 			
 			// aapt resource value: 0x7f02004f
-			public const int ic_bluetooth_grey = 2130837583;
+			public const int abc_textfield_search_activated_mtrl_alpha = 2130837583;
 			
 			// aapt resource value: 0x7f020050
-			public const int ic_bluetooth_white = 2130837584;
+			public const int abc_textfield_search_default_mtrl_alpha = 2130837584;
 			
 			// aapt resource value: 0x7f020051
-			public const int ic_cast_dark = 2130837585;
+			public const int abc_textfield_search_material = 2130837585;
 			
 			// aapt resource value: 0x7f020052
-			public const int ic_cast_disabled_light = 2130837586;
+			public const int abc_vector_test = 2130837586;
 			
 			// aapt resource value: 0x7f020053
-			public const int ic_cast_grey = 2130837587;
+			public const int avd_hide_password = 2130837587;
+			
+			// aapt resource value: 0x7f020110
+			public const int avd_hide_password_1 = 2130837776;
+			
+			// aapt resource value: 0x7f020111
+			public const int avd_hide_password_2 = 2130837777;
+			
+			// aapt resource value: 0x7f020112
+			public const int avd_hide_password_3 = 2130837778;
 			
 			// aapt resource value: 0x7f020054
-			public const int ic_cast_light = 2130837588;
+			public const int avd_show_password = 2130837588;
+			
+			// aapt resource value: 0x7f020113
+			public const int avd_show_password_1 = 2130837779;
+			
+			// aapt resource value: 0x7f020114
+			public const int avd_show_password_2 = 2130837780;
+			
+			// aapt resource value: 0x7f020115
+			public const int avd_show_password_3 = 2130837781;
 			
 			// aapt resource value: 0x7f020055
-			public const int ic_cast_off_light = 2130837589;
+			public const int design_bottom_navigation_item_background = 2130837589;
 			
 			// aapt resource value: 0x7f020056
-			public const int ic_cast_on_0_light = 2130837590;
+			public const int design_fab_background = 2130837590;
 			
 			// aapt resource value: 0x7f020057
-			public const int ic_cast_on_1_light = 2130837591;
+			public const int design_ic_visibility = 2130837591;
 			
 			// aapt resource value: 0x7f020058
-			public const int ic_cast_on_2_light = 2130837592;
+			public const int design_ic_visibility_off = 2130837592;
 			
 			// aapt resource value: 0x7f020059
-			public const int ic_cast_on_light = 2130837593;
+			public const int design_password_eye = 2130837593;
 			
 			// aapt resource value: 0x7f02005a
-			public const int ic_cast_white = 2130837594;
+			public const int design_snackbar_background = 2130837594;
 			
 			// aapt resource value: 0x7f02005b
-			public const int ic_close_dark = 2130837595;
+			public const int ic_audiotrack_dark = 2130837595;
 			
 			// aapt resource value: 0x7f02005c
-			public const int ic_close_light = 2130837596;
+			public const int ic_audiotrack_light = 2130837596;
 			
 			// aapt resource value: 0x7f02005d
-			public const int ic_collapse = 2130837597;
+			public const int ic_dialog_close_dark = 2130837597;
 			
 			// aapt resource value: 0x7f02005e
-			public const int ic_collapse_00000 = 2130837598;
+			public const int ic_dialog_close_light = 2130837598;
 			
 			// aapt resource value: 0x7f02005f
-			public const int ic_collapse_00001 = 2130837599;
+			public const int ic_group_collapse_00 = 2130837599;
 			
 			// aapt resource value: 0x7f020060
-			public const int ic_collapse_00002 = 2130837600;
+			public const int ic_group_collapse_01 = 2130837600;
 			
 			// aapt resource value: 0x7f020061
-			public const int ic_collapse_00003 = 2130837601;
+			public const int ic_group_collapse_02 = 2130837601;
 			
 			// aapt resource value: 0x7f020062
-			public const int ic_collapse_00004 = 2130837602;
+			public const int ic_group_collapse_03 = 2130837602;
 			
 			// aapt resource value: 0x7f020063
-			public const int ic_collapse_00005 = 2130837603;
+			public const int ic_group_collapse_04 = 2130837603;
 			
 			// aapt resource value: 0x7f020064
-			public const int ic_collapse_00006 = 2130837604;
+			public const int ic_group_collapse_05 = 2130837604;
 			
 			// aapt resource value: 0x7f020065
-			public const int ic_collapse_00007 = 2130837605;
+			public const int ic_group_collapse_06 = 2130837605;
 			
 			// aapt resource value: 0x7f020066
-			public const int ic_collapse_00008 = 2130837606;
+			public const int ic_group_collapse_07 = 2130837606;
 			
 			// aapt resource value: 0x7f020067
-			public const int ic_collapse_00009 = 2130837607;
+			public const int ic_group_collapse_08 = 2130837607;
 			
 			// aapt resource value: 0x7f020068
-			public const int ic_collapse_00010 = 2130837608;
+			public const int ic_group_collapse_09 = 2130837608;
 			
 			// aapt resource value: 0x7f020069
-			public const int ic_collapse_00011 = 2130837609;
+			public const int ic_group_collapse_10 = 2130837609;
 			
 			// aapt resource value: 0x7f02006a
-			public const int ic_collapse_00012 = 2130837610;
+			public const int ic_group_collapse_11 = 2130837610;
 			
 			// aapt resource value: 0x7f02006b
-			public const int ic_collapse_00013 = 2130837611;
+			public const int ic_group_collapse_12 = 2130837611;
 			
 			// aapt resource value: 0x7f02006c
-			public const int ic_collapse_00014 = 2130837612;
+			public const int ic_group_collapse_13 = 2130837612;
 			
 			// aapt resource value: 0x7f02006d
-			public const int ic_collapse_00015 = 2130837613;
+			public const int ic_group_collapse_14 = 2130837613;
 			
 			// aapt resource value: 0x7f02006e
-			public const int ic_expand = 2130837614;
+			public const int ic_group_collapse_15 = 2130837614;
 			
 			// aapt resource value: 0x7f02006f
-			public const int ic_expand_00000 = 2130837615;
+			public const int ic_group_expand_00 = 2130837615;
 			
 			// aapt resource value: 0x7f020070
-			public const int ic_expand_00001 = 2130837616;
+			public const int ic_group_expand_01 = 2130837616;
 			
 			// aapt resource value: 0x7f020071
-			public const int ic_expand_00002 = 2130837617;
+			public const int ic_group_expand_02 = 2130837617;
 			
 			// aapt resource value: 0x7f020072
-			public const int ic_expand_00003 = 2130837618;
+			public const int ic_group_expand_03 = 2130837618;
 			
 			// aapt resource value: 0x7f020073
-			public const int ic_expand_00004 = 2130837619;
+			public const int ic_group_expand_04 = 2130837619;
 			
 			// aapt resource value: 0x7f020074
-			public const int ic_expand_00005 = 2130837620;
+			public const int ic_group_expand_05 = 2130837620;
 			
 			// aapt resource value: 0x7f020075
-			public const int ic_expand_00006 = 2130837621;
+			public const int ic_group_expand_06 = 2130837621;
 			
 			// aapt resource value: 0x7f020076
-			public const int ic_expand_00007 = 2130837622;
+			public const int ic_group_expand_07 = 2130837622;
 			
 			// aapt resource value: 0x7f020077
-			public const int ic_expand_00008 = 2130837623;
+			public const int ic_group_expand_08 = 2130837623;
 			
 			// aapt resource value: 0x7f020078
-			public const int ic_expand_00009 = 2130837624;
+			public const int ic_group_expand_09 = 2130837624;
 			
 			// aapt resource value: 0x7f020079
-			public const int ic_expand_00010 = 2130837625;
+			public const int ic_group_expand_10 = 2130837625;
 			
 			// aapt resource value: 0x7f02007a
-			public const int ic_expand_00011 = 2130837626;
+			public const int ic_group_expand_11 = 2130837626;
 			
 			// aapt resource value: 0x7f02007b
-			public const int ic_expand_00012 = 2130837627;
+			public const int ic_group_expand_12 = 2130837627;
 			
 			// aapt resource value: 0x7f02007c
-			public const int ic_expand_00013 = 2130837628;
+			public const int ic_group_expand_13 = 2130837628;
 			
 			// aapt resource value: 0x7f02007d
-			public const int ic_expand_00014 = 2130837629;
+			public const int ic_group_expand_14 = 2130837629;
 			
 			// aapt resource value: 0x7f02007e
-			public const int ic_expand_00015 = 2130837630;
+			public const int ic_group_expand_15 = 2130837630;
 			
 			// aapt resource value: 0x7f02007f
-			public const int ic_media_pause = 2130837631;
+			public const int ic_media_pause_dark = 2130837631;
 			
 			// aapt resource value: 0x7f020080
-			public const int ic_media_play = 2130837632;
+			public const int ic_media_pause_light = 2130837632;
 			
 			// aapt resource value: 0x7f020081
-			public const int ic_media_route_disabled_mono_dark = 2130837633;
+			public const int ic_media_play_dark = 2130837633;
 			
 			// aapt resource value: 0x7f020082
-			public const int ic_media_route_off_mono_dark = 2130837634;
+			public const int ic_media_play_light = 2130837634;
 			
 			// aapt resource value: 0x7f020083
-			public const int ic_media_route_on_0_mono_dark = 2130837635;
+			public const int ic_media_stop_dark = 2130837635;
 			
 			// aapt resource value: 0x7f020084
-			public const int ic_media_route_on_1_mono_dark = 2130837636;
+			public const int ic_media_stop_light = 2130837636;
 			
 			// aapt resource value: 0x7f020085
-			public const int ic_media_route_on_2_mono_dark = 2130837637;
+			public const int ic_mr_button_connected_00_dark = 2130837637;
 			
 			// aapt resource value: 0x7f020086
-			public const int ic_media_route_on_mono_dark = 2130837638;
+			public const int ic_mr_button_connected_00_light = 2130837638;
 			
 			// aapt resource value: 0x7f020087
-			public const int ic_pause_dark = 2130837639;
+			public const int ic_mr_button_connected_01_dark = 2130837639;
 			
 			// aapt resource value: 0x7f020088
-			public const int ic_pause_light = 2130837640;
+			public const int ic_mr_button_connected_01_light = 2130837640;
 			
 			// aapt resource value: 0x7f020089
-			public const int ic_play_dark = 2130837641;
+			public const int ic_mr_button_connected_02_dark = 2130837641;
 			
 			// aapt resource value: 0x7f02008a
-			public const int ic_play_light = 2130837642;
+			public const int ic_mr_button_connected_02_light = 2130837642;
 			
 			// aapt resource value: 0x7f02008b
-			public const int ic_speaker_dark = 2130837643;
+			public const int ic_mr_button_connected_03_dark = 2130837643;
 			
 			// aapt resource value: 0x7f02008c
-			public const int ic_speaker_group_dark = 2130837644;
+			public const int ic_mr_button_connected_03_light = 2130837644;
 			
 			// aapt resource value: 0x7f02008d
-			public const int ic_speaker_group_light = 2130837645;
+			public const int ic_mr_button_connected_04_dark = 2130837645;
 			
 			// aapt resource value: 0x7f02008e
-			public const int ic_speaker_light = 2130837646;
+			public const int ic_mr_button_connected_04_light = 2130837646;
 			
 			// aapt resource value: 0x7f02008f
-			public const int ic_tv_dark = 2130837647;
+			public const int ic_mr_button_connected_05_dark = 2130837647;
 			
 			// aapt resource value: 0x7f020090
-			public const int ic_tv_light = 2130837648;
+			public const int ic_mr_button_connected_05_light = 2130837648;
 			
 			// aapt resource value: 0x7f020091
-			public const int icon = 2130837649;
+			public const int ic_mr_button_connected_06_dark = 2130837649;
 			
 			// aapt resource value: 0x7f020092
-			public const int mr_dialog_material_background_dark = 2130837650;
+			public const int ic_mr_button_connected_06_light = 2130837650;
 			
 			// aapt resource value: 0x7f020093
-			public const int mr_dialog_material_background_light = 2130837651;
+			public const int ic_mr_button_connected_07_dark = 2130837651;
 			
 			// aapt resource value: 0x7f020094
-			public const int mr_ic_audiotrack_light = 2130837652;
+			public const int ic_mr_button_connected_07_light = 2130837652;
 			
 			// aapt resource value: 0x7f020095
-			public const int mr_ic_cast_dark = 2130837653;
+			public const int ic_mr_button_connected_08_dark = 2130837653;
 			
 			// aapt resource value: 0x7f020096
-			public const int mr_ic_cast_light = 2130837654;
+			public const int ic_mr_button_connected_08_light = 2130837654;
 			
 			// aapt resource value: 0x7f020097
-			public const int mr_ic_close_dark = 2130837655;
+			public const int ic_mr_button_connected_09_dark = 2130837655;
 			
 			// aapt resource value: 0x7f020098
-			public const int mr_ic_close_light = 2130837656;
+			public const int ic_mr_button_connected_09_light = 2130837656;
 			
 			// aapt resource value: 0x7f020099
-			public const int mr_ic_media_route_connecting_mono_dark = 2130837657;
+			public const int ic_mr_button_connected_10_dark = 2130837657;
 			
 			// aapt resource value: 0x7f02009a
-			public const int mr_ic_media_route_connecting_mono_light = 2130837658;
+			public const int ic_mr_button_connected_10_light = 2130837658;
 			
 			// aapt resource value: 0x7f02009b
-			public const int mr_ic_media_route_mono_dark = 2130837659;
+			public const int ic_mr_button_connected_11_dark = 2130837659;
 			
 			// aapt resource value: 0x7f02009c
-			public const int mr_ic_media_route_mono_light = 2130837660;
+			public const int ic_mr_button_connected_11_light = 2130837660;
 			
 			// aapt resource value: 0x7f02009d
-			public const int mr_ic_pause_dark = 2130837661;
+			public const int ic_mr_button_connected_12_dark = 2130837661;
 			
 			// aapt resource value: 0x7f02009e
-			public const int mr_ic_pause_light = 2130837662;
+			public const int ic_mr_button_connected_12_light = 2130837662;
 			
 			// aapt resource value: 0x7f02009f
-			public const int mr_ic_play_dark = 2130837663;
+			public const int ic_mr_button_connected_13_dark = 2130837663;
 			
 			// aapt resource value: 0x7f0200a0
-			public const int mr_ic_play_light = 2130837664;
-			
-			// aapt resource value: 0x7f0200a3
-			public const int notification_template_icon_bg = 2130837667;
+			public const int ic_mr_button_connected_13_light = 2130837664;
 			
 			// aapt resource value: 0x7f0200a1
-			public const int settings = 2130837665;
+			public const int ic_mr_button_connected_14_dark = 2130837665;
 			
 			// aapt resource value: 0x7f0200a2
-			public const int xfgloss = 2130837666;
+			public const int ic_mr_button_connected_14_light = 2130837666;
+			
+			// aapt resource value: 0x7f0200a3
+			public const int ic_mr_button_connected_15_dark = 2130837667;
+			
+			// aapt resource value: 0x7f0200a4
+			public const int ic_mr_button_connected_15_light = 2130837668;
+			
+			// aapt resource value: 0x7f0200a5
+			public const int ic_mr_button_connected_16_dark = 2130837669;
+			
+			// aapt resource value: 0x7f0200a6
+			public const int ic_mr_button_connected_16_light = 2130837670;
+			
+			// aapt resource value: 0x7f0200a7
+			public const int ic_mr_button_connected_17_dark = 2130837671;
+			
+			// aapt resource value: 0x7f0200a8
+			public const int ic_mr_button_connected_17_light = 2130837672;
+			
+			// aapt resource value: 0x7f0200a9
+			public const int ic_mr_button_connected_18_dark = 2130837673;
+			
+			// aapt resource value: 0x7f0200aa
+			public const int ic_mr_button_connected_18_light = 2130837674;
+			
+			// aapt resource value: 0x7f0200ab
+			public const int ic_mr_button_connected_19_dark = 2130837675;
+			
+			// aapt resource value: 0x7f0200ac
+			public const int ic_mr_button_connected_19_light = 2130837676;
+			
+			// aapt resource value: 0x7f0200ad
+			public const int ic_mr_button_connected_20_dark = 2130837677;
+			
+			// aapt resource value: 0x7f0200ae
+			public const int ic_mr_button_connected_20_light = 2130837678;
+			
+			// aapt resource value: 0x7f0200af
+			public const int ic_mr_button_connected_21_dark = 2130837679;
+			
+			// aapt resource value: 0x7f0200b0
+			public const int ic_mr_button_connected_21_light = 2130837680;
+			
+			// aapt resource value: 0x7f0200b1
+			public const int ic_mr_button_connected_22_dark = 2130837681;
+			
+			// aapt resource value: 0x7f0200b2
+			public const int ic_mr_button_connected_22_light = 2130837682;
+			
+			// aapt resource value: 0x7f0200b3
+			public const int ic_mr_button_connecting_00_dark = 2130837683;
+			
+			// aapt resource value: 0x7f0200b4
+			public const int ic_mr_button_connecting_00_light = 2130837684;
+			
+			// aapt resource value: 0x7f0200b5
+			public const int ic_mr_button_connecting_01_dark = 2130837685;
+			
+			// aapt resource value: 0x7f0200b6
+			public const int ic_mr_button_connecting_01_light = 2130837686;
+			
+			// aapt resource value: 0x7f0200b7
+			public const int ic_mr_button_connecting_02_dark = 2130837687;
+			
+			// aapt resource value: 0x7f0200b8
+			public const int ic_mr_button_connecting_02_light = 2130837688;
+			
+			// aapt resource value: 0x7f0200b9
+			public const int ic_mr_button_connecting_03_dark = 2130837689;
+			
+			// aapt resource value: 0x7f0200ba
+			public const int ic_mr_button_connecting_03_light = 2130837690;
+			
+			// aapt resource value: 0x7f0200bb
+			public const int ic_mr_button_connecting_04_dark = 2130837691;
+			
+			// aapt resource value: 0x7f0200bc
+			public const int ic_mr_button_connecting_04_light = 2130837692;
+			
+			// aapt resource value: 0x7f0200bd
+			public const int ic_mr_button_connecting_05_dark = 2130837693;
+			
+			// aapt resource value: 0x7f0200be
+			public const int ic_mr_button_connecting_05_light = 2130837694;
+			
+			// aapt resource value: 0x7f0200bf
+			public const int ic_mr_button_connecting_06_dark = 2130837695;
+			
+			// aapt resource value: 0x7f0200c0
+			public const int ic_mr_button_connecting_06_light = 2130837696;
+			
+			// aapt resource value: 0x7f0200c1
+			public const int ic_mr_button_connecting_07_dark = 2130837697;
+			
+			// aapt resource value: 0x7f0200c2
+			public const int ic_mr_button_connecting_07_light = 2130837698;
+			
+			// aapt resource value: 0x7f0200c3
+			public const int ic_mr_button_connecting_08_dark = 2130837699;
+			
+			// aapt resource value: 0x7f0200c4
+			public const int ic_mr_button_connecting_08_light = 2130837700;
+			
+			// aapt resource value: 0x7f0200c5
+			public const int ic_mr_button_connecting_09_dark = 2130837701;
+			
+			// aapt resource value: 0x7f0200c6
+			public const int ic_mr_button_connecting_09_light = 2130837702;
+			
+			// aapt resource value: 0x7f0200c7
+			public const int ic_mr_button_connecting_10_dark = 2130837703;
+			
+			// aapt resource value: 0x7f0200c8
+			public const int ic_mr_button_connecting_10_light = 2130837704;
+			
+			// aapt resource value: 0x7f0200c9
+			public const int ic_mr_button_connecting_11_dark = 2130837705;
+			
+			// aapt resource value: 0x7f0200ca
+			public const int ic_mr_button_connecting_11_light = 2130837706;
+			
+			// aapt resource value: 0x7f0200cb
+			public const int ic_mr_button_connecting_12_dark = 2130837707;
+			
+			// aapt resource value: 0x7f0200cc
+			public const int ic_mr_button_connecting_12_light = 2130837708;
+			
+			// aapt resource value: 0x7f0200cd
+			public const int ic_mr_button_connecting_13_dark = 2130837709;
+			
+			// aapt resource value: 0x7f0200ce
+			public const int ic_mr_button_connecting_13_light = 2130837710;
+			
+			// aapt resource value: 0x7f0200cf
+			public const int ic_mr_button_connecting_14_dark = 2130837711;
+			
+			// aapt resource value: 0x7f0200d0
+			public const int ic_mr_button_connecting_14_light = 2130837712;
+			
+			// aapt resource value: 0x7f0200d1
+			public const int ic_mr_button_connecting_15_dark = 2130837713;
+			
+			// aapt resource value: 0x7f0200d2
+			public const int ic_mr_button_connecting_15_light = 2130837714;
+			
+			// aapt resource value: 0x7f0200d3
+			public const int ic_mr_button_connecting_16_dark = 2130837715;
+			
+			// aapt resource value: 0x7f0200d4
+			public const int ic_mr_button_connecting_16_light = 2130837716;
+			
+			// aapt resource value: 0x7f0200d5
+			public const int ic_mr_button_connecting_17_dark = 2130837717;
+			
+			// aapt resource value: 0x7f0200d6
+			public const int ic_mr_button_connecting_17_light = 2130837718;
+			
+			// aapt resource value: 0x7f0200d7
+			public const int ic_mr_button_connecting_18_dark = 2130837719;
+			
+			// aapt resource value: 0x7f0200d8
+			public const int ic_mr_button_connecting_18_light = 2130837720;
+			
+			// aapt resource value: 0x7f0200d9
+			public const int ic_mr_button_connecting_19_dark = 2130837721;
+			
+			// aapt resource value: 0x7f0200da
+			public const int ic_mr_button_connecting_19_light = 2130837722;
+			
+			// aapt resource value: 0x7f0200db
+			public const int ic_mr_button_connecting_20_dark = 2130837723;
+			
+			// aapt resource value: 0x7f0200dc
+			public const int ic_mr_button_connecting_20_light = 2130837724;
+			
+			// aapt resource value: 0x7f0200dd
+			public const int ic_mr_button_connecting_21_dark = 2130837725;
+			
+			// aapt resource value: 0x7f0200de
+			public const int ic_mr_button_connecting_21_light = 2130837726;
+			
+			// aapt resource value: 0x7f0200df
+			public const int ic_mr_button_connecting_22_dark = 2130837727;
+			
+			// aapt resource value: 0x7f0200e0
+			public const int ic_mr_button_connecting_22_light = 2130837728;
+			
+			// aapt resource value: 0x7f0200e1
+			public const int ic_mr_button_disabled_dark = 2130837729;
+			
+			// aapt resource value: 0x7f0200e2
+			public const int ic_mr_button_disabled_light = 2130837730;
+			
+			// aapt resource value: 0x7f0200e3
+			public const int ic_mr_button_disconnected_dark = 2130837731;
+			
+			// aapt resource value: 0x7f0200e4
+			public const int ic_mr_button_disconnected_light = 2130837732;
+			
+			// aapt resource value: 0x7f0200e5
+			public const int ic_mr_button_grey = 2130837733;
+			
+			// aapt resource value: 0x7f0200e6
+			public const int ic_vol_type_speaker_dark = 2130837734;
+			
+			// aapt resource value: 0x7f0200e7
+			public const int ic_vol_type_speaker_group_dark = 2130837735;
+			
+			// aapt resource value: 0x7f0200e8
+			public const int ic_vol_type_speaker_group_light = 2130837736;
+			
+			// aapt resource value: 0x7f0200e9
+			public const int ic_vol_type_speaker_light = 2130837737;
+			
+			// aapt resource value: 0x7f0200ea
+			public const int ic_vol_type_tv_dark = 2130837738;
+			
+			// aapt resource value: 0x7f0200eb
+			public const int ic_vol_type_tv_light = 2130837739;
+			
+			// aapt resource value: 0x7f0200ec
+			public const int icon = 2130837740;
+			
+			// aapt resource value: 0x7f0200ed
+			public const int mr_button_connected_dark = 2130837741;
+			
+			// aapt resource value: 0x7f0200ee
+			public const int mr_button_connected_light = 2130837742;
+			
+			// aapt resource value: 0x7f0200ef
+			public const int mr_button_connecting_dark = 2130837743;
+			
+			// aapt resource value: 0x7f0200f0
+			public const int mr_button_connecting_light = 2130837744;
+			
+			// aapt resource value: 0x7f0200f1
+			public const int mr_button_dark = 2130837745;
+			
+			// aapt resource value: 0x7f0200f2
+			public const int mr_button_light = 2130837746;
+			
+			// aapt resource value: 0x7f0200f3
+			public const int mr_dialog_close_dark = 2130837747;
+			
+			// aapt resource value: 0x7f0200f4
+			public const int mr_dialog_close_light = 2130837748;
+			
+			// aapt resource value: 0x7f0200f5
+			public const int mr_dialog_material_background_dark = 2130837749;
+			
+			// aapt resource value: 0x7f0200f6
+			public const int mr_dialog_material_background_light = 2130837750;
+			
+			// aapt resource value: 0x7f0200f7
+			public const int mr_group_collapse = 2130837751;
+			
+			// aapt resource value: 0x7f0200f8
+			public const int mr_group_expand = 2130837752;
+			
+			// aapt resource value: 0x7f0200f9
+			public const int mr_media_pause_dark = 2130837753;
+			
+			// aapt resource value: 0x7f0200fa
+			public const int mr_media_pause_light = 2130837754;
+			
+			// aapt resource value: 0x7f0200fb
+			public const int mr_media_play_dark = 2130837755;
+			
+			// aapt resource value: 0x7f0200fc
+			public const int mr_media_play_light = 2130837756;
+			
+			// aapt resource value: 0x7f0200fd
+			public const int mr_media_stop_dark = 2130837757;
+			
+			// aapt resource value: 0x7f0200fe
+			public const int mr_media_stop_light = 2130837758;
+			
+			// aapt resource value: 0x7f0200ff
+			public const int mr_vol_type_audiotrack_dark = 2130837759;
+			
+			// aapt resource value: 0x7f020100
+			public const int mr_vol_type_audiotrack_light = 2130837760;
+			
+			// aapt resource value: 0x7f020101
+			public const int navigation_empty_icon = 2130837761;
+			
+			// aapt resource value: 0x7f020102
+			public const int notification_action_background = 2130837762;
+			
+			// aapt resource value: 0x7f020103
+			public const int notification_bg = 2130837763;
+			
+			// aapt resource value: 0x7f020104
+			public const int notification_bg_low = 2130837764;
+			
+			// aapt resource value: 0x7f020105
+			public const int notification_bg_low_normal = 2130837765;
+			
+			// aapt resource value: 0x7f020106
+			public const int notification_bg_low_pressed = 2130837766;
+			
+			// aapt resource value: 0x7f020107
+			public const int notification_bg_normal = 2130837767;
+			
+			// aapt resource value: 0x7f020108
+			public const int notification_bg_normal_pressed = 2130837768;
+			
+			// aapt resource value: 0x7f020109
+			public const int notification_icon_background = 2130837769;
+			
+			// aapt resource value: 0x7f02010e
+			public const int notification_template_icon_bg = 2130837774;
+			
+			// aapt resource value: 0x7f02010f
+			public const int notification_template_icon_low_bg = 2130837775;
+			
+			// aapt resource value: 0x7f02010a
+			public const int notification_tile_bg = 2130837770;
+			
+			// aapt resource value: 0x7f02010b
+			public const int notify_panel_notification_icon_bg = 2130837771;
+			
+			// aapt resource value: 0x7f02010c
+			public const int settings = 2130837772;
+			
+			// aapt resource value: 0x7f02010d
+			public const int xfgloss = 2130837773;
 			
 			static Drawable()
 			{
@@ -4007,467 +4890,545 @@ namespace XFGlossSample.Droid
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f0b008b
-			public const int action0 = 2131427467;
+			// aapt resource value: 0x7f09009c
+			public const int action0 = 2131296412;
 			
-			// aapt resource value: 0x7f0b005a
-			public const int action_bar = 2131427418;
+			// aapt resource value: 0x7f090064
+			public const int action_bar = 2131296356;
 			
-			// aapt resource value: 0x7f0b0002
-			public const int action_bar_activity_content = 2131427330;
+			// aapt resource value: 0x7f090001
+			public const int action_bar_activity_content = 2131296257;
 			
-			// aapt resource value: 0x7f0b0059
-			public const int action_bar_container = 2131427417;
+			// aapt resource value: 0x7f090063
+			public const int action_bar_container = 2131296355;
 			
-			// aapt resource value: 0x7f0b0055
-			public const int action_bar_root = 2131427413;
+			// aapt resource value: 0x7f09005f
+			public const int action_bar_root = 2131296351;
 			
-			// aapt resource value: 0x7f0b0003
-			public const int action_bar_spinner = 2131427331;
+			// aapt resource value: 0x7f090002
+			public const int action_bar_spinner = 2131296258;
 			
-			// aapt resource value: 0x7f0b003b
-			public const int action_bar_subtitle = 2131427387;
+			// aapt resource value: 0x7f090042
+			public const int action_bar_subtitle = 2131296322;
 			
-			// aapt resource value: 0x7f0b003a
-			public const int action_bar_title = 2131427386;
+			// aapt resource value: 0x7f090041
+			public const int action_bar_title = 2131296321;
 			
-			// aapt resource value: 0x7f0b005b
-			public const int action_context_bar = 2131427419;
+			// aapt resource value: 0x7f090099
+			public const int action_container = 2131296409;
 			
-			// aapt resource value: 0x7f0b008f
-			public const int action_divider = 2131427471;
+			// aapt resource value: 0x7f090065
+			public const int action_context_bar = 2131296357;
 			
-			// aapt resource value: 0x7f0b0004
-			public const int action_menu_divider = 2131427332;
+			// aapt resource value: 0x7f0900a0
+			public const int action_divider = 2131296416;
 			
-			// aapt resource value: 0x7f0b0005
-			public const int action_menu_presenter = 2131427333;
+			// aapt resource value: 0x7f09009a
+			public const int action_image = 2131296410;
 			
-			// aapt resource value: 0x7f0b0057
-			public const int action_mode_bar = 2131427415;
+			// aapt resource value: 0x7f090003
+			public const int action_menu_divider = 2131296259;
 			
-			// aapt resource value: 0x7f0b0056
-			public const int action_mode_bar_stub = 2131427414;
+			// aapt resource value: 0x7f090004
+			public const int action_menu_presenter = 2131296260;
 			
-			// aapt resource value: 0x7f0b003c
-			public const int action_mode_close_button = 2131427388;
+			// aapt resource value: 0x7f090061
+			public const int action_mode_bar = 2131296353;
 			
-			// aapt resource value: 0x7f0b003d
-			public const int activity_chooser_view_content = 2131427389;
+			// aapt resource value: 0x7f090060
+			public const int action_mode_bar_stub = 2131296352;
 			
-			// aapt resource value: 0x7f0b0049
-			public const int alertTitle = 2131427401;
+			// aapt resource value: 0x7f090043
+			public const int action_mode_close_button = 2131296323;
 			
-			// aapt resource value: 0x7f0b0035
-			public const int always = 2131427381;
+			// aapt resource value: 0x7f09009b
+			public const int action_text = 2131296411;
 			
-			// aapt resource value: 0x7f0b0033
-			public const int beginning = 2131427379;
+			// aapt resource value: 0x7f0900a9
+			public const int actions = 2131296425;
 			
-			// aapt resource value: 0x7f0b0013
-			public const int bottom = 2131427347;
+			// aapt resource value: 0x7f090044
+			public const int activity_chooser_view_content = 2131296324;
 			
-			// aapt resource value: 0x7f0b0044
-			public const int buttonPanel = 2131427396;
+			// aapt resource value: 0x7f090019
+			public const int add = 2131296281;
 			
-			// aapt resource value: 0x7f0b008c
-			public const int cancel_action = 2131427468;
+			// aapt resource value: 0x7f090058
+			public const int alertTitle = 2131296344;
 			
-			// aapt resource value: 0x7f0b0014
-			public const int center = 2131427348;
+			// aapt resource value: 0x7f09003d
+			public const int all = 2131296317;
 			
-			// aapt resource value: 0x7f0b0015
-			public const int center_horizontal = 2131427349;
+			// aapt resource value: 0x7f090023
+			public const int always = 2131296291;
 			
-			// aapt resource value: 0x7f0b0016
-			public const int center_vertical = 2131427350;
+			// aapt resource value: 0x7f09002f
+			public const int auto = 2131296303;
 			
-			// aapt resource value: 0x7f0b0052
-			public const int checkbox = 2131427410;
+			// aapt resource value: 0x7f090020
+			public const int beginning = 2131296288;
 			
-			// aapt resource value: 0x7f0b0092
-			public const int chronometer = 2131427474;
+			// aapt resource value: 0x7f090028
+			public const int bottom = 2131296296;
 			
-			// aapt resource value: 0x7f0b001d
-			public const int clip_horizontal = 2131427357;
+			// aapt resource value: 0x7f09004b
+			public const int buttonPanel = 2131296331;
 			
-			// aapt resource value: 0x7f0b001e
-			public const int clip_vertical = 2131427358;
+			// aapt resource value: 0x7f09009d
+			public const int cancel_action = 2131296413;
 			
-			// aapt resource value: 0x7f0b0036
-			public const int collapseActionView = 2131427382;
+			// aapt resource value: 0x7f090030
+			public const int center = 2131296304;
 			
-			// aapt resource value: 0x7f0b004a
-			public const int contentPanel = 2131427402;
+			// aapt resource value: 0x7f090031
+			public const int center_horizontal = 2131296305;
 			
-			// aapt resource value: 0x7f0b0050
-			public const int custom = 2131427408;
+			// aapt resource value: 0x7f090032
+			public const int center_vertical = 2131296306;
 			
-			// aapt resource value: 0x7f0b004f
-			public const int customPanel = 2131427407;
+			// aapt resource value: 0x7f09005b
+			public const int checkbox = 2131296347;
 			
-			// aapt resource value: 0x7f0b0058
-			public const int decor_content_parent = 2131427416;
+			// aapt resource value: 0x7f0900a5
+			public const int chronometer = 2131296421;
 			
-			// aapt resource value: 0x7f0b0040
-			public const int default_activity_button = 2131427392;
+			// aapt resource value: 0x7f090039
+			public const int clip_horizontal = 2131296313;
 			
-			// aapt resource value: 0x7f0b006a
-			public const int design_bottom_sheet = 2131427434;
+			// aapt resource value: 0x7f09003a
+			public const int clip_vertical = 2131296314;
 			
-			// aapt resource value: 0x7f0b0071
-			public const int design_menu_item_action_area = 2131427441;
+			// aapt resource value: 0x7f090024
+			public const int collapseActionView = 2131296292;
 			
-			// aapt resource value: 0x7f0b0070
-			public const int design_menu_item_action_area_stub = 2131427440;
+			// aapt resource value: 0x7f09004e
+			public const int contentPanel = 2131296334;
 			
-			// aapt resource value: 0x7f0b006f
-			public const int design_menu_item_text = 2131427439;
+			// aapt resource value: 0x7f090055
+			public const int custom = 2131296341;
 			
-			// aapt resource value: 0x7f0b006e
-			public const int design_navigation_view = 2131427438;
+			// aapt resource value: 0x7f090054
+			public const int customPanel = 2131296340;
 			
-			// aapt resource value: 0x7f0b0027
-			public const int disableHome = 2131427367;
+			// aapt resource value: 0x7f090062
+			public const int decor_content_parent = 2131296354;
 			
-			// aapt resource value: 0x7f0b005c
-			public const int edit_query = 2131427420;
+			// aapt resource value: 0x7f090047
+			public const int default_activity_button = 2131296327;
 			
-			// aapt resource value: 0x7f0b0017
-			public const int end = 2131427351;
+			// aapt resource value: 0x7f090076
+			public const int design_bottom_sheet = 2131296374;
 			
-			// aapt resource value: 0x7f0b0097
-			public const int end_padder = 2131427479;
+			// aapt resource value: 0x7f09007d
+			public const int design_menu_item_action_area = 2131296381;
 			
-			// aapt resource value: 0x7f0b000b
-			public const int enterAlways = 2131427339;
+			// aapt resource value: 0x7f09007c
+			public const int design_menu_item_action_area_stub = 2131296380;
 			
-			// aapt resource value: 0x7f0b000c
-			public const int enterAlwaysCollapsed = 2131427340;
+			// aapt resource value: 0x7f09007b
+			public const int design_menu_item_text = 2131296379;
 			
-			// aapt resource value: 0x7f0b000d
-			public const int exitUntilCollapsed = 2131427341;
+			// aapt resource value: 0x7f09007a
+			public const int design_navigation_view = 2131296378;
 			
-			// aapt resource value: 0x7f0b003e
-			public const int expand_activities_button = 2131427390;
+			// aapt resource value: 0x7f090012
+			public const int disableHome = 2131296274;
 			
-			// aapt resource value: 0x7f0b0051
-			public const int expanded_menu = 2131427409;
+			// aapt resource value: 0x7f090066
+			public const int edit_query = 2131296358;
 			
-			// aapt resource value: 0x7f0b001f
-			public const int fill = 2131427359;
+			// aapt resource value: 0x7f090021
+			public const int end = 2131296289;
 			
-			// aapt resource value: 0x7f0b0020
-			public const int fill_horizontal = 2131427360;
+			// aapt resource value: 0x7f0900af
+			public const int end_padder = 2131296431;
 			
-			// aapt resource value: 0x7f0b0018
-			public const int fill_vertical = 2131427352;
+			// aapt resource value: 0x7f09002a
+			public const int enterAlways = 2131296298;
 			
-			// aapt resource value: 0x7f0b0023
-			public const int @fixed = 2131427363;
+			// aapt resource value: 0x7f09002b
+			public const int enterAlwaysCollapsed = 2131296299;
 			
-			// aapt resource value: 0x7f0b0006
-			public const int home = 2131427334;
+			// aapt resource value: 0x7f09002c
+			public const int exitUntilCollapsed = 2131296300;
 			
-			// aapt resource value: 0x7f0b0028
-			public const int homeAsUp = 2131427368;
+			// aapt resource value: 0x7f090045
+			public const int expand_activities_button = 2131296325;
 			
-			// aapt resource value: 0x7f0b0042
-			public const int icon = 2131427394;
+			// aapt resource value: 0x7f09005a
+			public const int expanded_menu = 2131296346;
 			
-			// aapt resource value: 0x7f0b0037
-			public const int ifRoom = 2131427383;
+			// aapt resource value: 0x7f09003b
+			public const int fill = 2131296315;
 			
-			// aapt resource value: 0x7f0b003f
-			public const int image = 2131427391;
+			// aapt resource value: 0x7f09003c
+			public const int fill_horizontal = 2131296316;
 			
-			// aapt resource value: 0x7f0b0096
-			public const int info = 2131427478;
+			// aapt resource value: 0x7f090033
+			public const int fill_vertical = 2131296307;
 			
-			// aapt resource value: 0x7f0b0001
-			public const int item_touch_helper_previous_elevation = 2131427329;
+			// aapt resource value: 0x7f09003f
+			public const int @fixed = 2131296319;
 			
-			// aapt resource value: 0x7f0b0019
-			public const int left = 2131427353;
+			// aapt resource value: 0x7f090005
+			public const int home = 2131296261;
 			
-			// aapt resource value: 0x7f0b0090
-			public const int line1 = 2131427472;
+			// aapt resource value: 0x7f090013
+			public const int homeAsUp = 2131296275;
 			
-			// aapt resource value: 0x7f0b0094
-			public const int line3 = 2131427476;
+			// aapt resource value: 0x7f090049
+			public const int icon = 2131296329;
 			
-			// aapt resource value: 0x7f0b0025
-			public const int listMode = 2131427365;
+			// aapt resource value: 0x7f0900aa
+			public const int icon_group = 2131296426;
 			
-			// aapt resource value: 0x7f0b0041
-			public const int list_item = 2131427393;
+			// aapt resource value: 0x7f090025
+			public const int ifRoom = 2131296293;
 			
-			// aapt resource value: 0x7f0b008e
-			public const int media_actions = 2131427470;
+			// aapt resource value: 0x7f090046
+			public const int image = 2131296326;
 			
-			// aapt resource value: 0x7f0b0034
-			public const int middle = 2131427380;
+			// aapt resource value: 0x7f0900a6
+			public const int info = 2131296422;
 			
-			// aapt resource value: 0x7f0b0021
-			public const int mini = 2131427361;
+			// aapt resource value: 0x7f090000
+			public const int item_touch_helper_previous_elevation = 2131296256;
 			
-			// aapt resource value: 0x7f0b007d
-			public const int mr_art = 2131427453;
+			// aapt resource value: 0x7f090074
+			public const int largeLabel = 2131296372;
 			
-			// aapt resource value: 0x7f0b0072
-			public const int mr_chooser_list = 2131427442;
+			// aapt resource value: 0x7f090034
+			public const int left = 2131296308;
 			
-			// aapt resource value: 0x7f0b0075
-			public const int mr_chooser_route_desc = 2131427445;
+			// aapt resource value: 0x7f0900ab
+			public const int line1 = 2131296427;
 			
-			// aapt resource value: 0x7f0b0073
-			public const int mr_chooser_route_icon = 2131427443;
+			// aapt resource value: 0x7f0900ad
+			public const int line3 = 2131296429;
 			
-			// aapt resource value: 0x7f0b0074
-			public const int mr_chooser_route_name = 2131427444;
+			// aapt resource value: 0x7f09000f
+			public const int listMode = 2131296271;
 			
-			// aapt resource value: 0x7f0b007a
-			public const int mr_close = 2131427450;
+			// aapt resource value: 0x7f090048
+			public const int list_item = 2131296328;
 			
-			// aapt resource value: 0x7f0b0080
-			public const int mr_control_divider = 2131427456;
+			// aapt resource value: 0x7f0900b3
+			public const int masked = 2131296435;
 			
-			// aapt resource value: 0x7f0b0086
-			public const int mr_control_play_pause = 2131427462;
+			// aapt resource value: 0x7f09009f
+			public const int media_actions = 2131296415;
 			
-			// aapt resource value: 0x7f0b0089
-			public const int mr_control_subtitle = 2131427465;
+			// aapt resource value: 0x7f090022
+			public const int middle = 2131296290;
 			
-			// aapt resource value: 0x7f0b0088
-			public const int mr_control_title = 2131427464;
+			// aapt resource value: 0x7f09003e
+			public const int mini = 2131296318;
 			
-			// aapt resource value: 0x7f0b0087
-			public const int mr_control_title_container = 2131427463;
+			// aapt resource value: 0x7f09008b
+			public const int mr_art = 2131296395;
 			
-			// aapt resource value: 0x7f0b007b
-			public const int mr_custom_control = 2131427451;
+			// aapt resource value: 0x7f090080
+			public const int mr_chooser_list = 2131296384;
 			
-			// aapt resource value: 0x7f0b007c
-			public const int mr_default_control = 2131427452;
+			// aapt resource value: 0x7f090083
+			public const int mr_chooser_route_desc = 2131296387;
 			
-			// aapt resource value: 0x7f0b0077
-			public const int mr_dialog_area = 2131427447;
+			// aapt resource value: 0x7f090081
+			public const int mr_chooser_route_icon = 2131296385;
 			
-			// aapt resource value: 0x7f0b0076
-			public const int mr_expandable_area = 2131427446;
+			// aapt resource value: 0x7f090082
+			public const int mr_chooser_route_name = 2131296386;
 			
-			// aapt resource value: 0x7f0b008a
-			public const int mr_group_expand_collapse = 2131427466;
+			// aapt resource value: 0x7f09007f
+			public const int mr_chooser_title = 2131296383;
 			
-			// aapt resource value: 0x7f0b007e
-			public const int mr_media_main_control = 2131427454;
+			// aapt resource value: 0x7f090088
+			public const int mr_close = 2131296392;
 			
-			// aapt resource value: 0x7f0b0079
-			public const int mr_name = 2131427449;
+			// aapt resource value: 0x7f09008e
+			public const int mr_control_divider = 2131296398;
 			
-			// aapt resource value: 0x7f0b007f
-			public const int mr_playback_control = 2131427455;
+			// aapt resource value: 0x7f090094
+			public const int mr_control_playback_ctrl = 2131296404;
 			
-			// aapt resource value: 0x7f0b0078
-			public const int mr_title_bar = 2131427448;
+			// aapt resource value: 0x7f090097
+			public const int mr_control_subtitle = 2131296407;
 			
-			// aapt resource value: 0x7f0b0081
-			public const int mr_volume_control = 2131427457;
+			// aapt resource value: 0x7f090096
+			public const int mr_control_title = 2131296406;
 			
-			// aapt resource value: 0x7f0b0082
-			public const int mr_volume_group_list = 2131427458;
+			// aapt resource value: 0x7f090095
+			public const int mr_control_title_container = 2131296405;
 			
-			// aapt resource value: 0x7f0b0084
-			public const int mr_volume_item_icon = 2131427460;
+			// aapt resource value: 0x7f090089
+			public const int mr_custom_control = 2131296393;
 			
-			// aapt resource value: 0x7f0b0085
-			public const int mr_volume_slider = 2131427461;
+			// aapt resource value: 0x7f09008a
+			public const int mr_default_control = 2131296394;
 			
-			// aapt resource value: 0x7f0b002e
-			public const int multiply = 2131427374;
+			// aapt resource value: 0x7f090085
+			public const int mr_dialog_area = 2131296389;
 			
-			// aapt resource value: 0x7f0b006d
-			public const int navigation_header_container = 2131427437;
+			// aapt resource value: 0x7f090084
+			public const int mr_expandable_area = 2131296388;
 			
-			// aapt resource value: 0x7f0b0038
-			public const int never = 2131427384;
+			// aapt resource value: 0x7f090098
+			public const int mr_group_expand_collapse = 2131296408;
 			
-			// aapt resource value: 0x7f0b0010
-			public const int none = 2131427344;
+			// aapt resource value: 0x7f09008c
+			public const int mr_media_main_control = 2131296396;
 			
-			// aapt resource value: 0x7f0b0022
-			public const int normal = 2131427362;
+			// aapt resource value: 0x7f090087
+			public const int mr_name = 2131296391;
 			
-			// aapt resource value: 0x7f0b0011
-			public const int parallax = 2131427345;
+			// aapt resource value: 0x7f09008d
+			public const int mr_playback_control = 2131296397;
 			
-			// aapt resource value: 0x7f0b0046
-			public const int parentPanel = 2131427398;
+			// aapt resource value: 0x7f090086
+			public const int mr_title_bar = 2131296390;
 			
-			// aapt resource value: 0x7f0b0012
-			public const int pin = 2131427346;
+			// aapt resource value: 0x7f09008f
+			public const int mr_volume_control = 2131296399;
 			
-			// aapt resource value: 0x7f0b0007
-			public const int progress_circular = 2131427335;
+			// aapt resource value: 0x7f090090
+			public const int mr_volume_group_list = 2131296400;
 			
-			// aapt resource value: 0x7f0b0008
-			public const int progress_horizontal = 2131427336;
+			// aapt resource value: 0x7f090092
+			public const int mr_volume_item_icon = 2131296402;
 			
-			// aapt resource value: 0x7f0b0054
-			public const int radio = 2131427412;
+			// aapt resource value: 0x7f090093
+			public const int mr_volume_slider = 2131296403;
 			
-			// aapt resource value: 0x7f0b001a
-			public const int right = 2131427354;
+			// aapt resource value: 0x7f09001a
+			public const int multiply = 2131296282;
 			
-			// aapt resource value: 0x7f0b002f
-			public const int screen = 2131427375;
+			// aapt resource value: 0x7f090079
+			public const int navigation_header_container = 2131296377;
 			
-			// aapt resource value: 0x7f0b000e
-			public const int scroll = 2131427342;
+			// aapt resource value: 0x7f090026
+			public const int never = 2131296294;
 			
-			// aapt resource value: 0x7f0b004e
-			public const int scrollIndicatorDown = 2131427406;
+			// aapt resource value: 0x7f090014
+			public const int none = 2131296276;
 			
-			// aapt resource value: 0x7f0b004b
-			public const int scrollIndicatorUp = 2131427403;
+			// aapt resource value: 0x7f090010
+			public const int normal = 2131296272;
 			
-			// aapt resource value: 0x7f0b004c
-			public const int scrollView = 2131427404;
+			// aapt resource value: 0x7f0900a8
+			public const int notification_background = 2131296424;
 			
-			// aapt resource value: 0x7f0b0024
-			public const int scrollable = 2131427364;
+			// aapt resource value: 0x7f0900a2
+			public const int notification_main_column = 2131296418;
 			
-			// aapt resource value: 0x7f0b005e
-			public const int search_badge = 2131427422;
+			// aapt resource value: 0x7f0900a1
+			public const int notification_main_column_container = 2131296417;
 			
-			// aapt resource value: 0x7f0b005d
-			public const int search_bar = 2131427421;
+			// aapt resource value: 0x7f090037
+			public const int parallax = 2131296311;
 			
-			// aapt resource value: 0x7f0b005f
-			public const int search_button = 2131427423;
+			// aapt resource value: 0x7f09004d
+			public const int parentPanel = 2131296333;
 			
-			// aapt resource value: 0x7f0b0064
-			public const int search_close_btn = 2131427428;
+			// aapt resource value: 0x7f090038
+			public const int pin = 2131296312;
 			
-			// aapt resource value: 0x7f0b0060
-			public const int search_edit_frame = 2131427424;
+			// aapt resource value: 0x7f090006
+			public const int progress_circular = 2131296262;
 			
-			// aapt resource value: 0x7f0b0066
-			public const int search_go_btn = 2131427430;
+			// aapt resource value: 0x7f090007
+			public const int progress_horizontal = 2131296263;
 			
-			// aapt resource value: 0x7f0b0061
-			public const int search_mag_icon = 2131427425;
+			// aapt resource value: 0x7f09005d
+			public const int radio = 2131296349;
 			
-			// aapt resource value: 0x7f0b0062
-			public const int search_plate = 2131427426;
+			// aapt resource value: 0x7f090035
+			public const int right = 2131296309;
 			
-			// aapt resource value: 0x7f0b0063
-			public const int search_src_text = 2131427427;
+			// aapt resource value: 0x7f0900a7
+			public const int right_icon = 2131296423;
 			
-			// aapt resource value: 0x7f0b0067
-			public const int search_voice_btn = 2131427431;
+			// aapt resource value: 0x7f0900a3
+			public const int right_side = 2131296419;
 			
-			// aapt resource value: 0x7f0b0068
-			public const int select_dialog_listview = 2131427432;
+			// aapt resource value: 0x7f09001b
+			public const int screen = 2131296283;
 			
-			// aapt resource value: 0x7f0b0053
-			public const int shortcut = 2131427411;
+			// aapt resource value: 0x7f09002d
+			public const int scroll = 2131296301;
 			
-			// aapt resource value: 0x7f0b0029
-			public const int showCustom = 2131427369;
+			// aapt resource value: 0x7f090053
+			public const int scrollIndicatorDown = 2131296339;
 			
-			// aapt resource value: 0x7f0b002a
-			public const int showHome = 2131427370;
+			// aapt resource value: 0x7f09004f
+			public const int scrollIndicatorUp = 2131296335;
 			
-			// aapt resource value: 0x7f0b002b
-			public const int showTitle = 2131427371;
+			// aapt resource value: 0x7f090050
+			public const int scrollView = 2131296336;
 			
-			// aapt resource value: 0x7f0b0098
-			public const int sliding_tabs = 2131427480;
+			// aapt resource value: 0x7f090040
+			public const int scrollable = 2131296320;
 			
-			// aapt resource value: 0x7f0b006c
-			public const int snackbar_action = 2131427436;
+			// aapt resource value: 0x7f090068
+			public const int search_badge = 2131296360;
 			
-			// aapt resource value: 0x7f0b006b
-			public const int snackbar_text = 2131427435;
+			// aapt resource value: 0x7f090067
+			public const int search_bar = 2131296359;
 			
-			// aapt resource value: 0x7f0b000f
-			public const int snap = 2131427343;
+			// aapt resource value: 0x7f090069
+			public const int search_button = 2131296361;
 			
-			// aapt resource value: 0x7f0b0045
-			public const int spacer = 2131427397;
+			// aapt resource value: 0x7f09006e
+			public const int search_close_btn = 2131296366;
 			
-			// aapt resource value: 0x7f0b0009
-			public const int split_action_bar = 2131427337;
+			// aapt resource value: 0x7f09006a
+			public const int search_edit_frame = 2131296362;
 			
-			// aapt resource value: 0x7f0b0030
-			public const int src_atop = 2131427376;
+			// aapt resource value: 0x7f090070
+			public const int search_go_btn = 2131296368;
 			
-			// aapt resource value: 0x7f0b0031
-			public const int src_in = 2131427377;
+			// aapt resource value: 0x7f09006b
+			public const int search_mag_icon = 2131296363;
 			
-			// aapt resource value: 0x7f0b0032
-			public const int src_over = 2131427378;
+			// aapt resource value: 0x7f09006c
+			public const int search_plate = 2131296364;
 			
-			// aapt resource value: 0x7f0b001b
-			public const int start = 2131427355;
+			// aapt resource value: 0x7f09006d
+			public const int search_src_text = 2131296365;
 			
-			// aapt resource value: 0x7f0b008d
-			public const int status_bar_latest_event_content = 2131427469;
+			// aapt resource value: 0x7f090071
+			public const int search_voice_btn = 2131296369;
 			
-			// aapt resource value: 0x7f0b0065
-			public const int submit_area = 2131427429;
+			// aapt resource value: 0x7f090072
+			public const int select_dialog_listview = 2131296370;
 			
-			// aapt resource value: 0x7f0b0026
-			public const int tabMode = 2131427366;
+			// aapt resource value: 0x7f09005c
+			public const int shortcut = 2131296348;
 			
-			// aapt resource value: 0x7f0b0095
-			public const int text = 2131427477;
+			// aapt resource value: 0x7f090015
+			public const int showCustom = 2131296277;
 			
-			// aapt resource value: 0x7f0b0093
-			public const int text2 = 2131427475;
+			// aapt resource value: 0x7f090016
+			public const int showHome = 2131296278;
 			
-			// aapt resource value: 0x7f0b004d
-			public const int textSpacerNoButtons = 2131427405;
+			// aapt resource value: 0x7f090017
+			public const int showTitle = 2131296279;
 			
-			// aapt resource value: 0x7f0b0091
-			public const int time = 2131427473;
+			// aapt resource value: 0x7f0900b0
+			public const int sliding_tabs = 2131296432;
 			
-			// aapt resource value: 0x7f0b0043
-			public const int title = 2131427395;
+			// aapt resource value: 0x7f090073
+			public const int smallLabel = 2131296371;
 			
-			// aapt resource value: 0x7f0b0048
-			public const int title_template = 2131427400;
+			// aapt resource value: 0x7f090078
+			public const int snackbar_action = 2131296376;
 			
-			// aapt resource value: 0x7f0b0099
-			public const int toolbar = 2131427481;
+			// aapt resource value: 0x7f090077
+			public const int snackbar_text = 2131296375;
 			
-			// aapt resource value: 0x7f0b001c
-			public const int top = 2131427356;
+			// aapt resource value: 0x7f09002e
+			public const int snap = 2131296302;
 			
-			// aapt resource value: 0x7f0b0047
-			public const int topPanel = 2131427399;
+			// aapt resource value: 0x7f09004c
+			public const int spacer = 2131296332;
 			
-			// aapt resource value: 0x7f0b0069
-			public const int touch_outside = 2131427433;
+			// aapt resource value: 0x7f090008
+			public const int split_action_bar = 2131296264;
 			
-			// aapt resource value: 0x7f0b000a
-			public const int up = 2131427338;
+			// aapt resource value: 0x7f09001c
+			public const int src_atop = 2131296284;
 			
-			// aapt resource value: 0x7f0b002c
-			public const int useLogo = 2131427372;
+			// aapt resource value: 0x7f09001d
+			public const int src_in = 2131296285;
 			
-			// aapt resource value: 0x7f0b0000
-			public const int view_offset_helper = 2131427328;
+			// aapt resource value: 0x7f09001e
+			public const int src_over = 2131296286;
 			
-			// aapt resource value: 0x7f0b0083
-			public const int volume_item_container = 2131427459;
+			// aapt resource value: 0x7f090036
+			public const int start = 2131296310;
 			
-			// aapt resource value: 0x7f0b0039
-			public const int withText = 2131427385;
+			// aapt resource value: 0x7f09009e
+			public const int status_bar_latest_event_content = 2131296414;
 			
-			// aapt resource value: 0x7f0b002d
-			public const int wrap_content = 2131427373;
+			// aapt resource value: 0x7f09005e
+			public const int submenuarrow = 2131296350;
+			
+			// aapt resource value: 0x7f09006f
+			public const int submit_area = 2131296367;
+			
+			// aapt resource value: 0x7f090011
+			public const int tabMode = 2131296273;
+			
+			// aapt resource value: 0x7f0900ae
+			public const int text = 2131296430;
+			
+			// aapt resource value: 0x7f0900ac
+			public const int text2 = 2131296428;
+			
+			// aapt resource value: 0x7f090052
+			public const int textSpacerNoButtons = 2131296338;
+			
+			// aapt resource value: 0x7f090051
+			public const int textSpacerNoTitle = 2131296337;
+			
+			// aapt resource value: 0x7f09007e
+			public const int text_input_password_toggle = 2131296382;
+			
+			// aapt resource value: 0x7f09000c
+			public const int textinput_counter = 2131296268;
+			
+			// aapt resource value: 0x7f09000d
+			public const int textinput_error = 2131296269;
+			
+			// aapt resource value: 0x7f0900a4
+			public const int time = 2131296420;
+			
+			// aapt resource value: 0x7f09004a
+			public const int title = 2131296330;
+			
+			// aapt resource value: 0x7f090059
+			public const int titleDividerNoCustom = 2131296345;
+			
+			// aapt resource value: 0x7f090057
+			public const int title_template = 2131296343;
+			
+			// aapt resource value: 0x7f0900b1
+			public const int toolbar = 2131296433;
+			
+			// aapt resource value: 0x7f090029
+			public const int top = 2131296297;
+			
+			// aapt resource value: 0x7f090056
+			public const int topPanel = 2131296342;
+			
+			// aapt resource value: 0x7f090075
+			public const int touch_outside = 2131296373;
+			
+			// aapt resource value: 0x7f09000a
+			public const int transition_current_scene = 2131296266;
+			
+			// aapt resource value: 0x7f09000b
+			public const int transition_scene_layoutid_cache = 2131296267;
+			
+			// aapt resource value: 0x7f090009
+			public const int up = 2131296265;
+			
+			// aapt resource value: 0x7f090018
+			public const int useLogo = 2131296280;
+			
+			// aapt resource value: 0x7f09000e
+			public const int view_offset_helper = 2131296270;
+			
+			// aapt resource value: 0x7f0900b2
+			public const int visible = 2131296434;
+			
+			// aapt resource value: 0x7f090091
+			public const int volume_item_container = 2131296401;
+			
+			// aapt resource value: 0x7f090027
+			public const int withText = 2131296295;
+			
+			// aapt resource value: 0x7f09001f
+			public const int wrap_content = 2131296287;
 			
 			static Id()
 			{
@@ -4482,35 +5443,41 @@ namespace XFGlossSample.Droid
 		public partial class Integer
 		{
 			
-			// aapt resource value: 0x7f080006
-			public const int abc_config_activityDefaultDur = 2131230726;
+			// aapt resource value: 0x7f0a0003
+			public const int abc_config_activityDefaultDur = 2131361795;
 			
-			// aapt resource value: 0x7f080007
-			public const int abc_config_activityShortDur = 2131230727;
+			// aapt resource value: 0x7f0a0004
+			public const int abc_config_activityShortDur = 2131361796;
 			
-			// aapt resource value: 0x7f080005
-			public const int abc_max_action_buttons = 2131230725;
+			// aapt resource value: 0x7f0a0008
+			public const int app_bar_elevation_anim_duration = 2131361800;
 			
-			// aapt resource value: 0x7f080004
-			public const int bottom_sheet_slide_duration = 2131230724;
+			// aapt resource value: 0x7f0a0009
+			public const int bottom_sheet_slide_duration = 2131361801;
 			
-			// aapt resource value: 0x7f080008
-			public const int cancel_button_image_alpha = 2131230728;
+			// aapt resource value: 0x7f0a0005
+			public const int cancel_button_image_alpha = 2131361797;
 			
-			// aapt resource value: 0x7f080003
-			public const int design_snackbar_text_max_lines = 2131230723;
+			// aapt resource value: 0x7f0a0007
+			public const int design_snackbar_text_max_lines = 2131361799;
 			
-			// aapt resource value: 0x7f080000
-			public const int mr_controller_volume_group_list_animation_duration_ms = 2131230720;
+			// aapt resource value: 0x7f0a000a
+			public const int hide_password_duration = 2131361802;
 			
-			// aapt resource value: 0x7f080001
-			public const int mr_controller_volume_group_list_fade_in_duration_ms = 2131230721;
+			// aapt resource value: 0x7f0a0000
+			public const int mr_controller_volume_group_list_animation_duration_ms = 2131361792;
 			
-			// aapt resource value: 0x7f080002
-			public const int mr_controller_volume_group_list_fade_out_duration_ms = 2131230722;
+			// aapt resource value: 0x7f0a0001
+			public const int mr_controller_volume_group_list_fade_in_duration_ms = 2131361793;
 			
-			// aapt resource value: 0x7f080009
-			public const int status_bar_notification_info_maxnum = 2131230729;
+			// aapt resource value: 0x7f0a0002
+			public const int mr_controller_volume_group_list_fade_out_duration_ms = 2131361794;
+			
+			// aapt resource value: 0x7f0a000b
+			public const int show_password_duration = 2131361803;
+			
+			// aapt resource value: 0x7f0a0006
+			public const int status_bar_notification_info_maxnum = 2131361798;
 			
 			static Integer()
 			{
@@ -4525,11 +5492,11 @@ namespace XFGlossSample.Droid
 		public partial class Interpolator
 		{
 			
-			// aapt resource value: 0x7f050000
-			public const int mr_fast_out_slow_in = 2131034112;
+			// aapt resource value: 0x7f060000
+			public const int mr_fast_out_slow_in = 2131099648;
 			
-			// aapt resource value: 0x7f050001
-			public const int mr_linear_out_slow_in = 2131034113;
+			// aapt resource value: 0x7f060001
+			public const int mr_linear_out_slow_in = 2131099649;
 			
 			static Interpolator()
 			{
@@ -4578,142 +5545,175 @@ namespace XFGlossSample.Droid
 			public const int abc_alert_dialog_material = 2130903050;
 			
 			// aapt resource value: 0x7f03000b
-			public const int abc_dialog_title_material = 2130903051;
+			public const int abc_alert_dialog_title_material = 2130903051;
 			
 			// aapt resource value: 0x7f03000c
-			public const int abc_expanded_menu_layout = 2130903052;
+			public const int abc_dialog_title_material = 2130903052;
 			
 			// aapt resource value: 0x7f03000d
-			public const int abc_list_menu_item_checkbox = 2130903053;
+			public const int abc_expanded_menu_layout = 2130903053;
 			
 			// aapt resource value: 0x7f03000e
-			public const int abc_list_menu_item_icon = 2130903054;
+			public const int abc_list_menu_item_checkbox = 2130903054;
 			
 			// aapt resource value: 0x7f03000f
-			public const int abc_list_menu_item_layout = 2130903055;
+			public const int abc_list_menu_item_icon = 2130903055;
 			
 			// aapt resource value: 0x7f030010
-			public const int abc_list_menu_item_radio = 2130903056;
+			public const int abc_list_menu_item_layout = 2130903056;
 			
 			// aapt resource value: 0x7f030011
-			public const int abc_popup_menu_item_layout = 2130903057;
+			public const int abc_list_menu_item_radio = 2130903057;
 			
 			// aapt resource value: 0x7f030012
-			public const int abc_screen_content_include = 2130903058;
+			public const int abc_popup_menu_header_item_layout = 2130903058;
 			
 			// aapt resource value: 0x7f030013
-			public const int abc_screen_simple = 2130903059;
+			public const int abc_popup_menu_item_layout = 2130903059;
 			
 			// aapt resource value: 0x7f030014
-			public const int abc_screen_simple_overlay_action_mode = 2130903060;
+			public const int abc_screen_content_include = 2130903060;
 			
 			// aapt resource value: 0x7f030015
-			public const int abc_screen_toolbar = 2130903061;
+			public const int abc_screen_simple = 2130903061;
 			
 			// aapt resource value: 0x7f030016
-			public const int abc_search_dropdown_item_icons_2line = 2130903062;
+			public const int abc_screen_simple_overlay_action_mode = 2130903062;
 			
 			// aapt resource value: 0x7f030017
-			public const int abc_search_view = 2130903063;
+			public const int abc_screen_toolbar = 2130903063;
 			
 			// aapt resource value: 0x7f030018
-			public const int abc_select_dialog_material = 2130903064;
+			public const int abc_search_dropdown_item_icons_2line = 2130903064;
 			
 			// aapt resource value: 0x7f030019
-			public const int design_bottom_sheet_dialog = 2130903065;
+			public const int abc_search_view = 2130903065;
 			
 			// aapt resource value: 0x7f03001a
-			public const int design_layout_snackbar = 2130903066;
+			public const int abc_select_dialog_material = 2130903066;
 			
 			// aapt resource value: 0x7f03001b
-			public const int design_layout_snackbar_include = 2130903067;
+			public const int design_bottom_navigation_item = 2130903067;
 			
 			// aapt resource value: 0x7f03001c
-			public const int design_layout_tab_icon = 2130903068;
+			public const int design_bottom_sheet_dialog = 2130903068;
 			
 			// aapt resource value: 0x7f03001d
-			public const int design_layout_tab_text = 2130903069;
+			public const int design_layout_snackbar = 2130903069;
 			
 			// aapt resource value: 0x7f03001e
-			public const int design_menu_item_action_area = 2130903070;
+			public const int design_layout_snackbar_include = 2130903070;
 			
 			// aapt resource value: 0x7f03001f
-			public const int design_navigation_item = 2130903071;
+			public const int design_layout_tab_icon = 2130903071;
 			
 			// aapt resource value: 0x7f030020
-			public const int design_navigation_item_header = 2130903072;
+			public const int design_layout_tab_text = 2130903072;
 			
 			// aapt resource value: 0x7f030021
-			public const int design_navigation_item_separator = 2130903073;
+			public const int design_menu_item_action_area = 2130903073;
 			
 			// aapt resource value: 0x7f030022
-			public const int design_navigation_item_subheader = 2130903074;
+			public const int design_navigation_item = 2130903074;
 			
 			// aapt resource value: 0x7f030023
-			public const int design_navigation_menu = 2130903075;
+			public const int design_navigation_item_header = 2130903075;
 			
 			// aapt resource value: 0x7f030024
-			public const int design_navigation_menu_item = 2130903076;
+			public const int design_navigation_item_separator = 2130903076;
 			
 			// aapt resource value: 0x7f030025
-			public const int mr_chooser_dialog = 2130903077;
+			public const int design_navigation_item_subheader = 2130903077;
 			
 			// aapt resource value: 0x7f030026
-			public const int mr_chooser_list_item = 2130903078;
+			public const int design_navigation_menu = 2130903078;
 			
 			// aapt resource value: 0x7f030027
-			public const int mr_controller_material_dialog_b = 2130903079;
+			public const int design_navigation_menu_item = 2130903079;
 			
 			// aapt resource value: 0x7f030028
-			public const int mr_controller_volume_item = 2130903080;
+			public const int design_text_input_password_icon = 2130903080;
 			
 			// aapt resource value: 0x7f030029
-			public const int mr_playback_control = 2130903081;
+			public const int mr_chooser_dialog = 2130903081;
 			
 			// aapt resource value: 0x7f03002a
-			public const int mr_volume_control = 2130903082;
+			public const int mr_chooser_list_item = 2130903082;
 			
 			// aapt resource value: 0x7f03002b
-			public const int notification_media_action = 2130903083;
+			public const int mr_controller_material_dialog_b = 2130903083;
 			
 			// aapt resource value: 0x7f03002c
-			public const int notification_media_cancel_action = 2130903084;
+			public const int mr_controller_volume_item = 2130903084;
 			
 			// aapt resource value: 0x7f03002d
-			public const int notification_template_big_media = 2130903085;
+			public const int mr_playback_control = 2130903085;
 			
 			// aapt resource value: 0x7f03002e
-			public const int notification_template_big_media_narrow = 2130903086;
+			public const int mr_volume_control = 2130903086;
 			
 			// aapt resource value: 0x7f03002f
-			public const int notification_template_lines = 2130903087;
+			public const int notification_action = 2130903087;
 			
 			// aapt resource value: 0x7f030030
-			public const int notification_template_media = 2130903088;
+			public const int notification_action_tombstone = 2130903088;
 			
 			// aapt resource value: 0x7f030031
-			public const int notification_template_part_chronometer = 2130903089;
+			public const int notification_media_action = 2130903089;
 			
 			// aapt resource value: 0x7f030032
-			public const int notification_template_part_time = 2130903090;
+			public const int notification_media_cancel_action = 2130903090;
 			
 			// aapt resource value: 0x7f030033
-			public const int select_dialog_item_material = 2130903091;
+			public const int notification_template_big_media = 2130903091;
 			
 			// aapt resource value: 0x7f030034
-			public const int select_dialog_multichoice_material = 2130903092;
+			public const int notification_template_big_media_custom = 2130903092;
 			
 			// aapt resource value: 0x7f030035
-			public const int select_dialog_singlechoice_material = 2130903093;
+			public const int notification_template_big_media_narrow = 2130903093;
 			
 			// aapt resource value: 0x7f030036
-			public const int support_simple_spinner_dropdown_item = 2130903094;
+			public const int notification_template_big_media_narrow_custom = 2130903094;
 			
 			// aapt resource value: 0x7f030037
-			public const int Tabbar = 2130903095;
+			public const int notification_template_custom_big = 2130903095;
 			
 			// aapt resource value: 0x7f030038
-			public const int Toolbar = 2130903096;
+			public const int notification_template_icon_group = 2130903096;
+			
+			// aapt resource value: 0x7f030039
+			public const int notification_template_lines_media = 2130903097;
+			
+			// aapt resource value: 0x7f03003a
+			public const int notification_template_media = 2130903098;
+			
+			// aapt resource value: 0x7f03003b
+			public const int notification_template_media_custom = 2130903099;
+			
+			// aapt resource value: 0x7f03003c
+			public const int notification_template_part_chronometer = 2130903100;
+			
+			// aapt resource value: 0x7f03003d
+			public const int notification_template_part_time = 2130903101;
+			
+			// aapt resource value: 0x7f03003e
+			public const int select_dialog_item_material = 2130903102;
+			
+			// aapt resource value: 0x7f03003f
+			public const int select_dialog_multichoice_material = 2130903103;
+			
+			// aapt resource value: 0x7f030040
+			public const int select_dialog_singlechoice_material = 2130903104;
+			
+			// aapt resource value: 0x7f030041
+			public const int support_simple_spinner_dropdown_item = 2130903105;
+			
+			// aapt resource value: 0x7f030042
+			public const int Tabbar = 2130903106;
+			
+			// aapt resource value: 0x7f030043
+			public const int Toolbar = 2130903107;
 			
 			static Layout()
 			{
@@ -4728,122 +5728,194 @@ namespace XFGlossSample.Droid
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f060012
-			public const int abc_action_bar_home_description = 2131099666;
+			// aapt resource value: 0x7f070016
+			public const int abc_action_bar_home_description = 2131165206;
 			
-			// aapt resource value: 0x7f060013
-			public const int abc_action_bar_home_description_format = 2131099667;
+			// aapt resource value: 0x7f070017
+			public const int abc_action_bar_home_description_format = 2131165207;
 			
-			// aapt resource value: 0x7f060014
-			public const int abc_action_bar_home_subtitle_description_format = 2131099668;
+			// aapt resource value: 0x7f070018
+			public const int abc_action_bar_home_subtitle_description_format = 2131165208;
 			
-			// aapt resource value: 0x7f060015
-			public const int abc_action_bar_up_description = 2131099669;
+			// aapt resource value: 0x7f070019
+			public const int abc_action_bar_up_description = 2131165209;
 			
-			// aapt resource value: 0x7f060016
-			public const int abc_action_menu_overflow_description = 2131099670;
+			// aapt resource value: 0x7f07001a
+			public const int abc_action_menu_overflow_description = 2131165210;
 			
-			// aapt resource value: 0x7f060017
-			public const int abc_action_mode_done = 2131099671;
+			// aapt resource value: 0x7f07001b
+			public const int abc_action_mode_done = 2131165211;
 			
-			// aapt resource value: 0x7f060018
-			public const int abc_activity_chooser_view_see_all = 2131099672;
+			// aapt resource value: 0x7f07001c
+			public const int abc_activity_chooser_view_see_all = 2131165212;
 			
-			// aapt resource value: 0x7f060019
-			public const int abc_activitychooserview_choose_application = 2131099673;
+			// aapt resource value: 0x7f07001d
+			public const int abc_activitychooserview_choose_application = 2131165213;
 			
-			// aapt resource value: 0x7f06001a
-			public const int abc_capital_off = 2131099674;
+			// aapt resource value: 0x7f07001e
+			public const int abc_capital_off = 2131165214;
 			
-			// aapt resource value: 0x7f06001b
-			public const int abc_capital_on = 2131099675;
+			// aapt resource value: 0x7f07001f
+			public const int abc_capital_on = 2131165215;
 			
-			// aapt resource value: 0x7f06001c
-			public const int abc_search_hint = 2131099676;
+			// aapt resource value: 0x7f07002b
+			public const int abc_font_family_body_1_material = 2131165227;
 			
-			// aapt resource value: 0x7f06001d
-			public const int abc_searchview_description_clear = 2131099677;
+			// aapt resource value: 0x7f07002c
+			public const int abc_font_family_body_2_material = 2131165228;
 			
-			// aapt resource value: 0x7f06001e
-			public const int abc_searchview_description_query = 2131099678;
+			// aapt resource value: 0x7f07002d
+			public const int abc_font_family_button_material = 2131165229;
 			
-			// aapt resource value: 0x7f06001f
-			public const int abc_searchview_description_search = 2131099679;
+			// aapt resource value: 0x7f07002e
+			public const int abc_font_family_caption_material = 2131165230;
 			
-			// aapt resource value: 0x7f060020
-			public const int abc_searchview_description_submit = 2131099680;
+			// aapt resource value: 0x7f07002f
+			public const int abc_font_family_display_1_material = 2131165231;
 			
-			// aapt resource value: 0x7f060021
-			public const int abc_searchview_description_voice = 2131099681;
+			// aapt resource value: 0x7f070030
+			public const int abc_font_family_display_2_material = 2131165232;
 			
-			// aapt resource value: 0x7f060022
-			public const int abc_shareactionprovider_share_with = 2131099682;
+			// aapt resource value: 0x7f070031
+			public const int abc_font_family_display_3_material = 2131165233;
 			
-			// aapt resource value: 0x7f060023
-			public const int abc_shareactionprovider_share_with_application = 2131099683;
+			// aapt resource value: 0x7f070032
+			public const int abc_font_family_display_4_material = 2131165234;
 			
-			// aapt resource value: 0x7f060024
-			public const int abc_toolbar_collapse_description = 2131099684;
+			// aapt resource value: 0x7f070033
+			public const int abc_font_family_headline_material = 2131165235;
 			
-			// aapt resource value: 0x7f06000f
-			public const int appbar_scrolling_view_behavior = 2131099663;
+			// aapt resource value: 0x7f070034
+			public const int abc_font_family_menu_material = 2131165236;
 			
-			// aapt resource value: 0x7f060010
-			public const int bottom_sheet_behavior = 2131099664;
+			// aapt resource value: 0x7f070035
+			public const int abc_font_family_subhead_material = 2131165237;
 			
-			// aapt resource value: 0x7f060011
-			public const int character_counter_pattern = 2131099665;
+			// aapt resource value: 0x7f070036
+			public const int abc_font_family_title_material = 2131165238;
 			
-			// aapt resource value: 0x7f060026
-			public const int library_name = 2131099686;
+			// aapt resource value: 0x7f070020
+			public const int abc_search_hint = 2131165216;
 			
-			// aapt resource value: 0x7f060000
-			public const int mr_button_content_description = 2131099648;
+			// aapt resource value: 0x7f070021
+			public const int abc_searchview_description_clear = 2131165217;
 			
-			// aapt resource value: 0x7f060001
-			public const int mr_chooser_searching = 2131099649;
+			// aapt resource value: 0x7f070022
+			public const int abc_searchview_description_query = 2131165218;
 			
-			// aapt resource value: 0x7f060002
-			public const int mr_chooser_title = 2131099650;
+			// aapt resource value: 0x7f070023
+			public const int abc_searchview_description_search = 2131165219;
 			
-			// aapt resource value: 0x7f060003
-			public const int mr_controller_casting_screen = 2131099651;
+			// aapt resource value: 0x7f070024
+			public const int abc_searchview_description_submit = 2131165220;
 			
-			// aapt resource value: 0x7f060004
-			public const int mr_controller_close_description = 2131099652;
+			// aapt resource value: 0x7f070025
+			public const int abc_searchview_description_voice = 2131165221;
 			
-			// aapt resource value: 0x7f060005
-			public const int mr_controller_collapse_group = 2131099653;
+			// aapt resource value: 0x7f070026
+			public const int abc_shareactionprovider_share_with = 2131165222;
 			
-			// aapt resource value: 0x7f060006
-			public const int mr_controller_disconnect = 2131099654;
+			// aapt resource value: 0x7f070027
+			public const int abc_shareactionprovider_share_with_application = 2131165223;
 			
-			// aapt resource value: 0x7f060007
-			public const int mr_controller_expand_group = 2131099655;
+			// aapt resource value: 0x7f070028
+			public const int abc_toolbar_collapse_description = 2131165224;
 			
-			// aapt resource value: 0x7f060008
-			public const int mr_controller_no_info_available = 2131099656;
+			// aapt resource value: 0x7f070037
+			public const int appbar_scrolling_view_behavior = 2131165239;
 			
-			// aapt resource value: 0x7f060009
-			public const int mr_controller_no_media_selected = 2131099657;
+			// aapt resource value: 0x7f070038
+			public const int bottom_sheet_behavior = 2131165240;
 			
-			// aapt resource value: 0x7f06000a
-			public const int mr_controller_pause = 2131099658;
+			// aapt resource value: 0x7f070039
+			public const int character_counter_pattern = 2131165241;
 			
-			// aapt resource value: 0x7f06000b
-			public const int mr_controller_play = 2131099659;
+			// aapt resource value: 0x7f070000
+			public const int library_name = 2131165184;
 			
-			// aapt resource value: 0x7f06000c
-			public const int mr_controller_stop = 2131099660;
+			// aapt resource value: 0x7f070001
+			public const int mr_button_content_description = 2131165185;
 			
-			// aapt resource value: 0x7f06000d
-			public const int mr_system_route_name = 2131099661;
+			// aapt resource value: 0x7f070002
+			public const int mr_cast_button_connected = 2131165186;
 			
-			// aapt resource value: 0x7f06000e
-			public const int mr_user_route_category_name = 2131099662;
+			// aapt resource value: 0x7f070003
+			public const int mr_cast_button_connecting = 2131165187;
 			
-			// aapt resource value: 0x7f060025
-			public const int status_bar_notification_info_overflow = 2131099685;
+			// aapt resource value: 0x7f070004
+			public const int mr_cast_button_disconnected = 2131165188;
+			
+			// aapt resource value: 0x7f070005
+			public const int mr_chooser_searching = 2131165189;
+			
+			// aapt resource value: 0x7f070006
+			public const int mr_chooser_title = 2131165190;
+			
+			// aapt resource value: 0x7f070007
+			public const int mr_controller_album_art = 2131165191;
+			
+			// aapt resource value: 0x7f070008
+			public const int mr_controller_casting_screen = 2131165192;
+			
+			// aapt resource value: 0x7f070009
+			public const int mr_controller_close_description = 2131165193;
+			
+			// aapt resource value: 0x7f07000a
+			public const int mr_controller_collapse_group = 2131165194;
+			
+			// aapt resource value: 0x7f07000b
+			public const int mr_controller_disconnect = 2131165195;
+			
+			// aapt resource value: 0x7f07000c
+			public const int mr_controller_expand_group = 2131165196;
+			
+			// aapt resource value: 0x7f07000d
+			public const int mr_controller_no_info_available = 2131165197;
+			
+			// aapt resource value: 0x7f07000e
+			public const int mr_controller_no_media_selected = 2131165198;
+			
+			// aapt resource value: 0x7f07000f
+			public const int mr_controller_pause = 2131165199;
+			
+			// aapt resource value: 0x7f070010
+			public const int mr_controller_play = 2131165200;
+			
+			// aapt resource value: 0x7f070015
+			public const int mr_controller_stop = 2131165205;
+			
+			// aapt resource value: 0x7f070011
+			public const int mr_controller_stop_casting = 2131165201;
+			
+			// aapt resource value: 0x7f070012
+			public const int mr_controller_volume_slider = 2131165202;
+			
+			// aapt resource value: 0x7f070013
+			public const int mr_system_route_name = 2131165203;
+			
+			// aapt resource value: 0x7f070014
+			public const int mr_user_route_category_name = 2131165204;
+			
+			// aapt resource value: 0x7f07003a
+			public const int password_toggle_content_description = 2131165242;
+			
+			// aapt resource value: 0x7f07003b
+			public const int path_password_eye = 2131165243;
+			
+			// aapt resource value: 0x7f07003c
+			public const int path_password_eye_mask_strike_through = 2131165244;
+			
+			// aapt resource value: 0x7f07003d
+			public const int path_password_eye_mask_visible = 2131165245;
+			
+			// aapt resource value: 0x7f07003e
+			public const int path_password_strike_through = 2131165246;
+			
+			// aapt resource value: 0x7f070029
+			public const int search_menu_title = 2131165225;
+			
+			// aapt resource value: 0x7f07002a
+			public const int status_bar_notification_info_overflow = 2131165226;
 			
 			static String()
 			{
@@ -4858,1124 +5930,1193 @@ namespace XFGlossSample.Droid
 		public partial class Style
 		{
 			
-			// aapt resource value: 0x7f0900ba
-			public const int AlertDialog_AppCompat = 2131296442;
+			// aapt resource value: 0x7f0b00ae
+			public const int AlertDialog_AppCompat = 2131427502;
 			
-			// aapt resource value: 0x7f0900bb
-			public const int AlertDialog_AppCompat_Light = 2131296443;
+			// aapt resource value: 0x7f0b00af
+			public const int AlertDialog_AppCompat_Light = 2131427503;
 			
-			// aapt resource value: 0x7f0900bc
-			public const int Animation_AppCompat_Dialog = 2131296444;
+			// aapt resource value: 0x7f0b00b0
+			public const int Animation_AppCompat_Dialog = 2131427504;
 			
-			// aapt resource value: 0x7f0900bd
-			public const int Animation_AppCompat_DropDownUp = 2131296445;
+			// aapt resource value: 0x7f0b00b1
+			public const int Animation_AppCompat_DropDownUp = 2131427505;
 			
-			// aapt resource value: 0x7f09001c
-			public const int Animation_Design_BottomSheetDialog = 2131296284;
+			// aapt resource value: 0x7f0b0170
+			public const int Animation_Design_BottomSheetDialog = 2131427696;
 			
-			// aapt resource value: 0x7f090174
-			public const int AppCompatDialogStyle = 2131296628;
+			// aapt resource value: 0x7f0b018b
+			public const int AppCompatDialogStyle = 2131427723;
 			
-			// aapt resource value: 0x7f0900be
-			public const int Base_AlertDialog_AppCompat = 2131296446;
+			// aapt resource value: 0x7f0b00b2
+			public const int Base_AlertDialog_AppCompat = 2131427506;
 			
-			// aapt resource value: 0x7f0900bf
-			public const int Base_AlertDialog_AppCompat_Light = 2131296447;
+			// aapt resource value: 0x7f0b00b3
+			public const int Base_AlertDialog_AppCompat_Light = 2131427507;
 			
-			// aapt resource value: 0x7f0900c0
-			public const int Base_Animation_AppCompat_Dialog = 2131296448;
+			// aapt resource value: 0x7f0b00b4
+			public const int Base_Animation_AppCompat_Dialog = 2131427508;
 			
-			// aapt resource value: 0x7f0900c1
-			public const int Base_Animation_AppCompat_DropDownUp = 2131296449;
+			// aapt resource value: 0x7f0b00b5
+			public const int Base_Animation_AppCompat_DropDownUp = 2131427509;
 			
-			// aapt resource value: 0x7f090018
-			public const int Base_CardView = 2131296280;
+			// aapt resource value: 0x7f0b000c
+			public const int Base_CardView = 2131427340;
 			
-			// aapt resource value: 0x7f0900c2
-			public const int Base_DialogWindowTitle_AppCompat = 2131296450;
+			// aapt resource value: 0x7f0b00b6
+			public const int Base_DialogWindowTitle_AppCompat = 2131427510;
 			
-			// aapt resource value: 0x7f0900c3
-			public const int Base_DialogWindowTitleBackground_AppCompat = 2131296451;
+			// aapt resource value: 0x7f0b00b7
+			public const int Base_DialogWindowTitleBackground_AppCompat = 2131427511;
 			
-			// aapt resource value: 0x7f09006a
-			public const int Base_TextAppearance_AppCompat = 2131296362;
+			// aapt resource value: 0x7f0b004e
+			public const int Base_TextAppearance_AppCompat = 2131427406;
 			
-			// aapt resource value: 0x7f09006b
-			public const int Base_TextAppearance_AppCompat_Body1 = 2131296363;
+			// aapt resource value: 0x7f0b004f
+			public const int Base_TextAppearance_AppCompat_Body1 = 2131427407;
 			
-			// aapt resource value: 0x7f09006c
-			public const int Base_TextAppearance_AppCompat_Body2 = 2131296364;
+			// aapt resource value: 0x7f0b0050
+			public const int Base_TextAppearance_AppCompat_Body2 = 2131427408;
 			
-			// aapt resource value: 0x7f090054
-			public const int Base_TextAppearance_AppCompat_Button = 2131296340;
+			// aapt resource value: 0x7f0b0036
+			public const int Base_TextAppearance_AppCompat_Button = 2131427382;
 			
-			// aapt resource value: 0x7f09006d
-			public const int Base_TextAppearance_AppCompat_Caption = 2131296365;
+			// aapt resource value: 0x7f0b0051
+			public const int Base_TextAppearance_AppCompat_Caption = 2131427409;
 			
-			// aapt resource value: 0x7f09006e
-			public const int Base_TextAppearance_AppCompat_Display1 = 2131296366;
+			// aapt resource value: 0x7f0b0052
+			public const int Base_TextAppearance_AppCompat_Display1 = 2131427410;
 			
-			// aapt resource value: 0x7f09006f
-			public const int Base_TextAppearance_AppCompat_Display2 = 2131296367;
+			// aapt resource value: 0x7f0b0053
+			public const int Base_TextAppearance_AppCompat_Display2 = 2131427411;
 			
-			// aapt resource value: 0x7f090070
-			public const int Base_TextAppearance_AppCompat_Display3 = 2131296368;
+			// aapt resource value: 0x7f0b0054
+			public const int Base_TextAppearance_AppCompat_Display3 = 2131427412;
 			
-			// aapt resource value: 0x7f090071
-			public const int Base_TextAppearance_AppCompat_Display4 = 2131296369;
+			// aapt resource value: 0x7f0b0055
+			public const int Base_TextAppearance_AppCompat_Display4 = 2131427413;
 			
-			// aapt resource value: 0x7f090072
-			public const int Base_TextAppearance_AppCompat_Headline = 2131296370;
+			// aapt resource value: 0x7f0b0056
+			public const int Base_TextAppearance_AppCompat_Headline = 2131427414;
 			
-			// aapt resource value: 0x7f09003f
-			public const int Base_TextAppearance_AppCompat_Inverse = 2131296319;
+			// aapt resource value: 0x7f0b001a
+			public const int Base_TextAppearance_AppCompat_Inverse = 2131427354;
 			
-			// aapt resource value: 0x7f090073
-			public const int Base_TextAppearance_AppCompat_Large = 2131296371;
+			// aapt resource value: 0x7f0b0057
+			public const int Base_TextAppearance_AppCompat_Large = 2131427415;
 			
-			// aapt resource value: 0x7f090040
-			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131296320;
+			// aapt resource value: 0x7f0b001b
+			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131427355;
 			
-			// aapt resource value: 0x7f090074
-			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131296372;
+			// aapt resource value: 0x7f0b0058
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131427416;
 			
-			// aapt resource value: 0x7f090075
-			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131296373;
+			// aapt resource value: 0x7f0b0059
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131427417;
 			
-			// aapt resource value: 0x7f090076
-			public const int Base_TextAppearance_AppCompat_Medium = 2131296374;
+			// aapt resource value: 0x7f0b005a
+			public const int Base_TextAppearance_AppCompat_Medium = 2131427418;
 			
-			// aapt resource value: 0x7f090041
-			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131296321;
+			// aapt resource value: 0x7f0b001c
+			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131427356;
 			
-			// aapt resource value: 0x7f090077
-			public const int Base_TextAppearance_AppCompat_Menu = 2131296375;
+			// aapt resource value: 0x7f0b005b
+			public const int Base_TextAppearance_AppCompat_Menu = 2131427419;
 			
-			// aapt resource value: 0x7f0900c4
-			public const int Base_TextAppearance_AppCompat_SearchResult = 2131296452;
+			// aapt resource value: 0x7f0b00b8
+			public const int Base_TextAppearance_AppCompat_SearchResult = 2131427512;
 			
-			// aapt resource value: 0x7f090078
-			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131296376;
+			// aapt resource value: 0x7f0b005c
+			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131427420;
 			
-			// aapt resource value: 0x7f090079
-			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131296377;
+			// aapt resource value: 0x7f0b005d
+			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131427421;
 			
-			// aapt resource value: 0x7f09007a
-			public const int Base_TextAppearance_AppCompat_Small = 2131296378;
+			// aapt resource value: 0x7f0b005e
+			public const int Base_TextAppearance_AppCompat_Small = 2131427422;
 			
-			// aapt resource value: 0x7f090042
-			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131296322;
+			// aapt resource value: 0x7f0b001d
+			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131427357;
 			
-			// aapt resource value: 0x7f09007b
-			public const int Base_TextAppearance_AppCompat_Subhead = 2131296379;
+			// aapt resource value: 0x7f0b005f
+			public const int Base_TextAppearance_AppCompat_Subhead = 2131427423;
 			
-			// aapt resource value: 0x7f090043
-			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131296323;
+			// aapt resource value: 0x7f0b001e
+			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131427358;
 			
-			// aapt resource value: 0x7f09007c
-			public const int Base_TextAppearance_AppCompat_Title = 2131296380;
+			// aapt resource value: 0x7f0b0060
+			public const int Base_TextAppearance_AppCompat_Title = 2131427424;
 			
-			// aapt resource value: 0x7f090044
-			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131296324;
+			// aapt resource value: 0x7f0b001f
+			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131427359;
 			
-			// aapt resource value: 0x7f0900b3
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131296435;
+			// aapt resource value: 0x7f0b00a3
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131427491;
 			
-			// aapt resource value: 0x7f09007d
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131296381;
+			// aapt resource value: 0x7f0b0061
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131427425;
 			
-			// aapt resource value: 0x7f09007e
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131296382;
+			// aapt resource value: 0x7f0b0062
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131427426;
 			
-			// aapt resource value: 0x7f09007f
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131296383;
+			// aapt resource value: 0x7f0b0063
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131427427;
 			
-			// aapt resource value: 0x7f090080
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131296384;
+			// aapt resource value: 0x7f0b0064
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131427428;
 			
-			// aapt resource value: 0x7f090081
-			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131296385;
+			// aapt resource value: 0x7f0b0065
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131427429;
 			
-			// aapt resource value: 0x7f090082
-			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131296386;
+			// aapt resource value: 0x7f0b0066
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131427430;
 			
-			// aapt resource value: 0x7f090083
-			public const int Base_TextAppearance_AppCompat_Widget_Button = 2131296387;
+			// aapt resource value: 0x7f0b0067
+			public const int Base_TextAppearance_AppCompat_Widget_Button = 2131427431;
 			
-			// aapt resource value: 0x7f0900b4
-			public const int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131296436;
+			// aapt resource value: 0x7f0b00aa
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131427498;
 			
-			// aapt resource value: 0x7f0900c5
-			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131296453;
+			// aapt resource value: 0x7f0b00ab
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Colored = 2131427499;
 			
-			// aapt resource value: 0x7f090084
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131296388;
+			// aapt resource value: 0x7f0b00a4
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131427492;
 			
-			// aapt resource value: 0x7f090085
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131296389;
+			// aapt resource value: 0x7f0b00b9
+			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131427513;
 			
-			// aapt resource value: 0x7f090086
-			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131296390;
+			// aapt resource value: 0x7f0b0068
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131427432;
 			
-			// aapt resource value: 0x7f090087
-			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131296391;
+			// aapt resource value: 0x7f0b0069
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131427433;
 			
-			// aapt resource value: 0x7f0900c6
-			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131296454;
+			// aapt resource value: 0x7f0b006a
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131427434;
 			
-			// aapt resource value: 0x7f090088
-			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131296392;
+			// aapt resource value: 0x7f0b006b
+			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131427435;
 			
-			// aapt resource value: 0x7f090089
-			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131296393;
+			// aapt resource value: 0x7f0b006c
+			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131427436;
 			
-			// aapt resource value: 0x7f09008a
-			public const int Base_Theme_AppCompat = 2131296394;
+			// aapt resource value: 0x7f0b00ba
+			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131427514;
 			
-			// aapt resource value: 0x7f0900c7
-			public const int Base_Theme_AppCompat_CompactMenu = 2131296455;
+			// aapt resource value: 0x7f0b006d
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131427437;
 			
-			// aapt resource value: 0x7f090045
-			public const int Base_Theme_AppCompat_Dialog = 2131296325;
+			// aapt resource value: 0x7f0b006e
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131427438;
 			
-			// aapt resource value: 0x7f0900c8
-			public const int Base_Theme_AppCompat_Dialog_Alert = 2131296456;
+			// aapt resource value: 0x7f0b006f
+			public const int Base_Theme_AppCompat = 2131427439;
 			
-			// aapt resource value: 0x7f0900c9
-			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131296457;
+			// aapt resource value: 0x7f0b00bb
+			public const int Base_Theme_AppCompat_CompactMenu = 2131427515;
 			
-			// aapt resource value: 0x7f0900ca
-			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131296458;
+			// aapt resource value: 0x7f0b0020
+			public const int Base_Theme_AppCompat_Dialog = 2131427360;
 			
-			// aapt resource value: 0x7f090035
-			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131296309;
+			// aapt resource value: 0x7f0b0021
+			public const int Base_Theme_AppCompat_Dialog_Alert = 2131427361;
 			
-			// aapt resource value: 0x7f09008b
-			public const int Base_Theme_AppCompat_Light = 2131296395;
+			// aapt resource value: 0x7f0b00bc
+			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131427516;
 			
-			// aapt resource value: 0x7f0900cb
-			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131296459;
+			// aapt resource value: 0x7f0b0022
+			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131427362;
 			
-			// aapt resource value: 0x7f090046
-			public const int Base_Theme_AppCompat_Light_Dialog = 2131296326;
+			// aapt resource value: 0x7f0b0010
+			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131427344;
 			
-			// aapt resource value: 0x7f0900cc
-			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131296460;
+			// aapt resource value: 0x7f0b0070
+			public const int Base_Theme_AppCompat_Light = 2131427440;
 			
-			// aapt resource value: 0x7f0900cd
-			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131296461;
+			// aapt resource value: 0x7f0b00bd
+			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131427517;
 			
-			// aapt resource value: 0x7f0900ce
-			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131296462;
+			// aapt resource value: 0x7f0b0023
+			public const int Base_Theme_AppCompat_Light_Dialog = 2131427363;
 			
-			// aapt resource value: 0x7f090036
-			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131296310;
+			// aapt resource value: 0x7f0b0024
+			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131427364;
 			
-			// aapt resource value: 0x7f0900cf
-			public const int Base_ThemeOverlay_AppCompat = 2131296463;
+			// aapt resource value: 0x7f0b00be
+			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131427518;
 			
-			// aapt resource value: 0x7f0900d0
-			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131296464;
+			// aapt resource value: 0x7f0b0025
+			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131427365;
 			
-			// aapt resource value: 0x7f0900d1
-			public const int Base_ThemeOverlay_AppCompat_Dark = 2131296465;
+			// aapt resource value: 0x7f0b0011
+			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131427345;
 			
-			// aapt resource value: 0x7f0900d2
-			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131296466;
+			// aapt resource value: 0x7f0b00bf
+			public const int Base_ThemeOverlay_AppCompat = 2131427519;
 			
-			// aapt resource value: 0x7f0900d3
-			public const int Base_ThemeOverlay_AppCompat_Light = 2131296467;
+			// aapt resource value: 0x7f0b00c0
+			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131427520;
 			
-			// aapt resource value: 0x7f090047
-			public const int Base_V11_Theme_AppCompat_Dialog = 2131296327;
+			// aapt resource value: 0x7f0b00c1
+			public const int Base_ThemeOverlay_AppCompat_Dark = 2131427521;
 			
-			// aapt resource value: 0x7f090048
-			public const int Base_V11_Theme_AppCompat_Light_Dialog = 2131296328;
+			// aapt resource value: 0x7f0b00c2
+			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131427522;
 			
-			// aapt resource value: 0x7f090050
-			public const int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131296336;
+			// aapt resource value: 0x7f0b0026
+			public const int Base_ThemeOverlay_AppCompat_Dialog = 2131427366;
 			
-			// aapt resource value: 0x7f090051
-			public const int Base_V12_Widget_AppCompat_EditText = 2131296337;
+			// aapt resource value: 0x7f0b0027
+			public const int Base_ThemeOverlay_AppCompat_Dialog_Alert = 2131427367;
 			
-			// aapt resource value: 0x7f09008c
-			public const int Base_V21_Theme_AppCompat = 2131296396;
+			// aapt resource value: 0x7f0b00c3
+			public const int Base_ThemeOverlay_AppCompat_Light = 2131427523;
 			
-			// aapt resource value: 0x7f09008d
-			public const int Base_V21_Theme_AppCompat_Dialog = 2131296397;
+			// aapt resource value: 0x7f0b0028
+			public const int Base_V11_Theme_AppCompat_Dialog = 2131427368;
 			
-			// aapt resource value: 0x7f09008e
-			public const int Base_V21_Theme_AppCompat_Light = 2131296398;
+			// aapt resource value: 0x7f0b0029
+			public const int Base_V11_Theme_AppCompat_Light_Dialog = 2131427369;
 			
-			// aapt resource value: 0x7f09008f
-			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131296399;
+			// aapt resource value: 0x7f0b002a
+			public const int Base_V11_ThemeOverlay_AppCompat_Dialog = 2131427370;
 			
-			// aapt resource value: 0x7f0900b1
-			public const int Base_V22_Theme_AppCompat = 2131296433;
+			// aapt resource value: 0x7f0b0032
+			public const int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131427378;
 			
-			// aapt resource value: 0x7f0900b2
-			public const int Base_V22_Theme_AppCompat_Light = 2131296434;
+			// aapt resource value: 0x7f0b0033
+			public const int Base_V12_Widget_AppCompat_EditText = 2131427379;
 			
-			// aapt resource value: 0x7f0900b5
-			public const int Base_V23_Theme_AppCompat = 2131296437;
+			// aapt resource value: 0x7f0b0071
+			public const int Base_V21_Theme_AppCompat = 2131427441;
 			
-			// aapt resource value: 0x7f0900b6
-			public const int Base_V23_Theme_AppCompat_Light = 2131296438;
+			// aapt resource value: 0x7f0b0072
+			public const int Base_V21_Theme_AppCompat_Dialog = 2131427442;
 			
-			// aapt resource value: 0x7f0900d4
-			public const int Base_V7_Theme_AppCompat = 2131296468;
+			// aapt resource value: 0x7f0b0073
+			public const int Base_V21_Theme_AppCompat_Light = 2131427443;
 			
-			// aapt resource value: 0x7f0900d5
-			public const int Base_V7_Theme_AppCompat_Dialog = 2131296469;
+			// aapt resource value: 0x7f0b0074
+			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131427444;
 			
-			// aapt resource value: 0x7f0900d6
-			public const int Base_V7_Theme_AppCompat_Light = 2131296470;
+			// aapt resource value: 0x7f0b0075
+			public const int Base_V21_ThemeOverlay_AppCompat_Dialog = 2131427445;
 			
-			// aapt resource value: 0x7f0900d7
-			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131296471;
+			// aapt resource value: 0x7f0b00a1
+			public const int Base_V22_Theme_AppCompat = 2131427489;
 			
-			// aapt resource value: 0x7f0900d8
-			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131296472;
+			// aapt resource value: 0x7f0b00a2
+			public const int Base_V22_Theme_AppCompat_Light = 2131427490;
 			
-			// aapt resource value: 0x7f0900d9
-			public const int Base_V7_Widget_AppCompat_EditText = 2131296473;
+			// aapt resource value: 0x7f0b00a5
+			public const int Base_V23_Theme_AppCompat = 2131427493;
 			
-			// aapt resource value: 0x7f0900da
-			public const int Base_Widget_AppCompat_ActionBar = 2131296474;
+			// aapt resource value: 0x7f0b00a6
+			public const int Base_V23_Theme_AppCompat_Light = 2131427494;
 			
-			// aapt resource value: 0x7f0900db
-			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131296475;
+			// aapt resource value: 0x7f0b00c4
+			public const int Base_V7_Theme_AppCompat = 2131427524;
 			
-			// aapt resource value: 0x7f0900dc
-			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131296476;
+			// aapt resource value: 0x7f0b00c5
+			public const int Base_V7_Theme_AppCompat_Dialog = 2131427525;
 			
-			// aapt resource value: 0x7f090090
-			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131296400;
+			// aapt resource value: 0x7f0b00c6
+			public const int Base_V7_Theme_AppCompat_Light = 2131427526;
 			
-			// aapt resource value: 0x7f090091
-			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131296401;
+			// aapt resource value: 0x7f0b00c7
+			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131427527;
 			
-			// aapt resource value: 0x7f090092
-			public const int Base_Widget_AppCompat_ActionButton = 2131296402;
+			// aapt resource value: 0x7f0b00c8
+			public const int Base_V7_ThemeOverlay_AppCompat_Dialog = 2131427528;
 			
-			// aapt resource value: 0x7f090093
-			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131296403;
+			// aapt resource value: 0x7f0b00c9
+			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131427529;
 			
-			// aapt resource value: 0x7f090094
-			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131296404;
+			// aapt resource value: 0x7f0b00ca
+			public const int Base_V7_Widget_AppCompat_EditText = 2131427530;
 			
-			// aapt resource value: 0x7f0900dd
-			public const int Base_Widget_AppCompat_ActionMode = 2131296477;
+			// aapt resource value: 0x7f0b00cb
+			public const int Base_Widget_AppCompat_ActionBar = 2131427531;
 			
-			// aapt resource value: 0x7f0900de
-			public const int Base_Widget_AppCompat_ActivityChooserView = 2131296478;
+			// aapt resource value: 0x7f0b00cc
+			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131427532;
 			
-			// aapt resource value: 0x7f090052
-			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131296338;
+			// aapt resource value: 0x7f0b00cd
+			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131427533;
 			
-			// aapt resource value: 0x7f090095
-			public const int Base_Widget_AppCompat_Button = 2131296405;
+			// aapt resource value: 0x7f0b0076
+			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131427446;
 			
-			// aapt resource value: 0x7f090096
-			public const int Base_Widget_AppCompat_Button_Borderless = 2131296406;
+			// aapt resource value: 0x7f0b0077
+			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131427447;
 			
-			// aapt resource value: 0x7f090097
-			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131296407;
+			// aapt resource value: 0x7f0b0078
+			public const int Base_Widget_AppCompat_ActionButton = 2131427448;
 			
-			// aapt resource value: 0x7f0900df
-			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131296479;
+			// aapt resource value: 0x7f0b0079
+			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131427449;
 			
-			// aapt resource value: 0x7f0900b7
-			public const int Base_Widget_AppCompat_Button_Colored = 2131296439;
+			// aapt resource value: 0x7f0b007a
+			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131427450;
 			
-			// aapt resource value: 0x7f090098
-			public const int Base_Widget_AppCompat_Button_Small = 2131296408;
+			// aapt resource value: 0x7f0b00ce
+			public const int Base_Widget_AppCompat_ActionMode = 2131427534;
 			
-			// aapt resource value: 0x7f090099
-			public const int Base_Widget_AppCompat_ButtonBar = 2131296409;
+			// aapt resource value: 0x7f0b00cf
+			public const int Base_Widget_AppCompat_ActivityChooserView = 2131427535;
 			
-			// aapt resource value: 0x7f0900e0
-			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131296480;
+			// aapt resource value: 0x7f0b0034
+			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131427380;
 			
-			// aapt resource value: 0x7f09009a
-			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131296410;
+			// aapt resource value: 0x7f0b007b
+			public const int Base_Widget_AppCompat_Button = 2131427451;
 			
-			// aapt resource value: 0x7f09009b
-			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131296411;
+			// aapt resource value: 0x7f0b007c
+			public const int Base_Widget_AppCompat_Button_Borderless = 2131427452;
 			
-			// aapt resource value: 0x7f0900e1
-			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131296481;
+			// aapt resource value: 0x7f0b007d
+			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131427453;
 			
-			// aapt resource value: 0x7f090034
-			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131296308;
+			// aapt resource value: 0x7f0b00d0
+			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131427536;
 			
-			// aapt resource value: 0x7f0900e2
-			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131296482;
+			// aapt resource value: 0x7f0b00a7
+			public const int Base_Widget_AppCompat_Button_Colored = 2131427495;
 			
-			// aapt resource value: 0x7f09009c
-			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131296412;
+			// aapt resource value: 0x7f0b007e
+			public const int Base_Widget_AppCompat_Button_Small = 2131427454;
 			
-			// aapt resource value: 0x7f090053
-			public const int Base_Widget_AppCompat_EditText = 2131296339;
+			// aapt resource value: 0x7f0b007f
+			public const int Base_Widget_AppCompat_ButtonBar = 2131427455;
 			
-			// aapt resource value: 0x7f09009d
-			public const int Base_Widget_AppCompat_ImageButton = 2131296413;
+			// aapt resource value: 0x7f0b00d1
+			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131427537;
 			
-			// aapt resource value: 0x7f0900e3
-			public const int Base_Widget_AppCompat_Light_ActionBar = 2131296483;
+			// aapt resource value: 0x7f0b0080
+			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131427456;
 			
-			// aapt resource value: 0x7f0900e4
-			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131296484;
+			// aapt resource value: 0x7f0b0081
+			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131427457;
 			
-			// aapt resource value: 0x7f0900e5
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131296485;
+			// aapt resource value: 0x7f0b00d2
+			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131427538;
 			
-			// aapt resource value: 0x7f09009e
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131296414;
+			// aapt resource value: 0x7f0b000f
+			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131427343;
 			
-			// aapt resource value: 0x7f09009f
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131296415;
+			// aapt resource value: 0x7f0b00d3
+			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131427539;
 			
-			// aapt resource value: 0x7f0900a0
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131296416;
+			// aapt resource value: 0x7f0b0082
+			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131427458;
 			
-			// aapt resource value: 0x7f0900a1
-			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131296417;
+			// aapt resource value: 0x7f0b0035
+			public const int Base_Widget_AppCompat_EditText = 2131427381;
 			
-			// aapt resource value: 0x7f0900a2
-			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131296418;
+			// aapt resource value: 0x7f0b0083
+			public const int Base_Widget_AppCompat_ImageButton = 2131427459;
 			
-			// aapt resource value: 0x7f0900a3
-			public const int Base_Widget_AppCompat_ListPopupWindow = 2131296419;
+			// aapt resource value: 0x7f0b00d4
+			public const int Base_Widget_AppCompat_Light_ActionBar = 2131427540;
 			
-			// aapt resource value: 0x7f0900a4
-			public const int Base_Widget_AppCompat_ListView = 2131296420;
+			// aapt resource value: 0x7f0b00d5
+			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131427541;
 			
-			// aapt resource value: 0x7f0900a5
-			public const int Base_Widget_AppCompat_ListView_DropDown = 2131296421;
+			// aapt resource value: 0x7f0b00d6
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131427542;
 			
-			// aapt resource value: 0x7f0900a6
-			public const int Base_Widget_AppCompat_ListView_Menu = 2131296422;
+			// aapt resource value: 0x7f0b0084
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131427460;
 			
-			// aapt resource value: 0x7f0900a7
-			public const int Base_Widget_AppCompat_PopupMenu = 2131296423;
+			// aapt resource value: 0x7f0b0085
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131427461;
 			
-			// aapt resource value: 0x7f0900a8
-			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131296424;
+			// aapt resource value: 0x7f0b0086
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131427462;
 			
-			// aapt resource value: 0x7f0900e6
-			public const int Base_Widget_AppCompat_PopupWindow = 2131296486;
+			// aapt resource value: 0x7f0b0087
+			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131427463;
 			
-			// aapt resource value: 0x7f090049
-			public const int Base_Widget_AppCompat_ProgressBar = 2131296329;
+			// aapt resource value: 0x7f0b0088
+			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131427464;
 			
-			// aapt resource value: 0x7f09004a
-			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131296330;
+			// aapt resource value: 0x7f0b00d7
+			public const int Base_Widget_AppCompat_ListMenuView = 2131427543;
 			
-			// aapt resource value: 0x7f0900a9
-			public const int Base_Widget_AppCompat_RatingBar = 2131296425;
+			// aapt resource value: 0x7f0b0089
+			public const int Base_Widget_AppCompat_ListPopupWindow = 2131427465;
 			
-			// aapt resource value: 0x7f0900b8
-			public const int Base_Widget_AppCompat_RatingBar_Indicator = 2131296440;
+			// aapt resource value: 0x7f0b008a
+			public const int Base_Widget_AppCompat_ListView = 2131427466;
 			
-			// aapt resource value: 0x7f0900b9
-			public const int Base_Widget_AppCompat_RatingBar_Small = 2131296441;
+			// aapt resource value: 0x7f0b008b
+			public const int Base_Widget_AppCompat_ListView_DropDown = 2131427467;
 			
-			// aapt resource value: 0x7f0900e7
-			public const int Base_Widget_AppCompat_SearchView = 2131296487;
+			// aapt resource value: 0x7f0b008c
+			public const int Base_Widget_AppCompat_ListView_Menu = 2131427468;
 			
-			// aapt resource value: 0x7f0900e8
-			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131296488;
+			// aapt resource value: 0x7f0b008d
+			public const int Base_Widget_AppCompat_PopupMenu = 2131427469;
 			
-			// aapt resource value: 0x7f0900aa
-			public const int Base_Widget_AppCompat_SeekBar = 2131296426;
+			// aapt resource value: 0x7f0b008e
+			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131427470;
 			
-			// aapt resource value: 0x7f0900ab
-			public const int Base_Widget_AppCompat_Spinner = 2131296427;
+			// aapt resource value: 0x7f0b00d8
+			public const int Base_Widget_AppCompat_PopupWindow = 2131427544;
 			
-			// aapt resource value: 0x7f090037
-			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131296311;
+			// aapt resource value: 0x7f0b002b
+			public const int Base_Widget_AppCompat_ProgressBar = 2131427371;
 			
-			// aapt resource value: 0x7f0900ac
-			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131296428;
+			// aapt resource value: 0x7f0b002c
+			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131427372;
 			
-			// aapt resource value: 0x7f0900e9
-			public const int Base_Widget_AppCompat_Toolbar = 2131296489;
+			// aapt resource value: 0x7f0b008f
+			public const int Base_Widget_AppCompat_RatingBar = 2131427471;
 			
-			// aapt resource value: 0x7f0900ad
-			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131296429;
+			// aapt resource value: 0x7f0b00a8
+			public const int Base_Widget_AppCompat_RatingBar_Indicator = 2131427496;
 			
-			// aapt resource value: 0x7f09001d
-			public const int Base_Widget_Design_TabLayout = 2131296285;
+			// aapt resource value: 0x7f0b00a9
+			public const int Base_Widget_AppCompat_RatingBar_Small = 2131427497;
 			
-			// aapt resource value: 0x7f090017
-			public const int CardView = 2131296279;
+			// aapt resource value: 0x7f0b00d9
+			public const int Base_Widget_AppCompat_SearchView = 2131427545;
 			
-			// aapt resource value: 0x7f090019
-			public const int CardView_Dark = 2131296281;
+			// aapt resource value: 0x7f0b00da
+			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131427546;
 			
-			// aapt resource value: 0x7f09001a
-			public const int CardView_Light = 2131296282;
+			// aapt resource value: 0x7f0b0090
+			public const int Base_Widget_AppCompat_SeekBar = 2131427472;
 			
-			// aapt resource value: 0x7f090172
-			public const int MyTheme = 2131296626;
+			// aapt resource value: 0x7f0b00db
+			public const int Base_Widget_AppCompat_SeekBar_Discrete = 2131427547;
 			
-			// aapt resource value: 0x7f090173
-			public const int MyTheme_Base = 2131296627;
+			// aapt resource value: 0x7f0b0091
+			public const int Base_Widget_AppCompat_Spinner = 2131427473;
 			
-			// aapt resource value: 0x7f09004b
-			public const int Platform_AppCompat = 2131296331;
+			// aapt resource value: 0x7f0b0012
+			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131427346;
 			
-			// aapt resource value: 0x7f09004c
-			public const int Platform_AppCompat_Light = 2131296332;
+			// aapt resource value: 0x7f0b0092
+			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131427474;
 			
-			// aapt resource value: 0x7f0900ae
-			public const int Platform_ThemeOverlay_AppCompat = 2131296430;
+			// aapt resource value: 0x7f0b00dc
+			public const int Base_Widget_AppCompat_Toolbar = 2131427548;
 			
-			// aapt resource value: 0x7f0900af
-			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131296431;
+			// aapt resource value: 0x7f0b0093
+			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131427475;
 			
-			// aapt resource value: 0x7f0900b0
-			public const int Platform_ThemeOverlay_AppCompat_Light = 2131296432;
+			// aapt resource value: 0x7f0b0171
+			public const int Base_Widget_Design_AppBarLayout = 2131427697;
 			
-			// aapt resource value: 0x7f09004d
-			public const int Platform_V11_AppCompat = 2131296333;
+			// aapt resource value: 0x7f0b0172
+			public const int Base_Widget_Design_TabLayout = 2131427698;
 			
-			// aapt resource value: 0x7f09004e
-			public const int Platform_V11_AppCompat_Light = 2131296334;
+			// aapt resource value: 0x7f0b000b
+			public const int CardView = 2131427339;
 			
-			// aapt resource value: 0x7f090055
-			public const int Platform_V14_AppCompat = 2131296341;
+			// aapt resource value: 0x7f0b000d
+			public const int CardView_Dark = 2131427341;
 			
-			// aapt resource value: 0x7f090056
-			public const int Platform_V14_AppCompat_Light = 2131296342;
+			// aapt resource value: 0x7f0b000e
+			public const int CardView_Light = 2131427342;
 			
-			// aapt resource value: 0x7f09004f
-			public const int Platform_Widget_AppCompat_Spinner = 2131296335;
+			// aapt resource value: 0x7f0b0189
+			public const int MyTheme = 2131427721;
 			
-			// aapt resource value: 0x7f09005c
-			public const int RtlOverlay_DialogWindowTitle_AppCompat = 2131296348;
+			// aapt resource value: 0x7f0b018a
+			public const int MyTheme_Base = 2131427722;
 			
-			// aapt resource value: 0x7f09005d
-			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131296349;
+			// aapt resource value: 0x7f0b002d
+			public const int Platform_AppCompat = 2131427373;
 			
-			// aapt resource value: 0x7f09005e
-			public const int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131296350;
+			// aapt resource value: 0x7f0b002e
+			public const int Platform_AppCompat_Light = 2131427374;
 			
-			// aapt resource value: 0x7f09005f
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131296351;
+			// aapt resource value: 0x7f0b0094
+			public const int Platform_ThemeOverlay_AppCompat = 2131427476;
 			
-			// aapt resource value: 0x7f090060
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131296352;
+			// aapt resource value: 0x7f0b0095
+			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131427477;
 			
-			// aapt resource value: 0x7f090061
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131296353;
+			// aapt resource value: 0x7f0b0096
+			public const int Platform_ThemeOverlay_AppCompat_Light = 2131427478;
 			
-			// aapt resource value: 0x7f090062
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131296354;
+			// aapt resource value: 0x7f0b002f
+			public const int Platform_V11_AppCompat = 2131427375;
 			
-			// aapt resource value: 0x7f090063
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131296355;
+			// aapt resource value: 0x7f0b0030
+			public const int Platform_V11_AppCompat_Light = 2131427376;
 			
-			// aapt resource value: 0x7f090064
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131296356;
+			// aapt resource value: 0x7f0b0037
+			public const int Platform_V14_AppCompat = 2131427383;
 			
-			// aapt resource value: 0x7f090065
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131296357;
+			// aapt resource value: 0x7f0b0038
+			public const int Platform_V14_AppCompat_Light = 2131427384;
 			
-			// aapt resource value: 0x7f090066
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131296358;
+			// aapt resource value: 0x7f0b0097
+			public const int Platform_V21_AppCompat = 2131427479;
 			
-			// aapt resource value: 0x7f090067
-			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131296359;
+			// aapt resource value: 0x7f0b0098
+			public const int Platform_V21_AppCompat_Light = 2131427480;
 			
-			// aapt resource value: 0x7f090068
-			public const int RtlUnderlay_Widget_AppCompat_ActionButton = 2131296360;
+			// aapt resource value: 0x7f0b00ac
+			public const int Platform_V25_AppCompat = 2131427500;
 			
-			// aapt resource value: 0x7f090069
-			public const int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131296361;
+			// aapt resource value: 0x7f0b00ad
+			public const int Platform_V25_AppCompat_Light = 2131427501;
 			
-			// aapt resource value: 0x7f0900ea
-			public const int TextAppearance_AppCompat = 2131296490;
+			// aapt resource value: 0x7f0b0031
+			public const int Platform_Widget_AppCompat_Spinner = 2131427377;
 			
-			// aapt resource value: 0x7f0900eb
-			public const int TextAppearance_AppCompat_Body1 = 2131296491;
+			// aapt resource value: 0x7f0b0040
+			public const int RtlOverlay_DialogWindowTitle_AppCompat = 2131427392;
 			
-			// aapt resource value: 0x7f0900ec
-			public const int TextAppearance_AppCompat_Body2 = 2131296492;
+			// aapt resource value: 0x7f0b0041
+			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131427393;
 			
-			// aapt resource value: 0x7f0900ed
-			public const int TextAppearance_AppCompat_Button = 2131296493;
+			// aapt resource value: 0x7f0b0042
+			public const int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131427394;
 			
-			// aapt resource value: 0x7f0900ee
-			public const int TextAppearance_AppCompat_Caption = 2131296494;
+			// aapt resource value: 0x7f0b0043
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131427395;
 			
-			// aapt resource value: 0x7f0900ef
-			public const int TextAppearance_AppCompat_Display1 = 2131296495;
+			// aapt resource value: 0x7f0b0044
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131427396;
 			
-			// aapt resource value: 0x7f0900f0
-			public const int TextAppearance_AppCompat_Display2 = 2131296496;
+			// aapt resource value: 0x7f0b0045
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131427397;
 			
-			// aapt resource value: 0x7f0900f1
-			public const int TextAppearance_AppCompat_Display3 = 2131296497;
+			// aapt resource value: 0x7f0b0046
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131427398;
 			
-			// aapt resource value: 0x7f0900f2
-			public const int TextAppearance_AppCompat_Display4 = 2131296498;
+			// aapt resource value: 0x7f0b0047
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131427399;
 			
-			// aapt resource value: 0x7f0900f3
-			public const int TextAppearance_AppCompat_Headline = 2131296499;
+			// aapt resource value: 0x7f0b0048
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131427400;
 			
-			// aapt resource value: 0x7f0900f4
-			public const int TextAppearance_AppCompat_Inverse = 2131296500;
+			// aapt resource value: 0x7f0b0049
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131427401;
 			
-			// aapt resource value: 0x7f0900f5
-			public const int TextAppearance_AppCompat_Large = 2131296501;
+			// aapt resource value: 0x7f0b004a
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131427402;
 			
-			// aapt resource value: 0x7f0900f6
-			public const int TextAppearance_AppCompat_Large_Inverse = 2131296502;
+			// aapt resource value: 0x7f0b004b
+			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131427403;
 			
-			// aapt resource value: 0x7f0900f7
-			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131296503;
+			// aapt resource value: 0x7f0b004c
+			public const int RtlUnderlay_Widget_AppCompat_ActionButton = 2131427404;
 			
-			// aapt resource value: 0x7f0900f8
-			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131296504;
+			// aapt resource value: 0x7f0b004d
+			public const int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131427405;
 			
-			// aapt resource value: 0x7f0900f9
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131296505;
+			// aapt resource value: 0x7f0b00dd
+			public const int TextAppearance_AppCompat = 2131427549;
 			
-			// aapt resource value: 0x7f0900fa
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131296506;
+			// aapt resource value: 0x7f0b00de
+			public const int TextAppearance_AppCompat_Body1 = 2131427550;
 			
-			// aapt resource value: 0x7f0900fb
-			public const int TextAppearance_AppCompat_Medium = 2131296507;
+			// aapt resource value: 0x7f0b00df
+			public const int TextAppearance_AppCompat_Body2 = 2131427551;
 			
-			// aapt resource value: 0x7f0900fc
-			public const int TextAppearance_AppCompat_Medium_Inverse = 2131296508;
+			// aapt resource value: 0x7f0b00e0
+			public const int TextAppearance_AppCompat_Button = 2131427552;
 			
-			// aapt resource value: 0x7f0900fd
-			public const int TextAppearance_AppCompat_Menu = 2131296509;
+			// aapt resource value: 0x7f0b00e1
+			public const int TextAppearance_AppCompat_Caption = 2131427553;
 			
-			// aapt resource value: 0x7f0900fe
-			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131296510;
+			// aapt resource value: 0x7f0b00e2
+			public const int TextAppearance_AppCompat_Display1 = 2131427554;
 			
-			// aapt resource value: 0x7f0900ff
-			public const int TextAppearance_AppCompat_SearchResult_Title = 2131296511;
+			// aapt resource value: 0x7f0b00e3
+			public const int TextAppearance_AppCompat_Display2 = 2131427555;
 			
-			// aapt resource value: 0x7f090100
-			public const int TextAppearance_AppCompat_Small = 2131296512;
+			// aapt resource value: 0x7f0b00e4
+			public const int TextAppearance_AppCompat_Display3 = 2131427556;
 			
-			// aapt resource value: 0x7f090101
-			public const int TextAppearance_AppCompat_Small_Inverse = 2131296513;
+			// aapt resource value: 0x7f0b00e5
+			public const int TextAppearance_AppCompat_Display4 = 2131427557;
 			
-			// aapt resource value: 0x7f090102
-			public const int TextAppearance_AppCompat_Subhead = 2131296514;
+			// aapt resource value: 0x7f0b00e6
+			public const int TextAppearance_AppCompat_Headline = 2131427558;
 			
-			// aapt resource value: 0x7f090103
-			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131296515;
+			// aapt resource value: 0x7f0b00e7
+			public const int TextAppearance_AppCompat_Inverse = 2131427559;
 			
-			// aapt resource value: 0x7f090104
-			public const int TextAppearance_AppCompat_Title = 2131296516;
+			// aapt resource value: 0x7f0b00e8
+			public const int TextAppearance_AppCompat_Large = 2131427560;
 			
-			// aapt resource value: 0x7f090105
-			public const int TextAppearance_AppCompat_Title_Inverse = 2131296517;
+			// aapt resource value: 0x7f0b00e9
+			public const int TextAppearance_AppCompat_Large_Inverse = 2131427561;
 			
-			// aapt resource value: 0x7f090106
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131296518;
+			// aapt resource value: 0x7f0b00ea
+			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131427562;
 			
-			// aapt resource value: 0x7f090107
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131296519;
+			// aapt resource value: 0x7f0b00eb
+			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131427563;
 			
-			// aapt resource value: 0x7f090108
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131296520;
+			// aapt resource value: 0x7f0b00ec
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131427564;
 			
-			// aapt resource value: 0x7f090109
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131296521;
+			// aapt resource value: 0x7f0b00ed
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131427565;
 			
-			// aapt resource value: 0x7f09010a
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131296522;
+			// aapt resource value: 0x7f0b00ee
+			public const int TextAppearance_AppCompat_Medium = 2131427566;
 			
-			// aapt resource value: 0x7f09010b
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131296523;
+			// aapt resource value: 0x7f0b00ef
+			public const int TextAppearance_AppCompat_Medium_Inverse = 2131427567;
 			
-			// aapt resource value: 0x7f09010c
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131296524;
+			// aapt resource value: 0x7f0b00f0
+			public const int TextAppearance_AppCompat_Menu = 2131427568;
 			
-			// aapt resource value: 0x7f09010d
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131296525;
+			// aapt resource value: 0x7f0b0039
+			public const int TextAppearance_AppCompat_Notification = 2131427385;
 			
-			// aapt resource value: 0x7f09010e
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131296526;
+			// aapt resource value: 0x7f0b0099
+			public const int TextAppearance_AppCompat_Notification_Info = 2131427481;
 			
-			// aapt resource value: 0x7f09010f
-			public const int TextAppearance_AppCompat_Widget_Button = 2131296527;
+			// aapt resource value: 0x7f0b009a
+			public const int TextAppearance_AppCompat_Notification_Info_Media = 2131427482;
 			
-			// aapt resource value: 0x7f090110
-			public const int TextAppearance_AppCompat_Widget_Button_Inverse = 2131296528;
+			// aapt resource value: 0x7f0b00f1
+			public const int TextAppearance_AppCompat_Notification_Line2 = 2131427569;
 			
-			// aapt resource value: 0x7f090111
-			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131296529;
+			// aapt resource value: 0x7f0b00f2
+			public const int TextAppearance_AppCompat_Notification_Line2_Media = 2131427570;
 			
-			// aapt resource value: 0x7f090112
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131296530;
+			// aapt resource value: 0x7f0b009b
+			public const int TextAppearance_AppCompat_Notification_Media = 2131427483;
 			
-			// aapt resource value: 0x7f090113
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131296531;
+			// aapt resource value: 0x7f0b009c
+			public const int TextAppearance_AppCompat_Notification_Time = 2131427484;
 			
-			// aapt resource value: 0x7f090114
-			public const int TextAppearance_AppCompat_Widget_Switch = 2131296532;
+			// aapt resource value: 0x7f0b009d
+			public const int TextAppearance_AppCompat_Notification_Time_Media = 2131427485;
 			
-			// aapt resource value: 0x7f090115
-			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131296533;
+			// aapt resource value: 0x7f0b003a
+			public const int TextAppearance_AppCompat_Notification_Title = 2131427386;
 			
-			// aapt resource value: 0x7f09001e
-			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131296286;
+			// aapt resource value: 0x7f0b009e
+			public const int TextAppearance_AppCompat_Notification_Title_Media = 2131427486;
 			
-			// aapt resource value: 0x7f09001f
-			public const int TextAppearance_Design_Counter = 2131296287;
+			// aapt resource value: 0x7f0b00f3
+			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131427571;
 			
-			// aapt resource value: 0x7f090020
-			public const int TextAppearance_Design_Counter_Overflow = 2131296288;
+			// aapt resource value: 0x7f0b00f4
+			public const int TextAppearance_AppCompat_SearchResult_Title = 2131427572;
 			
-			// aapt resource value: 0x7f090021
-			public const int TextAppearance_Design_Error = 2131296289;
+			// aapt resource value: 0x7f0b00f5
+			public const int TextAppearance_AppCompat_Small = 2131427573;
 			
-			// aapt resource value: 0x7f090022
-			public const int TextAppearance_Design_Hint = 2131296290;
+			// aapt resource value: 0x7f0b00f6
+			public const int TextAppearance_AppCompat_Small_Inverse = 2131427574;
 			
-			// aapt resource value: 0x7f090023
-			public const int TextAppearance_Design_Snackbar_Message = 2131296291;
+			// aapt resource value: 0x7f0b00f7
+			public const int TextAppearance_AppCompat_Subhead = 2131427575;
 			
-			// aapt resource value: 0x7f090024
-			public const int TextAppearance_Design_Tab = 2131296292;
+			// aapt resource value: 0x7f0b00f8
+			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131427576;
 			
-			// aapt resource value: 0x7f090057
-			public const int TextAppearance_StatusBar_EventContent = 2131296343;
+			// aapt resource value: 0x7f0b00f9
+			public const int TextAppearance_AppCompat_Title = 2131427577;
 			
-			// aapt resource value: 0x7f090058
-			public const int TextAppearance_StatusBar_EventContent_Info = 2131296344;
+			// aapt resource value: 0x7f0b00fa
+			public const int TextAppearance_AppCompat_Title_Inverse = 2131427578;
 			
-			// aapt resource value: 0x7f090059
-			public const int TextAppearance_StatusBar_EventContent_Line2 = 2131296345;
+			// aapt resource value: 0x7f0b00fb
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131427579;
 			
-			// aapt resource value: 0x7f09005a
-			public const int TextAppearance_StatusBar_EventContent_Time = 2131296346;
+			// aapt resource value: 0x7f0b00fc
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131427580;
 			
-			// aapt resource value: 0x7f09005b
-			public const int TextAppearance_StatusBar_EventContent_Title = 2131296347;
+			// aapt resource value: 0x7f0b00fd
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131427581;
 			
-			// aapt resource value: 0x7f090116
-			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131296534;
+			// aapt resource value: 0x7f0b00fe
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131427582;
 			
-			// aapt resource value: 0x7f090117
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131296535;
+			// aapt resource value: 0x7f0b00ff
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131427583;
 			
-			// aapt resource value: 0x7f090118
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131296536;
+			// aapt resource value: 0x7f0b0100
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131427584;
 			
-			// aapt resource value: 0x7f090119
-			public const int Theme_AppCompat = 2131296537;
+			// aapt resource value: 0x7f0b0101
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131427585;
 			
-			// aapt resource value: 0x7f09011a
-			public const int Theme_AppCompat_CompactMenu = 2131296538;
+			// aapt resource value: 0x7f0b0102
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131427586;
 			
-			// aapt resource value: 0x7f090038
-			public const int Theme_AppCompat_DayNight = 2131296312;
+			// aapt resource value: 0x7f0b0103
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131427587;
 			
-			// aapt resource value: 0x7f090039
-			public const int Theme_AppCompat_DayNight_DarkActionBar = 2131296313;
+			// aapt resource value: 0x7f0b0104
+			public const int TextAppearance_AppCompat_Widget_Button = 2131427588;
 			
-			// aapt resource value: 0x7f09003a
-			public const int Theme_AppCompat_DayNight_Dialog = 2131296314;
+			// aapt resource value: 0x7f0b0105
+			public const int TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131427589;
 			
-			// aapt resource value: 0x7f09003b
-			public const int Theme_AppCompat_DayNight_Dialog_Alert = 2131296315;
+			// aapt resource value: 0x7f0b0106
+			public const int TextAppearance_AppCompat_Widget_Button_Colored = 2131427590;
 			
-			// aapt resource value: 0x7f09003c
-			public const int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131296316;
+			// aapt resource value: 0x7f0b0107
+			public const int TextAppearance_AppCompat_Widget_Button_Inverse = 2131427591;
 			
-			// aapt resource value: 0x7f09003d
-			public const int Theme_AppCompat_DayNight_DialogWhenLarge = 2131296317;
+			// aapt resource value: 0x7f0b0108
+			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131427592;
 			
-			// aapt resource value: 0x7f09003e
-			public const int Theme_AppCompat_DayNight_NoActionBar = 2131296318;
+			// aapt resource value: 0x7f0b0109
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131427593;
 			
-			// aapt resource value: 0x7f09011b
-			public const int Theme_AppCompat_Dialog = 2131296539;
+			// aapt resource value: 0x7f0b010a
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131427594;
 			
-			// aapt resource value: 0x7f09011c
-			public const int Theme_AppCompat_Dialog_Alert = 2131296540;
+			// aapt resource value: 0x7f0b010b
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131427595;
 			
-			// aapt resource value: 0x7f09011d
-			public const int Theme_AppCompat_Dialog_MinWidth = 2131296541;
+			// aapt resource value: 0x7f0b010c
+			public const int TextAppearance_AppCompat_Widget_Switch = 2131427596;
 			
-			// aapt resource value: 0x7f09011e
-			public const int Theme_AppCompat_DialogWhenLarge = 2131296542;
+			// aapt resource value: 0x7f0b010d
+			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131427597;
 			
-			// aapt resource value: 0x7f09011f
-			public const int Theme_AppCompat_Light = 2131296543;
+			// aapt resource value: 0x7f0b0173
+			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131427699;
 			
-			// aapt resource value: 0x7f090120
-			public const int Theme_AppCompat_Light_DarkActionBar = 2131296544;
+			// aapt resource value: 0x7f0b0174
+			public const int TextAppearance_Design_Counter = 2131427700;
 			
-			// aapt resource value: 0x7f090121
-			public const int Theme_AppCompat_Light_Dialog = 2131296545;
+			// aapt resource value: 0x7f0b0175
+			public const int TextAppearance_Design_Counter_Overflow = 2131427701;
 			
-			// aapt resource value: 0x7f090122
-			public const int Theme_AppCompat_Light_Dialog_Alert = 2131296546;
+			// aapt resource value: 0x7f0b0176
+			public const int TextAppearance_Design_Error = 2131427702;
 			
-			// aapt resource value: 0x7f090123
-			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131296547;
+			// aapt resource value: 0x7f0b0177
+			public const int TextAppearance_Design_Hint = 2131427703;
 			
-			// aapt resource value: 0x7f090124
-			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131296548;
+			// aapt resource value: 0x7f0b0178
+			public const int TextAppearance_Design_Snackbar_Message = 2131427704;
 			
-			// aapt resource value: 0x7f090125
-			public const int Theme_AppCompat_Light_NoActionBar = 2131296549;
+			// aapt resource value: 0x7f0b0179
+			public const int TextAppearance_Design_Tab = 2131427705;
 			
-			// aapt resource value: 0x7f090126
-			public const int Theme_AppCompat_NoActionBar = 2131296550;
+			// aapt resource value: 0x7f0b0000
+			public const int TextAppearance_MediaRouter_PrimaryText = 2131427328;
 			
-			// aapt resource value: 0x7f090025
-			public const int Theme_Design = 2131296293;
+			// aapt resource value: 0x7f0b0001
+			public const int TextAppearance_MediaRouter_SecondaryText = 2131427329;
 			
-			// aapt resource value: 0x7f090026
-			public const int Theme_Design_BottomSheetDialog = 2131296294;
+			// aapt resource value: 0x7f0b0002
+			public const int TextAppearance_MediaRouter_Title = 2131427330;
 			
-			// aapt resource value: 0x7f090027
-			public const int Theme_Design_Light = 2131296295;
+			// aapt resource value: 0x7f0b003b
+			public const int TextAppearance_StatusBar_EventContent = 2131427387;
 			
-			// aapt resource value: 0x7f090028
-			public const int Theme_Design_Light_BottomSheetDialog = 2131296296;
+			// aapt resource value: 0x7f0b003c
+			public const int TextAppearance_StatusBar_EventContent_Info = 2131427388;
 			
-			// aapt resource value: 0x7f090029
-			public const int Theme_Design_Light_NoActionBar = 2131296297;
+			// aapt resource value: 0x7f0b003d
+			public const int TextAppearance_StatusBar_EventContent_Line2 = 2131427389;
 			
-			// aapt resource value: 0x7f09002a
-			public const int Theme_Design_NoActionBar = 2131296298;
+			// aapt resource value: 0x7f0b003e
+			public const int TextAppearance_StatusBar_EventContent_Time = 2131427390;
 			
-			// aapt resource value: 0x7f090000
-			public const int Theme_MediaRouter = 2131296256;
+			// aapt resource value: 0x7f0b003f
+			public const int TextAppearance_StatusBar_EventContent_Title = 2131427391;
 			
-			// aapt resource value: 0x7f090001
-			public const int Theme_MediaRouter_Light = 2131296257;
+			// aapt resource value: 0x7f0b010e
+			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131427598;
 			
-			// aapt resource value: 0x7f090002
-			public const int Theme_MediaRouter_Light_DarkControlPanel = 2131296258;
+			// aapt resource value: 0x7f0b010f
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131427599;
 			
-			// aapt resource value: 0x7f090003
-			public const int Theme_MediaRouter_LightControlPanel = 2131296259;
+			// aapt resource value: 0x7f0b0110
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131427600;
 			
-			// aapt resource value: 0x7f090127
-			public const int ThemeOverlay_AppCompat = 2131296551;
+			// aapt resource value: 0x7f0b0111
+			public const int Theme_AppCompat = 2131427601;
 			
-			// aapt resource value: 0x7f090128
-			public const int ThemeOverlay_AppCompat_ActionBar = 2131296552;
+			// aapt resource value: 0x7f0b0112
+			public const int Theme_AppCompat_CompactMenu = 2131427602;
 			
-			// aapt resource value: 0x7f090129
-			public const int ThemeOverlay_AppCompat_Dark = 2131296553;
+			// aapt resource value: 0x7f0b0013
+			public const int Theme_AppCompat_DayNight = 2131427347;
 			
-			// aapt resource value: 0x7f09012a
-			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131296554;
+			// aapt resource value: 0x7f0b0014
+			public const int Theme_AppCompat_DayNight_DarkActionBar = 2131427348;
 			
-			// aapt resource value: 0x7f09012b
-			public const int ThemeOverlay_AppCompat_Light = 2131296555;
+			// aapt resource value: 0x7f0b0015
+			public const int Theme_AppCompat_DayNight_Dialog = 2131427349;
 			
-			// aapt resource value: 0x7f09012c
-			public const int Widget_AppCompat_ActionBar = 2131296556;
+			// aapt resource value: 0x7f0b0016
+			public const int Theme_AppCompat_DayNight_Dialog_Alert = 2131427350;
 			
-			// aapt resource value: 0x7f09012d
-			public const int Widget_AppCompat_ActionBar_Solid = 2131296557;
+			// aapt resource value: 0x7f0b0017
+			public const int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131427351;
 			
-			// aapt resource value: 0x7f09012e
-			public const int Widget_AppCompat_ActionBar_TabBar = 2131296558;
+			// aapt resource value: 0x7f0b0018
+			public const int Theme_AppCompat_DayNight_DialogWhenLarge = 2131427352;
 			
-			// aapt resource value: 0x7f09012f
-			public const int Widget_AppCompat_ActionBar_TabText = 2131296559;
+			// aapt resource value: 0x7f0b0019
+			public const int Theme_AppCompat_DayNight_NoActionBar = 2131427353;
 			
-			// aapt resource value: 0x7f090130
-			public const int Widget_AppCompat_ActionBar_TabView = 2131296560;
+			// aapt resource value: 0x7f0b0113
+			public const int Theme_AppCompat_Dialog = 2131427603;
 			
-			// aapt resource value: 0x7f090131
-			public const int Widget_AppCompat_ActionButton = 2131296561;
+			// aapt resource value: 0x7f0b0114
+			public const int Theme_AppCompat_Dialog_Alert = 2131427604;
 			
-			// aapt resource value: 0x7f090132
-			public const int Widget_AppCompat_ActionButton_CloseMode = 2131296562;
+			// aapt resource value: 0x7f0b0115
+			public const int Theme_AppCompat_Dialog_MinWidth = 2131427605;
 			
-			// aapt resource value: 0x7f090133
-			public const int Widget_AppCompat_ActionButton_Overflow = 2131296563;
+			// aapt resource value: 0x7f0b0116
+			public const int Theme_AppCompat_DialogWhenLarge = 2131427606;
 			
-			// aapt resource value: 0x7f090134
-			public const int Widget_AppCompat_ActionMode = 2131296564;
+			// aapt resource value: 0x7f0b0117
+			public const int Theme_AppCompat_Light = 2131427607;
 			
-			// aapt resource value: 0x7f090135
-			public const int Widget_AppCompat_ActivityChooserView = 2131296565;
+			// aapt resource value: 0x7f0b0118
+			public const int Theme_AppCompat_Light_DarkActionBar = 2131427608;
 			
-			// aapt resource value: 0x7f090136
-			public const int Widget_AppCompat_AutoCompleteTextView = 2131296566;
+			// aapt resource value: 0x7f0b0119
+			public const int Theme_AppCompat_Light_Dialog = 2131427609;
 			
-			// aapt resource value: 0x7f090137
-			public const int Widget_AppCompat_Button = 2131296567;
+			// aapt resource value: 0x7f0b011a
+			public const int Theme_AppCompat_Light_Dialog_Alert = 2131427610;
 			
-			// aapt resource value: 0x7f090138
-			public const int Widget_AppCompat_Button_Borderless = 2131296568;
+			// aapt resource value: 0x7f0b011b
+			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131427611;
 			
-			// aapt resource value: 0x7f090139
-			public const int Widget_AppCompat_Button_Borderless_Colored = 2131296569;
+			// aapt resource value: 0x7f0b011c
+			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131427612;
 			
-			// aapt resource value: 0x7f09013a
-			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131296570;
+			// aapt resource value: 0x7f0b011d
+			public const int Theme_AppCompat_Light_NoActionBar = 2131427613;
 			
-			// aapt resource value: 0x7f09013b
-			public const int Widget_AppCompat_Button_Colored = 2131296571;
+			// aapt resource value: 0x7f0b011e
+			public const int Theme_AppCompat_NoActionBar = 2131427614;
 			
-			// aapt resource value: 0x7f09013c
-			public const int Widget_AppCompat_Button_Small = 2131296572;
+			// aapt resource value: 0x7f0b017a
+			public const int Theme_Design = 2131427706;
 			
-			// aapt resource value: 0x7f09013d
-			public const int Widget_AppCompat_ButtonBar = 2131296573;
+			// aapt resource value: 0x7f0b017b
+			public const int Theme_Design_BottomSheetDialog = 2131427707;
 			
-			// aapt resource value: 0x7f09013e
-			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131296574;
+			// aapt resource value: 0x7f0b017c
+			public const int Theme_Design_Light = 2131427708;
 			
-			// aapt resource value: 0x7f09013f
-			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131296575;
+			// aapt resource value: 0x7f0b017d
+			public const int Theme_Design_Light_BottomSheetDialog = 2131427709;
 			
-			// aapt resource value: 0x7f090140
-			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131296576;
+			// aapt resource value: 0x7f0b017e
+			public const int Theme_Design_Light_NoActionBar = 2131427710;
 			
-			// aapt resource value: 0x7f090141
-			public const int Widget_AppCompat_CompoundButton_Switch = 2131296577;
+			// aapt resource value: 0x7f0b017f
+			public const int Theme_Design_NoActionBar = 2131427711;
 			
-			// aapt resource value: 0x7f090142
-			public const int Widget_AppCompat_DrawerArrowToggle = 2131296578;
+			// aapt resource value: 0x7f0b0003
+			public const int Theme_MediaRouter = 2131427331;
 			
-			// aapt resource value: 0x7f090143
-			public const int Widget_AppCompat_DropDownItem_Spinner = 2131296579;
+			// aapt resource value: 0x7f0b0004
+			public const int Theme_MediaRouter_Light = 2131427332;
 			
-			// aapt resource value: 0x7f090144
-			public const int Widget_AppCompat_EditText = 2131296580;
+			// aapt resource value: 0x7f0b0005
+			public const int Theme_MediaRouter_Light_DarkControlPanel = 2131427333;
 			
-			// aapt resource value: 0x7f090145
-			public const int Widget_AppCompat_ImageButton = 2131296581;
+			// aapt resource value: 0x7f0b0006
+			public const int Theme_MediaRouter_LightControlPanel = 2131427334;
 			
-			// aapt resource value: 0x7f090146
-			public const int Widget_AppCompat_Light_ActionBar = 2131296582;
+			// aapt resource value: 0x7f0b011f
+			public const int ThemeOverlay_AppCompat = 2131427615;
 			
-			// aapt resource value: 0x7f090147
-			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131296583;
+			// aapt resource value: 0x7f0b0120
+			public const int ThemeOverlay_AppCompat_ActionBar = 2131427616;
 			
-			// aapt resource value: 0x7f090148
-			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131296584;
+			// aapt resource value: 0x7f0b0121
+			public const int ThemeOverlay_AppCompat_Dark = 2131427617;
 			
-			// aapt resource value: 0x7f090149
-			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131296585;
+			// aapt resource value: 0x7f0b0122
+			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131427618;
 			
-			// aapt resource value: 0x7f09014a
-			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131296586;
+			// aapt resource value: 0x7f0b0123
+			public const int ThemeOverlay_AppCompat_Dialog = 2131427619;
 			
-			// aapt resource value: 0x7f09014b
-			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131296587;
+			// aapt resource value: 0x7f0b0124
+			public const int ThemeOverlay_AppCompat_Dialog_Alert = 2131427620;
 			
-			// aapt resource value: 0x7f09014c
-			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131296588;
+			// aapt resource value: 0x7f0b0125
+			public const int ThemeOverlay_AppCompat_Light = 2131427621;
 			
-			// aapt resource value: 0x7f09014d
-			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131296589;
+			// aapt resource value: 0x7f0b0007
+			public const int ThemeOverlay_MediaRouter_Dark = 2131427335;
 			
-			// aapt resource value: 0x7f09014e
-			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131296590;
+			// aapt resource value: 0x7f0b0008
+			public const int ThemeOverlay_MediaRouter_Light = 2131427336;
 			
-			// aapt resource value: 0x7f09014f
-			public const int Widget_AppCompat_Light_ActionButton = 2131296591;
+			// aapt resource value: 0x7f0b0126
+			public const int Widget_AppCompat_ActionBar = 2131427622;
 			
-			// aapt resource value: 0x7f090150
-			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131296592;
+			// aapt resource value: 0x7f0b0127
+			public const int Widget_AppCompat_ActionBar_Solid = 2131427623;
 			
-			// aapt resource value: 0x7f090151
-			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131296593;
+			// aapt resource value: 0x7f0b0128
+			public const int Widget_AppCompat_ActionBar_TabBar = 2131427624;
 			
-			// aapt resource value: 0x7f090152
-			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131296594;
+			// aapt resource value: 0x7f0b0129
+			public const int Widget_AppCompat_ActionBar_TabText = 2131427625;
 			
-			// aapt resource value: 0x7f090153
-			public const int Widget_AppCompat_Light_ActivityChooserView = 2131296595;
+			// aapt resource value: 0x7f0b012a
+			public const int Widget_AppCompat_ActionBar_TabView = 2131427626;
 			
-			// aapt resource value: 0x7f090154
-			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131296596;
+			// aapt resource value: 0x7f0b012b
+			public const int Widget_AppCompat_ActionButton = 2131427627;
 			
-			// aapt resource value: 0x7f090155
-			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131296597;
+			// aapt resource value: 0x7f0b012c
+			public const int Widget_AppCompat_ActionButton_CloseMode = 2131427628;
 			
-			// aapt resource value: 0x7f090156
-			public const int Widget_AppCompat_Light_ListPopupWindow = 2131296598;
+			// aapt resource value: 0x7f0b012d
+			public const int Widget_AppCompat_ActionButton_Overflow = 2131427629;
 			
-			// aapt resource value: 0x7f090157
-			public const int Widget_AppCompat_Light_ListView_DropDown = 2131296599;
+			// aapt resource value: 0x7f0b012e
+			public const int Widget_AppCompat_ActionMode = 2131427630;
 			
-			// aapt resource value: 0x7f090158
-			public const int Widget_AppCompat_Light_PopupMenu = 2131296600;
+			// aapt resource value: 0x7f0b012f
+			public const int Widget_AppCompat_ActivityChooserView = 2131427631;
 			
-			// aapt resource value: 0x7f090159
-			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131296601;
+			// aapt resource value: 0x7f0b0130
+			public const int Widget_AppCompat_AutoCompleteTextView = 2131427632;
 			
-			// aapt resource value: 0x7f09015a
-			public const int Widget_AppCompat_Light_SearchView = 2131296602;
+			// aapt resource value: 0x7f0b0131
+			public const int Widget_AppCompat_Button = 2131427633;
 			
-			// aapt resource value: 0x7f09015b
-			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131296603;
+			// aapt resource value: 0x7f0b0132
+			public const int Widget_AppCompat_Button_Borderless = 2131427634;
 			
-			// aapt resource value: 0x7f09015c
-			public const int Widget_AppCompat_ListPopupWindow = 2131296604;
+			// aapt resource value: 0x7f0b0133
+			public const int Widget_AppCompat_Button_Borderless_Colored = 2131427635;
 			
-			// aapt resource value: 0x7f09015d
-			public const int Widget_AppCompat_ListView = 2131296605;
+			// aapt resource value: 0x7f0b0134
+			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131427636;
 			
-			// aapt resource value: 0x7f09015e
-			public const int Widget_AppCompat_ListView_DropDown = 2131296606;
+			// aapt resource value: 0x7f0b0135
+			public const int Widget_AppCompat_Button_Colored = 2131427637;
 			
-			// aapt resource value: 0x7f09015f
-			public const int Widget_AppCompat_ListView_Menu = 2131296607;
+			// aapt resource value: 0x7f0b0136
+			public const int Widget_AppCompat_Button_Small = 2131427638;
 			
-			// aapt resource value: 0x7f090160
-			public const int Widget_AppCompat_PopupMenu = 2131296608;
+			// aapt resource value: 0x7f0b0137
+			public const int Widget_AppCompat_ButtonBar = 2131427639;
 			
-			// aapt resource value: 0x7f090161
-			public const int Widget_AppCompat_PopupMenu_Overflow = 2131296609;
+			// aapt resource value: 0x7f0b0138
+			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131427640;
 			
-			// aapt resource value: 0x7f090162
-			public const int Widget_AppCompat_PopupWindow = 2131296610;
+			// aapt resource value: 0x7f0b0139
+			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131427641;
 			
-			// aapt resource value: 0x7f090163
-			public const int Widget_AppCompat_ProgressBar = 2131296611;
+			// aapt resource value: 0x7f0b013a
+			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131427642;
 			
-			// aapt resource value: 0x7f090164
-			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131296612;
+			// aapt resource value: 0x7f0b013b
+			public const int Widget_AppCompat_CompoundButton_Switch = 2131427643;
 			
-			// aapt resource value: 0x7f090165
-			public const int Widget_AppCompat_RatingBar = 2131296613;
+			// aapt resource value: 0x7f0b013c
+			public const int Widget_AppCompat_DrawerArrowToggle = 2131427644;
 			
-			// aapt resource value: 0x7f090166
-			public const int Widget_AppCompat_RatingBar_Indicator = 2131296614;
+			// aapt resource value: 0x7f0b013d
+			public const int Widget_AppCompat_DropDownItem_Spinner = 2131427645;
 			
-			// aapt resource value: 0x7f090167
-			public const int Widget_AppCompat_RatingBar_Small = 2131296615;
+			// aapt resource value: 0x7f0b013e
+			public const int Widget_AppCompat_EditText = 2131427646;
 			
-			// aapt resource value: 0x7f090168
-			public const int Widget_AppCompat_SearchView = 2131296616;
+			// aapt resource value: 0x7f0b013f
+			public const int Widget_AppCompat_ImageButton = 2131427647;
 			
-			// aapt resource value: 0x7f090169
-			public const int Widget_AppCompat_SearchView_ActionBar = 2131296617;
+			// aapt resource value: 0x7f0b0140
+			public const int Widget_AppCompat_Light_ActionBar = 2131427648;
 			
-			// aapt resource value: 0x7f09016a
-			public const int Widget_AppCompat_SeekBar = 2131296618;
+			// aapt resource value: 0x7f0b0141
+			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131427649;
 			
-			// aapt resource value: 0x7f09016b
-			public const int Widget_AppCompat_Spinner = 2131296619;
+			// aapt resource value: 0x7f0b0142
+			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131427650;
 			
-			// aapt resource value: 0x7f09016c
-			public const int Widget_AppCompat_Spinner_DropDown = 2131296620;
+			// aapt resource value: 0x7f0b0143
+			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131427651;
 			
-			// aapt resource value: 0x7f09016d
-			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131296621;
+			// aapt resource value: 0x7f0b0144
+			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131427652;
 			
-			// aapt resource value: 0x7f09016e
-			public const int Widget_AppCompat_Spinner_Underlined = 2131296622;
+			// aapt resource value: 0x7f0b0145
+			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131427653;
 			
-			// aapt resource value: 0x7f09016f
-			public const int Widget_AppCompat_TextView_SpinnerItem = 2131296623;
+			// aapt resource value: 0x7f0b0146
+			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131427654;
 			
-			// aapt resource value: 0x7f090170
-			public const int Widget_AppCompat_Toolbar = 2131296624;
+			// aapt resource value: 0x7f0b0147
+			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131427655;
 			
-			// aapt resource value: 0x7f090171
-			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131296625;
+			// aapt resource value: 0x7f0b0148
+			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131427656;
 			
-			// aapt resource value: 0x7f09002b
-			public const int Widget_Design_AppBarLayout = 2131296299;
+			// aapt resource value: 0x7f0b0149
+			public const int Widget_AppCompat_Light_ActionButton = 2131427657;
 			
-			// aapt resource value: 0x7f09002c
-			public const int Widget_Design_BottomSheet_Modal = 2131296300;
+			// aapt resource value: 0x7f0b014a
+			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131427658;
 			
-			// aapt resource value: 0x7f09002d
-			public const int Widget_Design_CollapsingToolbar = 2131296301;
+			// aapt resource value: 0x7f0b014b
+			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131427659;
 			
-			// aapt resource value: 0x7f09002e
-			public const int Widget_Design_CoordinatorLayout = 2131296302;
+			// aapt resource value: 0x7f0b014c
+			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131427660;
 			
-			// aapt resource value: 0x7f09002f
-			public const int Widget_Design_FloatingActionButton = 2131296303;
+			// aapt resource value: 0x7f0b014d
+			public const int Widget_AppCompat_Light_ActivityChooserView = 2131427661;
 			
-			// aapt resource value: 0x7f090030
-			public const int Widget_Design_NavigationView = 2131296304;
+			// aapt resource value: 0x7f0b014e
+			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131427662;
 			
-			// aapt resource value: 0x7f090031
-			public const int Widget_Design_ScrimInsetsFrameLayout = 2131296305;
+			// aapt resource value: 0x7f0b014f
+			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131427663;
 			
-			// aapt resource value: 0x7f090032
-			public const int Widget_Design_Snackbar = 2131296306;
+			// aapt resource value: 0x7f0b0150
+			public const int Widget_AppCompat_Light_ListPopupWindow = 2131427664;
 			
-			// aapt resource value: 0x7f09001b
-			public const int Widget_Design_TabLayout = 2131296283;
+			// aapt resource value: 0x7f0b0151
+			public const int Widget_AppCompat_Light_ListView_DropDown = 2131427665;
 			
-			// aapt resource value: 0x7f090033
-			public const int Widget_Design_TextInputLayout = 2131296307;
+			// aapt resource value: 0x7f0b0152
+			public const int Widget_AppCompat_Light_PopupMenu = 2131427666;
 			
-			// aapt resource value: 0x7f090004
-			public const int Widget_MediaRouter_ChooserText = 2131296260;
+			// aapt resource value: 0x7f0b0153
+			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131427667;
 			
-			// aapt resource value: 0x7f090005
-			public const int Widget_MediaRouter_ChooserText_Primary = 2131296261;
+			// aapt resource value: 0x7f0b0154
+			public const int Widget_AppCompat_Light_SearchView = 2131427668;
 			
-			// aapt resource value: 0x7f090006
-			public const int Widget_MediaRouter_ChooserText_Primary_Dark = 2131296262;
+			// aapt resource value: 0x7f0b0155
+			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131427669;
 			
-			// aapt resource value: 0x7f090007
-			public const int Widget_MediaRouter_ChooserText_Primary_Light = 2131296263;
+			// aapt resource value: 0x7f0b0156
+			public const int Widget_AppCompat_ListMenuView = 2131427670;
 			
-			// aapt resource value: 0x7f090008
-			public const int Widget_MediaRouter_ChooserText_Secondary = 2131296264;
+			// aapt resource value: 0x7f0b0157
+			public const int Widget_AppCompat_ListPopupWindow = 2131427671;
 			
-			// aapt resource value: 0x7f090009
-			public const int Widget_MediaRouter_ChooserText_Secondary_Dark = 2131296265;
+			// aapt resource value: 0x7f0b0158
+			public const int Widget_AppCompat_ListView = 2131427672;
 			
-			// aapt resource value: 0x7f09000a
-			public const int Widget_MediaRouter_ChooserText_Secondary_Light = 2131296266;
+			// aapt resource value: 0x7f0b0159
+			public const int Widget_AppCompat_ListView_DropDown = 2131427673;
 			
-			// aapt resource value: 0x7f09000b
-			public const int Widget_MediaRouter_ControllerText = 2131296267;
+			// aapt resource value: 0x7f0b015a
+			public const int Widget_AppCompat_ListView_Menu = 2131427674;
 			
-			// aapt resource value: 0x7f09000c
-			public const int Widget_MediaRouter_ControllerText_Primary = 2131296268;
+			// aapt resource value: 0x7f0b009f
+			public const int Widget_AppCompat_NotificationActionContainer = 2131427487;
 			
-			// aapt resource value: 0x7f09000d
-			public const int Widget_MediaRouter_ControllerText_Primary_Dark = 2131296269;
+			// aapt resource value: 0x7f0b00a0
+			public const int Widget_AppCompat_NotificationActionText = 2131427488;
 			
-			// aapt resource value: 0x7f09000e
-			public const int Widget_MediaRouter_ControllerText_Primary_Light = 2131296270;
+			// aapt resource value: 0x7f0b015b
+			public const int Widget_AppCompat_PopupMenu = 2131427675;
 			
-			// aapt resource value: 0x7f09000f
-			public const int Widget_MediaRouter_ControllerText_Secondary = 2131296271;
+			// aapt resource value: 0x7f0b015c
+			public const int Widget_AppCompat_PopupMenu_Overflow = 2131427676;
 			
-			// aapt resource value: 0x7f090010
-			public const int Widget_MediaRouter_ControllerText_Secondary_Dark = 2131296272;
+			// aapt resource value: 0x7f0b015d
+			public const int Widget_AppCompat_PopupWindow = 2131427677;
 			
-			// aapt resource value: 0x7f090011
-			public const int Widget_MediaRouter_ControllerText_Secondary_Light = 2131296273;
+			// aapt resource value: 0x7f0b015e
+			public const int Widget_AppCompat_ProgressBar = 2131427678;
 			
-			// aapt resource value: 0x7f090012
-			public const int Widget_MediaRouter_ControllerText_Title = 2131296274;
+			// aapt resource value: 0x7f0b015f
+			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131427679;
 			
-			// aapt resource value: 0x7f090013
-			public const int Widget_MediaRouter_ControllerText_Title_Dark = 2131296275;
+			// aapt resource value: 0x7f0b0160
+			public const int Widget_AppCompat_RatingBar = 2131427680;
 			
-			// aapt resource value: 0x7f090014
-			public const int Widget_MediaRouter_ControllerText_Title_Light = 2131296276;
+			// aapt resource value: 0x7f0b0161
+			public const int Widget_AppCompat_RatingBar_Indicator = 2131427681;
 			
-			// aapt resource value: 0x7f090015
-			public const int Widget_MediaRouter_Light_MediaRouteButton = 2131296277;
+			// aapt resource value: 0x7f0b0162
+			public const int Widget_AppCompat_RatingBar_Small = 2131427682;
 			
-			// aapt resource value: 0x7f090016
-			public const int Widget_MediaRouter_MediaRouteButton = 2131296278;
+			// aapt resource value: 0x7f0b0163
+			public const int Widget_AppCompat_SearchView = 2131427683;
+			
+			// aapt resource value: 0x7f0b0164
+			public const int Widget_AppCompat_SearchView_ActionBar = 2131427684;
+			
+			// aapt resource value: 0x7f0b0165
+			public const int Widget_AppCompat_SeekBar = 2131427685;
+			
+			// aapt resource value: 0x7f0b0166
+			public const int Widget_AppCompat_SeekBar_Discrete = 2131427686;
+			
+			// aapt resource value: 0x7f0b0167
+			public const int Widget_AppCompat_Spinner = 2131427687;
+			
+			// aapt resource value: 0x7f0b0168
+			public const int Widget_AppCompat_Spinner_DropDown = 2131427688;
+			
+			// aapt resource value: 0x7f0b0169
+			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131427689;
+			
+			// aapt resource value: 0x7f0b016a
+			public const int Widget_AppCompat_Spinner_Underlined = 2131427690;
+			
+			// aapt resource value: 0x7f0b016b
+			public const int Widget_AppCompat_TextView_SpinnerItem = 2131427691;
+			
+			// aapt resource value: 0x7f0b016c
+			public const int Widget_AppCompat_Toolbar = 2131427692;
+			
+			// aapt resource value: 0x7f0b016d
+			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131427693;
+			
+			// aapt resource value: 0x7f0b016f
+			public const int Widget_Design_AppBarLayout = 2131427695;
+			
+			// aapt resource value: 0x7f0b0180
+			public const int Widget_Design_BottomNavigationView = 2131427712;
+			
+			// aapt resource value: 0x7f0b0181
+			public const int Widget_Design_BottomSheet_Modal = 2131427713;
+			
+			// aapt resource value: 0x7f0b0182
+			public const int Widget_Design_CollapsingToolbar = 2131427714;
+			
+			// aapt resource value: 0x7f0b0183
+			public const int Widget_Design_CoordinatorLayout = 2131427715;
+			
+			// aapt resource value: 0x7f0b0184
+			public const int Widget_Design_FloatingActionButton = 2131427716;
+			
+			// aapt resource value: 0x7f0b0185
+			public const int Widget_Design_NavigationView = 2131427717;
+			
+			// aapt resource value: 0x7f0b0186
+			public const int Widget_Design_ScrimInsetsFrameLayout = 2131427718;
+			
+			// aapt resource value: 0x7f0b0187
+			public const int Widget_Design_Snackbar = 2131427719;
+			
+			// aapt resource value: 0x7f0b016e
+			public const int Widget_Design_TabLayout = 2131427694;
+			
+			// aapt resource value: 0x7f0b0188
+			public const int Widget_Design_TextInputLayout = 2131427720;
+			
+			// aapt resource value: 0x7f0b0009
+			public const int Widget_MediaRouter_Light_MediaRouteButton = 2131427337;
+			
+			// aapt resource value: 0x7f0b000a
+			public const int Widget_MediaRouter_MediaRouteButton = 2131427338;
 			
 			static Style()
 			{
@@ -5992,33 +7133,35 @@ namespace XFGlossSample.Droid
 			
 			public static int[] ActionBar = new int[]
 			{
-					2130772076,
-					2130772078,
-					2130772079,
-					2130772080,
-					2130772081,
-					2130772082,
-					2130772083,
-					2130772084,
-					2130772085,
-					2130772086,
-					2130772087,
-					2130772088,
-					2130772089,
-					2130772090,
-					2130772091,
-					2130772092,
-					2130772093,
-					2130772094,
-					2130772095,
-					2130772096,
-					2130772097,
-					2130772098,
-					2130772099,
-					2130772100,
-					2130772101,
-					2130772102,
-					2130772159};
+					2130771997,
+					2130771999,
+					2130772000,
+					2130772001,
+					2130772002,
+					2130772003,
+					2130772004,
+					2130772005,
+					2130772006,
+					2130772007,
+					2130772008,
+					2130772009,
+					2130772010,
+					2130772011,
+					2130772012,
+					2130772013,
+					2130772014,
+					2130772015,
+					2130772016,
+					2130772017,
+					2130772018,
+					2130772019,
+					2130772020,
+					2130772021,
+					2130772022,
+					2130772023,
+					2130772024,
+					2130772025,
+					2130772087};
 			
 			// aapt resource value: 10
 			public const int ActionBar_background = 10;
@@ -6032,6 +7175,9 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 21
 			public const int ActionBar_contentInsetEnd = 21;
 			
+			// aapt resource value: 25
+			public const int ActionBar_contentInsetEndWithActions = 25;
+			
 			// aapt resource value: 22
 			public const int ActionBar_contentInsetLeft = 22;
 			
@@ -6040,6 +7186,9 @@ namespace XFGlossSample.Droid
 			
 			// aapt resource value: 20
 			public const int ActionBar_contentInsetStart = 20;
+			
+			// aapt resource value: 24
+			public const int ActionBar_contentInsetStartWithNavigation = 24;
 			
 			// aapt resource value: 13
 			public const int ActionBar_customNavigationLayout = 13;
@@ -6050,8 +7199,8 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 9
 			public const int ActionBar_divider = 9;
 			
-			// aapt resource value: 24
-			public const int ActionBar_elevation = 24;
+			// aapt resource value: 26
+			public const int ActionBar_elevation = 26;
 			
 			// aapt resource value: 0
 			public const int ActionBar_height = 0;
@@ -6059,8 +7208,8 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 19
 			public const int ActionBar_hideOnContentScroll = 19;
 			
-			// aapt resource value: 26
-			public const int ActionBar_homeAsUpIndicator = 26;
+			// aapt resource value: 28
+			public const int ActionBar_homeAsUpIndicator = 28;
 			
 			// aapt resource value: 14
 			public const int ActionBar_homeLayout = 14;
@@ -6080,8 +7229,8 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 2
 			public const int ActionBar_navigationMode = 2;
 			
-			// aapt resource value: 25
-			public const int ActionBar_popupTheme = 25;
+			// aapt resource value: 27
+			public const int ActionBar_popupTheme = 27;
 			
 			// aapt resource value: 17
 			public const int ActionBar_progressBarPadding = 17;
@@ -6119,12 +7268,12 @@ namespace XFGlossSample.Droid
 			
 			public static int[] ActionMode = new int[]
 			{
-					2130772076,
-					2130772082,
-					2130772083,
-					2130772087,
-					2130772089,
-					2130772103};
+					2130771997,
+					2130772003,
+					2130772004,
+					2130772008,
+					2130772010,
+					2130772026};
 			
 			// aapt resource value: 3
 			public const int ActionMode_background = 3;
@@ -6146,8 +7295,8 @@ namespace XFGlossSample.Droid
 			
 			public static int[] ActivityChooserView = new int[]
 			{
-					2130772104,
-					2130772105};
+					2130772027,
+					2130772028};
 			
 			// aapt resource value: 1
 			public const int ActivityChooserView_expandActivityOverflowButtonDrawable = 1;
@@ -6158,11 +7307,12 @@ namespace XFGlossSample.Droid
 			public static int[] AlertDialog = new int[]
 			{
 					16842994,
-					2130772106,
-					2130772107,
-					2130772108,
-					2130772109,
-					2130772110};
+					2130772029,
+					2130772030,
+					2130772031,
+					2130772032,
+					2130772033,
+					2130772034};
 			
 			// aapt resource value: 0
 			public const int AlertDialog_android_layout = 0;
@@ -6179,39 +7329,53 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 3
 			public const int AlertDialog_multiChoiceItemLayout = 3;
 			
+			// aapt resource value: 6
+			public const int AlertDialog_showTitle = 6;
+			
 			// aapt resource value: 4
 			public const int AlertDialog_singleChoiceItemLayout = 4;
 			
 			public static int[] AppBarLayout = new int[]
 			{
 					16842964,
-					2130772002,
-					2130772101};
+					2130772024,
+					2130772224};
 			
 			// aapt resource value: 0
 			public const int AppBarLayout_android_background = 0;
 			
-			// aapt resource value: 2
-			public const int AppBarLayout_elevation = 2;
-			
 			// aapt resource value: 1
-			public const int AppBarLayout_expanded = 1;
+			public const int AppBarLayout_elevation = 1;
 			
-			public static int[] AppBarLayout_LayoutParams = new int[]
+			// aapt resource value: 2
+			public const int AppBarLayout_expanded = 2;
+			
+			public static int[] AppBarLayoutStates = new int[]
 			{
-					2130772003,
-					2130772004};
+					2130772225,
+					2130772226};
 			
 			// aapt resource value: 0
-			public const int AppBarLayout_LayoutParams_layout_scrollFlags = 0;
+			public const int AppBarLayoutStates_state_collapsed = 0;
 			
 			// aapt resource value: 1
-			public const int AppBarLayout_LayoutParams_layout_scrollInterpolator = 1;
+			public const int AppBarLayoutStates_state_collapsible = 1;
+			
+			public static int[] AppBarLayout_Layout = new int[]
+			{
+					2130772227,
+					2130772228};
+			
+			// aapt resource value: 0
+			public const int AppBarLayout_Layout_layout_scrollFlags = 0;
+			
+			// aapt resource value: 1
+			public const int AppBarLayout_Layout_layout_scrollInterpolator = 1;
 			
 			public static int[] AppCompatImageView = new int[]
 			{
 					16843033,
-					2130772111};
+					2130772035};
 			
 			// aapt resource value: 0
 			public const int AppCompatImageView_android_src = 0;
@@ -6219,10 +7383,60 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 1
 			public const int AppCompatImageView_srcCompat = 1;
 			
+			public static int[] AppCompatSeekBar = new int[]
+			{
+					16843074,
+					2130772036,
+					2130772037,
+					2130772038};
+			
+			// aapt resource value: 0
+			public const int AppCompatSeekBar_android_thumb = 0;
+			
+			// aapt resource value: 1
+			public const int AppCompatSeekBar_tickMark = 1;
+			
+			// aapt resource value: 2
+			public const int AppCompatSeekBar_tickMarkTint = 2;
+			
+			// aapt resource value: 3
+			public const int AppCompatSeekBar_tickMarkTintMode = 3;
+			
+			public static int[] AppCompatTextHelper = new int[]
+			{
+					16842804,
+					16843117,
+					16843118,
+					16843119,
+					16843120,
+					16843666,
+					16843667};
+			
+			// aapt resource value: 2
+			public const int AppCompatTextHelper_android_drawableBottom = 2;
+			
+			// aapt resource value: 6
+			public const int AppCompatTextHelper_android_drawableEnd = 6;
+			
+			// aapt resource value: 3
+			public const int AppCompatTextHelper_android_drawableLeft = 3;
+			
+			// aapt resource value: 4
+			public const int AppCompatTextHelper_android_drawableRight = 4;
+			
+			// aapt resource value: 5
+			public const int AppCompatTextHelper_android_drawableStart = 5;
+			
+			// aapt resource value: 1
+			public const int AppCompatTextHelper_android_drawableTop = 1;
+			
+			// aapt resource value: 0
+			public const int AppCompatTextHelper_android_textAppearance = 0;
+			
 			public static int[] AppCompatTextView = new int[]
 			{
 					16842804,
-					2130772112};
+					2130772039};
 			
 			// aapt resource value: 0
 			public const int AppCompatTextView_android_textAppearance = 0;
@@ -6234,6 +7448,79 @@ namespace XFGlossSample.Droid
 			{
 					16842839,
 					16842926,
+					2130772040,
+					2130772041,
+					2130772042,
+					2130772043,
+					2130772044,
+					2130772045,
+					2130772046,
+					2130772047,
+					2130772048,
+					2130772049,
+					2130772050,
+					2130772051,
+					2130772052,
+					2130772053,
+					2130772054,
+					2130772055,
+					2130772056,
+					2130772057,
+					2130772058,
+					2130772059,
+					2130772060,
+					2130772061,
+					2130772062,
+					2130772063,
+					2130772064,
+					2130772065,
+					2130772066,
+					2130772067,
+					2130772068,
+					2130772069,
+					2130772070,
+					2130772071,
+					2130772072,
+					2130772073,
+					2130772074,
+					2130772075,
+					2130772076,
+					2130772077,
+					2130772078,
+					2130772079,
+					2130772080,
+					2130772081,
+					2130772082,
+					2130772083,
+					2130772084,
+					2130772085,
+					2130772086,
+					2130772087,
+					2130772088,
+					2130772089,
+					2130772090,
+					2130772091,
+					2130772092,
+					2130772093,
+					2130772094,
+					2130772095,
+					2130772096,
+					2130772097,
+					2130772098,
+					2130772099,
+					2130772100,
+					2130772101,
+					2130772102,
+					2130772103,
+					2130772104,
+					2130772105,
+					2130772106,
+					2130772107,
+					2130772108,
+					2130772109,
+					2130772110,
+					2130772111,
+					2130772112,
 					2130772113,
 					2130772114,
 					2130772115,
@@ -6273,77 +7560,7 @@ namespace XFGlossSample.Droid
 					2130772149,
 					2130772150,
 					2130772151,
-					2130772152,
-					2130772153,
-					2130772154,
-					2130772155,
-					2130772156,
-					2130772157,
-					2130772158,
-					2130772159,
-					2130772160,
-					2130772161,
-					2130772162,
-					2130772163,
-					2130772164,
-					2130772165,
-					2130772166,
-					2130772167,
-					2130772168,
-					2130772169,
-					2130772170,
-					2130772171,
-					2130772172,
-					2130772173,
-					2130772174,
-					2130772175,
-					2130772176,
-					2130772177,
-					2130772178,
-					2130772179,
-					2130772180,
-					2130772181,
-					2130772182,
-					2130772183,
-					2130772184,
-					2130772185,
-					2130772186,
-					2130772187,
-					2130772188,
-					2130772189,
-					2130772190,
-					2130772191,
-					2130772192,
-					2130772193,
-					2130772194,
-					2130772195,
-					2130772196,
-					2130772197,
-					2130772198,
-					2130772199,
-					2130772200,
-					2130772201,
-					2130772202,
-					2130772203,
-					2130772204,
-					2130772205,
-					2130772206,
-					2130772207,
-					2130772208,
-					2130772209,
-					2130772210,
-					2130772211,
-					2130772212,
-					2130772213,
-					2130772214,
-					2130772215,
-					2130772216,
-					2130772217,
-					2130772218,
-					2130772219,
-					2130772220,
-					2130772221,
-					2130772222};
+					2130772152};
 			
 			// aapt resource value: 23
 			public const int AppCompatTheme_actionBarDivider = 23;
@@ -6378,11 +7595,11 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 21
 			public const int AppCompatTheme_actionBarWidgetTheme = 21;
 			
-			// aapt resource value: 49
-			public const int AppCompatTheme_actionButtonStyle = 49;
+			// aapt resource value: 50
+			public const int AppCompatTheme_actionButtonStyle = 50;
 			
-			// aapt resource value: 45
-			public const int AppCompatTheme_actionDropDownStyle = 45;
+			// aapt resource value: 46
+			public const int AppCompatTheme_actionDropDownStyle = 46;
 			
 			// aapt resource value: 25
 			public const int AppCompatTheme_actionMenuTextAppearance = 25;
@@ -6435,20 +7652,20 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 16
 			public const int AppCompatTheme_actionOverflowMenuStyle = 16;
 			
-			// aapt resource value: 57
-			public const int AppCompatTheme_activityChooserViewStyle = 57;
-			
-			// aapt resource value: 92
-			public const int AppCompatTheme_alertDialogButtonGroupStyle = 92;
-			
-			// aapt resource value: 93
-			public const int AppCompatTheme_alertDialogCenterButtons = 93;
-			
-			// aapt resource value: 91
-			public const int AppCompatTheme_alertDialogStyle = 91;
+			// aapt resource value: 58
+			public const int AppCompatTheme_activityChooserViewStyle = 58;
 			
 			// aapt resource value: 94
-			public const int AppCompatTheme_alertDialogTheme = 94;
+			public const int AppCompatTheme_alertDialogButtonGroupStyle = 94;
+			
+			// aapt resource value: 95
+			public const int AppCompatTheme_alertDialogCenterButtons = 95;
+			
+			// aapt resource value: 93
+			public const int AppCompatTheme_alertDialogStyle = 93;
+			
+			// aapt resource value: 96
+			public const int AppCompatTheme_alertDialogTheme = 96;
 			
 			// aapt resource value: 1
 			public const int AppCompatTheme_android_windowAnimationStyle = 1;
@@ -6456,200 +7673,209 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 0
 			public const int AppCompatTheme_android_windowIsFloating = 0;
 			
-			// aapt resource value: 99
-			public const int AppCompatTheme_autoCompleteTextViewStyle = 99;
-			
-			// aapt resource value: 54
-			public const int AppCompatTheme_borderlessButtonStyle = 54;
-			
-			// aapt resource value: 51
-			public const int AppCompatTheme_buttonBarButtonStyle = 51;
-			
-			// aapt resource value: 97
-			public const int AppCompatTheme_buttonBarNegativeButtonStyle = 97;
-			
-			// aapt resource value: 98
-			public const int AppCompatTheme_buttonBarNeutralButtonStyle = 98;
-			
-			// aapt resource value: 96
-			public const int AppCompatTheme_buttonBarPositiveButtonStyle = 96;
-			
-			// aapt resource value: 50
-			public const int AppCompatTheme_buttonBarStyle = 50;
-			
-			// aapt resource value: 100
-			public const int AppCompatTheme_buttonStyle = 100;
-			
 			// aapt resource value: 101
-			public const int AppCompatTheme_buttonStyleSmall = 101;
-			
-			// aapt resource value: 102
-			public const int AppCompatTheme_checkboxStyle = 102;
-			
-			// aapt resource value: 103
-			public const int AppCompatTheme_checkedTextViewStyle = 103;
-			
-			// aapt resource value: 84
-			public const int AppCompatTheme_colorAccent = 84;
-			
-			// aapt resource value: 88
-			public const int AppCompatTheme_colorButtonNormal = 88;
-			
-			// aapt resource value: 86
-			public const int AppCompatTheme_colorControlActivated = 86;
-			
-			// aapt resource value: 87
-			public const int AppCompatTheme_colorControlHighlight = 87;
-			
-			// aapt resource value: 85
-			public const int AppCompatTheme_colorControlNormal = 85;
-			
-			// aapt resource value: 82
-			public const int AppCompatTheme_colorPrimary = 82;
-			
-			// aapt resource value: 83
-			public const int AppCompatTheme_colorPrimaryDark = 83;
-			
-			// aapt resource value: 89
-			public const int AppCompatTheme_colorSwitchThumbNormal = 89;
-			
-			// aapt resource value: 90
-			public const int AppCompatTheme_controlBackground = 90;
-			
-			// aapt resource value: 43
-			public const int AppCompatTheme_dialogPreferredPadding = 43;
-			
-			// aapt resource value: 42
-			public const int AppCompatTheme_dialogTheme = 42;
-			
-			// aapt resource value: 56
-			public const int AppCompatTheme_dividerHorizontal = 56;
+			public const int AppCompatTheme_autoCompleteTextViewStyle = 101;
 			
 			// aapt resource value: 55
-			public const int AppCompatTheme_dividerVertical = 55;
-			
-			// aapt resource value: 74
-			public const int AppCompatTheme_dropDownListViewStyle = 74;
-			
-			// aapt resource value: 46
-			public const int AppCompatTheme_dropdownListPreferredItemHeight = 46;
-			
-			// aapt resource value: 63
-			public const int AppCompatTheme_editTextBackground = 63;
-			
-			// aapt resource value: 62
-			public const int AppCompatTheme_editTextColor = 62;
-			
-			// aapt resource value: 104
-			public const int AppCompatTheme_editTextStyle = 104;
-			
-			// aapt resource value: 48
-			public const int AppCompatTheme_homeAsUpIndicator = 48;
-			
-			// aapt resource value: 64
-			public const int AppCompatTheme_imageButtonStyle = 64;
-			
-			// aapt resource value: 81
-			public const int AppCompatTheme_listChoiceBackgroundIndicator = 81;
-			
-			// aapt resource value: 44
-			public const int AppCompatTheme_listDividerAlertDialog = 44;
-			
-			// aapt resource value: 75
-			public const int AppCompatTheme_listPopupWindowStyle = 75;
-			
-			// aapt resource value: 69
-			public const int AppCompatTheme_listPreferredItemHeight = 69;
-			
-			// aapt resource value: 71
-			public const int AppCompatTheme_listPreferredItemHeightLarge = 71;
-			
-			// aapt resource value: 70
-			public const int AppCompatTheme_listPreferredItemHeightSmall = 70;
-			
-			// aapt resource value: 72
-			public const int AppCompatTheme_listPreferredItemPaddingLeft = 72;
-			
-			// aapt resource value: 73
-			public const int AppCompatTheme_listPreferredItemPaddingRight = 73;
-			
-			// aapt resource value: 78
-			public const int AppCompatTheme_panelBackground = 78;
-			
-			// aapt resource value: 80
-			public const int AppCompatTheme_panelMenuListTheme = 80;
-			
-			// aapt resource value: 79
-			public const int AppCompatTheme_panelMenuListWidth = 79;
-			
-			// aapt resource value: 60
-			public const int AppCompatTheme_popupMenuStyle = 60;
-			
-			// aapt resource value: 61
-			public const int AppCompatTheme_popupWindowStyle = 61;
-			
-			// aapt resource value: 105
-			public const int AppCompatTheme_radioButtonStyle = 105;
-			
-			// aapt resource value: 106
-			public const int AppCompatTheme_ratingBarStyle = 106;
-			
-			// aapt resource value: 107
-			public const int AppCompatTheme_ratingBarStyleIndicator = 107;
-			
-			// aapt resource value: 108
-			public const int AppCompatTheme_ratingBarStyleSmall = 108;
-			
-			// aapt resource value: 68
-			public const int AppCompatTheme_searchViewStyle = 68;
-			
-			// aapt resource value: 109
-			public const int AppCompatTheme_seekBarStyle = 109;
+			public const int AppCompatTheme_borderlessButtonStyle = 55;
 			
 			// aapt resource value: 52
-			public const int AppCompatTheme_selectableItemBackground = 52;
+			public const int AppCompatTheme_buttonBarButtonStyle = 52;
 			
-			// aapt resource value: 53
-			public const int AppCompatTheme_selectableItemBackgroundBorderless = 53;
+			// aapt resource value: 99
+			public const int AppCompatTheme_buttonBarNegativeButtonStyle = 99;
+			
+			// aapt resource value: 100
+			public const int AppCompatTheme_buttonBarNeutralButtonStyle = 100;
+			
+			// aapt resource value: 98
+			public const int AppCompatTheme_buttonBarPositiveButtonStyle = 98;
+			
+			// aapt resource value: 51
+			public const int AppCompatTheme_buttonBarStyle = 51;
+			
+			// aapt resource value: 102
+			public const int AppCompatTheme_buttonStyle = 102;
+			
+			// aapt resource value: 103
+			public const int AppCompatTheme_buttonStyleSmall = 103;
+			
+			// aapt resource value: 104
+			public const int AppCompatTheme_checkboxStyle = 104;
+			
+			// aapt resource value: 105
+			public const int AppCompatTheme_checkedTextViewStyle = 105;
+			
+			// aapt resource value: 85
+			public const int AppCompatTheme_colorAccent = 85;
+			
+			// aapt resource value: 92
+			public const int AppCompatTheme_colorBackgroundFloating = 92;
+			
+			// aapt resource value: 89
+			public const int AppCompatTheme_colorButtonNormal = 89;
+			
+			// aapt resource value: 87
+			public const int AppCompatTheme_colorControlActivated = 87;
+			
+			// aapt resource value: 88
+			public const int AppCompatTheme_colorControlHighlight = 88;
+			
+			// aapt resource value: 86
+			public const int AppCompatTheme_colorControlNormal = 86;
+			
+			// aapt resource value: 83
+			public const int AppCompatTheme_colorPrimary = 83;
+			
+			// aapt resource value: 84
+			public const int AppCompatTheme_colorPrimaryDark = 84;
+			
+			// aapt resource value: 90
+			public const int AppCompatTheme_colorSwitchThumbNormal = 90;
+			
+			// aapt resource value: 91
+			public const int AppCompatTheme_controlBackground = 91;
+			
+			// aapt resource value: 44
+			public const int AppCompatTheme_dialogPreferredPadding = 44;
+			
+			// aapt resource value: 43
+			public const int AppCompatTheme_dialogTheme = 43;
+			
+			// aapt resource value: 57
+			public const int AppCompatTheme_dividerHorizontal = 57;
+			
+			// aapt resource value: 56
+			public const int AppCompatTheme_dividerVertical = 56;
+			
+			// aapt resource value: 75
+			public const int AppCompatTheme_dropDownListViewStyle = 75;
 			
 			// aapt resource value: 47
-			public const int AppCompatTheme_spinnerDropDownItemStyle = 47;
+			public const int AppCompatTheme_dropdownListPreferredItemHeight = 47;
+			
+			// aapt resource value: 64
+			public const int AppCompatTheme_editTextBackground = 64;
+			
+			// aapt resource value: 63
+			public const int AppCompatTheme_editTextColor = 63;
+			
+			// aapt resource value: 106
+			public const int AppCompatTheme_editTextStyle = 106;
+			
+			// aapt resource value: 49
+			public const int AppCompatTheme_homeAsUpIndicator = 49;
+			
+			// aapt resource value: 65
+			public const int AppCompatTheme_imageButtonStyle = 65;
+			
+			// aapt resource value: 82
+			public const int AppCompatTheme_listChoiceBackgroundIndicator = 82;
+			
+			// aapt resource value: 45
+			public const int AppCompatTheme_listDividerAlertDialog = 45;
+			
+			// aapt resource value: 114
+			public const int AppCompatTheme_listMenuViewStyle = 114;
+			
+			// aapt resource value: 76
+			public const int AppCompatTheme_listPopupWindowStyle = 76;
+			
+			// aapt resource value: 70
+			public const int AppCompatTheme_listPreferredItemHeight = 70;
+			
+			// aapt resource value: 72
+			public const int AppCompatTheme_listPreferredItemHeightLarge = 72;
+			
+			// aapt resource value: 71
+			public const int AppCompatTheme_listPreferredItemHeightSmall = 71;
+			
+			// aapt resource value: 73
+			public const int AppCompatTheme_listPreferredItemPaddingLeft = 73;
+			
+			// aapt resource value: 74
+			public const int AppCompatTheme_listPreferredItemPaddingRight = 74;
+			
+			// aapt resource value: 79
+			public const int AppCompatTheme_panelBackground = 79;
+			
+			// aapt resource value: 81
+			public const int AppCompatTheme_panelMenuListTheme = 81;
+			
+			// aapt resource value: 80
+			public const int AppCompatTheme_panelMenuListWidth = 80;
+			
+			// aapt resource value: 61
+			public const int AppCompatTheme_popupMenuStyle = 61;
+			
+			// aapt resource value: 62
+			public const int AppCompatTheme_popupWindowStyle = 62;
+			
+			// aapt resource value: 107
+			public const int AppCompatTheme_radioButtonStyle = 107;
+			
+			// aapt resource value: 108
+			public const int AppCompatTheme_ratingBarStyle = 108;
+			
+			// aapt resource value: 109
+			public const int AppCompatTheme_ratingBarStyleIndicator = 109;
 			
 			// aapt resource value: 110
-			public const int AppCompatTheme_spinnerStyle = 110;
+			public const int AppCompatTheme_ratingBarStyleSmall = 110;
+			
+			// aapt resource value: 69
+			public const int AppCompatTheme_searchViewStyle = 69;
 			
 			// aapt resource value: 111
-			public const int AppCompatTheme_switchStyle = 111;
+			public const int AppCompatTheme_seekBarStyle = 111;
+			
+			// aapt resource value: 53
+			public const int AppCompatTheme_selectableItemBackground = 53;
+			
+			// aapt resource value: 54
+			public const int AppCompatTheme_selectableItemBackgroundBorderless = 54;
+			
+			// aapt resource value: 48
+			public const int AppCompatTheme_spinnerDropDownItemStyle = 48;
+			
+			// aapt resource value: 112
+			public const int AppCompatTheme_spinnerStyle = 112;
+			
+			// aapt resource value: 113
+			public const int AppCompatTheme_switchStyle = 113;
 			
 			// aapt resource value: 40
 			public const int AppCompatTheme_textAppearanceLargePopupMenu = 40;
 			
-			// aapt resource value: 76
-			public const int AppCompatTheme_textAppearanceListItem = 76;
-			
 			// aapt resource value: 77
-			public const int AppCompatTheme_textAppearanceListItemSmall = 77;
+			public const int AppCompatTheme_textAppearanceListItem = 77;
+			
+			// aapt resource value: 78
+			public const int AppCompatTheme_textAppearanceListItemSmall = 78;
+			
+			// aapt resource value: 42
+			public const int AppCompatTheme_textAppearancePopupMenuHeader = 42;
+			
+			// aapt resource value: 67
+			public const int AppCompatTheme_textAppearanceSearchResultSubtitle = 67;
 			
 			// aapt resource value: 66
-			public const int AppCompatTheme_textAppearanceSearchResultSubtitle = 66;
-			
-			// aapt resource value: 65
-			public const int AppCompatTheme_textAppearanceSearchResultTitle = 65;
+			public const int AppCompatTheme_textAppearanceSearchResultTitle = 66;
 			
 			// aapt resource value: 41
 			public const int AppCompatTheme_textAppearanceSmallPopupMenu = 41;
 			
-			// aapt resource value: 95
-			public const int AppCompatTheme_textColorAlertDialogListItem = 95;
+			// aapt resource value: 97
+			public const int AppCompatTheme_textColorAlertDialogListItem = 97;
 			
-			// aapt resource value: 67
-			public const int AppCompatTheme_textColorSearchUrl = 67;
+			// aapt resource value: 68
+			public const int AppCompatTheme_textColorSearchUrl = 68;
+			
+			// aapt resource value: 60
+			public const int AppCompatTheme_toolbarNavigationButtonStyle = 60;
 			
 			// aapt resource value: 59
-			public const int AppCompatTheme_toolbarNavigationButtonStyle = 59;
-			
-			// aapt resource value: 58
-			public const int AppCompatTheme_toolbarStyle = 58;
+			public const int AppCompatTheme_toolbarStyle = 59;
 			
 			// aapt resource value: 2
 			public const int AppCompatTheme_windowActionBar = 2;
@@ -6681,20 +7907,47 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 3
 			public const int AppCompatTheme_windowNoTitle = 3;
 			
-			public static int[] BottomSheetBehavior_Params = new int[]
+			public static int[] BottomNavigationView = new int[]
 			{
-					2130772005,
-					2130772006};
-			
-			// aapt resource value: 1
-			public const int BottomSheetBehavior_Params_behavior_hideable = 1;
+					2130772024,
+					2130772267,
+					2130772268,
+					2130772269,
+					2130772270};
 			
 			// aapt resource value: 0
-			public const int BottomSheetBehavior_Params_behavior_peekHeight = 0;
+			public const int BottomNavigationView_elevation = 0;
+			
+			// aapt resource value: 4
+			public const int BottomNavigationView_itemBackground = 4;
+			
+			// aapt resource value: 2
+			public const int BottomNavigationView_itemIconTint = 2;
+			
+			// aapt resource value: 3
+			public const int BottomNavigationView_itemTextColor = 3;
+			
+			// aapt resource value: 1
+			public const int BottomNavigationView_menu = 1;
+			
+			public static int[] BottomSheetBehavior_Layout = new int[]
+			{
+					2130772229,
+					2130772230,
+					2130772231};
+			
+			// aapt resource value: 1
+			public const int BottomSheetBehavior_Layout_behavior_hideable = 1;
+			
+			// aapt resource value: 0
+			public const int BottomSheetBehavior_Layout_behavior_peekHeight = 0;
+			
+			// aapt resource value: 2
+			public const int BottomSheetBehavior_Layout_behavior_skipCollapsed = 2;
 			
 			public static int[] ButtonBarLayout = new int[]
 			{
-					2130772223};
+					2130772153};
 			
 			// aapt resource value: 0
 			public const int ButtonBarLayout_allowStacking = 0;
@@ -6703,17 +7956,17 @@ namespace XFGlossSample.Droid
 			{
 					16843071,
 					16843072,
+					2130771985,
+					2130771986,
+					2130771987,
+					2130771988,
+					2130771989,
+					2130771990,
 					2130771991,
 					2130771992,
 					2130771993,
 					2130771994,
-					2130771995,
-					2130771996,
-					2130771997,
-					2130771998,
-					2130771999,
-					2130772000,
-					2130772001};
+					2130771995};
 			
 			// aapt resource value: 1
 			public const int CardView_android_minHeight = 1;
@@ -6754,81 +8007,104 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 11
 			public const int CardView_contentPaddingTop = 11;
 			
-			public static int[] CollapsingAppBarLayout_LayoutParams = new int[]
-			{
-					2130772007,
-					2130772008};
-			
-			// aapt resource value: 0
-			public const int CollapsingAppBarLayout_LayoutParams_layout_collapseMode = 0;
-			
-			// aapt resource value: 1
-			public const int CollapsingAppBarLayout_LayoutParams_layout_collapseParallaxMultiplier = 1;
-			
 			public static int[] CollapsingToolbarLayout = new int[]
 			{
-					2130772009,
-					2130772010,
-					2130772011,
-					2130772012,
-					2130772013,
-					2130772014,
-					2130772015,
-					2130772016,
-					2130772017,
-					2130772018,
-					2130772019,
-					2130772020,
-					2130772021,
-					2130772078};
-			
-			// aapt resource value: 10
-			public const int CollapsingToolbarLayout_collapsedTitleGravity = 10;
-			
-			// aapt resource value: 6
-			public const int CollapsingToolbarLayout_collapsedTitleTextAppearance = 6;
-			
-			// aapt resource value: 7
-			public const int CollapsingToolbarLayout_contentScrim = 7;
-			
-			// aapt resource value: 11
-			public const int CollapsingToolbarLayout_expandedTitleGravity = 11;
-			
-			// aapt resource value: 0
-			public const int CollapsingToolbarLayout_expandedTitleMargin = 0;
-			
-			// aapt resource value: 4
-			public const int CollapsingToolbarLayout_expandedTitleMarginBottom = 4;
-			
-			// aapt resource value: 3
-			public const int CollapsingToolbarLayout_expandedTitleMarginEnd = 3;
-			
-			// aapt resource value: 1
-			public const int CollapsingToolbarLayout_expandedTitleMarginStart = 1;
-			
-			// aapt resource value: 2
-			public const int CollapsingToolbarLayout_expandedTitleMarginTop = 2;
-			
-			// aapt resource value: 5
-			public const int CollapsingToolbarLayout_expandedTitleTextAppearance = 5;
-			
-			// aapt resource value: 8
-			public const int CollapsingToolbarLayout_statusBarScrim = 8;
+					2130771999,
+					2130772232,
+					2130772233,
+					2130772234,
+					2130772235,
+					2130772236,
+					2130772237,
+					2130772238,
+					2130772239,
+					2130772240,
+					2130772241,
+					2130772242,
+					2130772243,
+					2130772244,
+					2130772245,
+					2130772246};
 			
 			// aapt resource value: 13
-			public const int CollapsingToolbarLayout_title = 13;
+			public const int CollapsingToolbarLayout_collapsedTitleGravity = 13;
+			
+			// aapt resource value: 7
+			public const int CollapsingToolbarLayout_collapsedTitleTextAppearance = 7;
+			
+			// aapt resource value: 8
+			public const int CollapsingToolbarLayout_contentScrim = 8;
+			
+			// aapt resource value: 14
+			public const int CollapsingToolbarLayout_expandedTitleGravity = 14;
+			
+			// aapt resource value: 1
+			public const int CollapsingToolbarLayout_expandedTitleMargin = 1;
+			
+			// aapt resource value: 5
+			public const int CollapsingToolbarLayout_expandedTitleMarginBottom = 5;
+			
+			// aapt resource value: 4
+			public const int CollapsingToolbarLayout_expandedTitleMarginEnd = 4;
+			
+			// aapt resource value: 2
+			public const int CollapsingToolbarLayout_expandedTitleMarginStart = 2;
+			
+			// aapt resource value: 3
+			public const int CollapsingToolbarLayout_expandedTitleMarginTop = 3;
+			
+			// aapt resource value: 6
+			public const int CollapsingToolbarLayout_expandedTitleTextAppearance = 6;
 			
 			// aapt resource value: 12
-			public const int CollapsingToolbarLayout_titleEnabled = 12;
+			public const int CollapsingToolbarLayout_scrimAnimationDuration = 12;
+			
+			// aapt resource value: 11
+			public const int CollapsingToolbarLayout_scrimVisibleHeightTrigger = 11;
 			
 			// aapt resource value: 9
-			public const int CollapsingToolbarLayout_toolbarId = 9;
+			public const int CollapsingToolbarLayout_statusBarScrim = 9;
+			
+			// aapt resource value: 0
+			public const int CollapsingToolbarLayout_title = 0;
+			
+			// aapt resource value: 15
+			public const int CollapsingToolbarLayout_titleEnabled = 15;
+			
+			// aapt resource value: 10
+			public const int CollapsingToolbarLayout_toolbarId = 10;
+			
+			public static int[] CollapsingToolbarLayout_Layout = new int[]
+			{
+					2130772247,
+					2130772248};
+			
+			// aapt resource value: 0
+			public const int CollapsingToolbarLayout_Layout_layout_collapseMode = 0;
+			
+			// aapt resource value: 1
+			public const int CollapsingToolbarLayout_Layout_layout_collapseParallaxMultiplier = 1;
+			
+			public static int[] ColorStateListItem = new int[]
+			{
+					16843173,
+					16843551,
+					2130772154};
+			
+			// aapt resource value: 2
+			public const int ColorStateListItem_alpha = 2;
+			
+			// aapt resource value: 1
+			public const int ColorStateListItem_android_alpha = 1;
+			
+			// aapt resource value: 0
+			public const int ColorStateListItem_android_color = 0;
 			
 			public static int[] CompoundButton = new int[]
 			{
 					16843015,
-					2130772224,
-					2130772225};
+					2130772155,
+					2130772156};
 			
 			// aapt resource value: 0
 			public const int CompoundButton_android_button = 0;
@@ -6841,8 +8117,8 @@ namespace XFGlossSample.Droid
 			
 			public static int[] CoordinatorLayout = new int[]
 			{
-					2130772022,
-					2130772023};
+					2130772249,
+					2130772250};
 			
 			// aapt resource value: 0
 			public const int CoordinatorLayout_keylines = 0;
@@ -6850,34 +8126,42 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 1
 			public const int CoordinatorLayout_statusBarBackground = 1;
 			
-			public static int[] CoordinatorLayout_LayoutParams = new int[]
+			public static int[] CoordinatorLayout_Layout = new int[]
 			{
 					16842931,
-					2130772024,
-					2130772025,
-					2130772026,
-					2130772027};
+					2130772251,
+					2130772252,
+					2130772253,
+					2130772254,
+					2130772255,
+					2130772256};
 			
 			// aapt resource value: 0
-			public const int CoordinatorLayout_LayoutParams_android_layout_gravity = 0;
+			public const int CoordinatorLayout_Layout_android_layout_gravity = 0;
 			
 			// aapt resource value: 2
-			public const int CoordinatorLayout_LayoutParams_layout_anchor = 2;
+			public const int CoordinatorLayout_Layout_layout_anchor = 2;
 			
 			// aapt resource value: 4
-			public const int CoordinatorLayout_LayoutParams_layout_anchorGravity = 4;
+			public const int CoordinatorLayout_Layout_layout_anchorGravity = 4;
 			
 			// aapt resource value: 1
-			public const int CoordinatorLayout_LayoutParams_layout_behavior = 1;
+			public const int CoordinatorLayout_Layout_layout_behavior = 1;
+			
+			// aapt resource value: 6
+			public const int CoordinatorLayout_Layout_layout_dodgeInsetEdges = 6;
+			
+			// aapt resource value: 5
+			public const int CoordinatorLayout_Layout_layout_insetEdge = 5;
 			
 			// aapt resource value: 3
-			public const int CoordinatorLayout_LayoutParams_layout_keyline = 3;
+			public const int CoordinatorLayout_Layout_layout_keyline = 3;
 			
 			public static int[] DesignTheme = new int[]
 			{
-					2130772028,
-					2130772029,
-					2130772030};
+					2130772257,
+					2130772258,
+					2130772259};
 			
 			// aapt resource value: 0
 			public const int DesignTheme_bottomSheetDialogTheme = 0;
@@ -6890,14 +8174,14 @@ namespace XFGlossSample.Droid
 			
 			public static int[] DrawerArrowToggle = new int[]
 			{
-					2130772226,
-					2130772227,
-					2130772228,
-					2130772229,
-					2130772230,
-					2130772231,
-					2130772232,
-					2130772233};
+					2130772157,
+					2130772158,
+					2130772159,
+					2130772160,
+					2130772161,
+					2130772162,
+					2130772163,
+					2130772164};
 			
 			// aapt resource value: 4
 			public const int DrawerArrowToggle_arrowHeadLength = 4;
@@ -6925,44 +8209,51 @@ namespace XFGlossSample.Droid
 			
 			public static int[] FloatingActionButton = new int[]
 			{
-					2130772031,
-					2130772032,
-					2130772033,
-					2130772034,
-					2130772035,
-					2130772101,
-					2130772282,
-					2130772283};
-			
-			// aapt resource value: 6
-			public const int FloatingActionButton_backgroundTint = 6;
-			
-			// aapt resource value: 7
-			public const int FloatingActionButton_backgroundTintMode = 7;
-			
-			// aapt resource value: 3
-			public const int FloatingActionButton_borderWidth = 3;
-			
-			// aapt resource value: 5
-			public const int FloatingActionButton_elevation = 5;
+					2130772024,
+					2130772222,
+					2130772223,
+					2130772260,
+					2130772261,
+					2130772262,
+					2130772263,
+					2130772264};
 			
 			// aapt resource value: 1
-			public const int FloatingActionButton_fabSize = 1;
+			public const int FloatingActionButton_backgroundTint = 1;
 			
 			// aapt resource value: 2
-			public const int FloatingActionButton_pressedTranslationZ = 2;
+			public const int FloatingActionButton_backgroundTintMode = 2;
+			
+			// aapt resource value: 6
+			public const int FloatingActionButton_borderWidth = 6;
 			
 			// aapt resource value: 0
-			public const int FloatingActionButton_rippleColor = 0;
+			public const int FloatingActionButton_elevation = 0;
 			
 			// aapt resource value: 4
-			public const int FloatingActionButton_useCompatPadding = 4;
+			public const int FloatingActionButton_fabSize = 4;
+			
+			// aapt resource value: 5
+			public const int FloatingActionButton_pressedTranslationZ = 5;
+			
+			// aapt resource value: 3
+			public const int FloatingActionButton_rippleColor = 3;
+			
+			// aapt resource value: 7
+			public const int FloatingActionButton_useCompatPadding = 7;
+			
+			public static int[] FloatingActionButton_Behavior_Layout = new int[]
+			{
+					2130772265};
+			
+			// aapt resource value: 0
+			public const int FloatingActionButton_Behavior_Layout_behavior_autoHide = 0;
 			
 			public static int[] ForegroundLinearLayout = new int[]
 			{
 					16843017,
 					16843264,
-					2130772036};
+					2130772266};
 			
 			// aapt resource value: 0
 			public const int ForegroundLinearLayout_android_foreground = 0;
@@ -6980,10 +8271,10 @@ namespace XFGlossSample.Droid
 					16843046,
 					16843047,
 					16843048,
-					2130772086,
-					2130772234,
-					2130772235,
-					2130772236};
+					2130772007,
+					2130772165,
+					2130772166,
+					2130772167};
 			
 			// aapt resource value: 2
 			public const int LinearLayoutCompat_android_baselineAligned = 2;
@@ -7046,13 +8337,17 @@ namespace XFGlossSample.Droid
 			{
 					16843071,
 					16843072,
-					2130771990};
+					2130771984,
+					2130772155};
 			
 			// aapt resource value: 1
 			public const int MediaRouteButton_android_minHeight = 1;
 			
 			// aapt resource value: 0
 			public const int MediaRouteButton_android_minWidth = 0;
+			
+			// aapt resource value: 3
+			public const int MediaRouteButton_buttonTint = 3;
 			
 			// aapt resource value: 2
 			public const int MediaRouteButton_externalRouteEnabledDrawable = 2;
@@ -7099,10 +8394,10 @@ namespace XFGlossSample.Droid
 					16843236,
 					16843237,
 					16843375,
-					2130772237,
-					2130772238,
-					2130772239,
-					2130772240};
+					2130772168,
+					2130772169,
+					2130772170,
+					2130772171};
 			
 			// aapt resource value: 14
 			public const int MenuItem_actionLayout = 14;
@@ -7164,7 +8459,8 @@ namespace XFGlossSample.Droid
 					16843055,
 					16843056,
 					16843057,
-					2130772241};
+					2130772172,
+					2130772173};
 			
 			// aapt resource value: 4
 			public const int MenuView_android_headerBackground = 4;
@@ -7190,18 +8486,21 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 7
 			public const int MenuView_preserveIconSpacing = 7;
 			
+			// aapt resource value: 8
+			public const int MenuView_subMenuArrow = 8;
+			
 			public static int[] NavigationView = new int[]
 			{
 					16842964,
 					16842973,
 					16843039,
-					2130772037,
-					2130772038,
-					2130772039,
-					2130772040,
-					2130772041,
-					2130772042,
-					2130772101};
+					2130772024,
+					2130772267,
+					2130772268,
+					2130772269,
+					2130772270,
+					2130772271,
+					2130772272};
 			
 			// aapt resource value: 0
 			public const int NavigationView_android_background = 0;
@@ -7212,81 +8511,100 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 2
 			public const int NavigationView_android_maxWidth = 2;
 			
+			// aapt resource value: 3
+			public const int NavigationView_elevation = 3;
+			
 			// aapt resource value: 9
-			public const int NavigationView_elevation = 9;
-			
-			// aapt resource value: 8
-			public const int NavigationView_headerLayout = 8;
-			
-			// aapt resource value: 6
-			public const int NavigationView_itemBackground = 6;
-			
-			// aapt resource value: 4
-			public const int NavigationView_itemIconTint = 4;
+			public const int NavigationView_headerLayout = 9;
 			
 			// aapt resource value: 7
-			public const int NavigationView_itemTextAppearance = 7;
+			public const int NavigationView_itemBackground = 7;
 			
 			// aapt resource value: 5
-			public const int NavigationView_itemTextColor = 5;
+			public const int NavigationView_itemIconTint = 5;
 			
-			// aapt resource value: 3
-			public const int NavigationView_menu = 3;
+			// aapt resource value: 8
+			public const int NavigationView_itemTextAppearance = 8;
+			
+			// aapt resource value: 6
+			public const int NavigationView_itemTextColor = 6;
+			
+			// aapt resource value: 4
+			public const int NavigationView_menu = 4;
 			
 			public static int[] PopupWindow = new int[]
 			{
 					16843126,
-					2130772242};
+					16843465,
+					2130772174};
+			
+			// aapt resource value: 1
+			public const int PopupWindow_android_popupAnimationStyle = 1;
 			
 			// aapt resource value: 0
 			public const int PopupWindow_android_popupBackground = 0;
 			
-			// aapt resource value: 1
-			public const int PopupWindow_overlapAnchor = 1;
+			// aapt resource value: 2
+			public const int PopupWindow_overlapAnchor = 2;
 			
 			public static int[] PopupWindowBackgroundState = new int[]
 			{
-					2130772243};
+					2130772175};
 			
 			// aapt resource value: 0
 			public const int PopupWindowBackgroundState_state_above_anchor = 0;
 			
+			public static int[] RecycleListView = new int[]
+			{
+					2130772176,
+					2130772177};
+			
+			// aapt resource value: 0
+			public const int RecycleListView_paddingBottomNoButtons = 0;
+			
+			// aapt resource value: 1
+			public const int RecycleListView_paddingTopNoTitle = 1;
+			
 			public static int[] RecyclerView = new int[]
 			{
 					16842948,
-					2130772071,
-					2130772072,
-					2130772073,
-					2130772074};
+					16842993,
+					2130771968,
+					2130771969,
+					2130771970,
+					2130771971};
+			
+			// aapt resource value: 1
+			public const int RecyclerView_android_descendantFocusability = 1;
 			
 			// aapt resource value: 0
 			public const int RecyclerView_android_orientation = 0;
 			
-			// aapt resource value: 1
-			public const int RecyclerView_layoutManager = 1;
-			
-			// aapt resource value: 3
-			public const int RecyclerView_reverseLayout = 3;
-			
 			// aapt resource value: 2
-			public const int RecyclerView_spanCount = 2;
+			public const int RecyclerView_layoutManager = 2;
 			
 			// aapt resource value: 4
-			public const int RecyclerView_stackFromEnd = 4;
+			public const int RecyclerView_reverseLayout = 4;
+			
+			// aapt resource value: 3
+			public const int RecyclerView_spanCount = 3;
+			
+			// aapt resource value: 5
+			public const int RecyclerView_stackFromEnd = 5;
 			
 			public static int[] ScrimInsetsFrameLayout = new int[]
 			{
-					2130772043};
+					2130772273};
 			
 			// aapt resource value: 0
 			public const int ScrimInsetsFrameLayout_insetForeground = 0;
 			
-			public static int[] ScrollingViewBehavior_Params = new int[]
+			public static int[] ScrollingViewBehavior_Layout = new int[]
 			{
-					2130772044};
+					2130772274};
 			
 			// aapt resource value: 0
-			public const int ScrollingViewBehavior_Params_behavior_overlapTop = 0;
+			public const int ScrollingViewBehavior_Layout_behavior_overlapTop = 0;
 			
 			public static int[] SearchView = new int[]
 			{
@@ -7294,19 +8612,19 @@ namespace XFGlossSample.Droid
 					16843039,
 					16843296,
 					16843364,
-					2130772244,
-					2130772245,
-					2130772246,
-					2130772247,
-					2130772248,
-					2130772249,
-					2130772250,
-					2130772251,
-					2130772252,
-					2130772253,
-					2130772254,
-					2130772255,
-					2130772256};
+					2130772178,
+					2130772179,
+					2130772180,
+					2130772181,
+					2130772182,
+					2130772183,
+					2130772184,
+					2130772185,
+					2130772186,
+					2130772187,
+					2130772188,
+					2130772189,
+					2130772190};
 			
 			// aapt resource value: 0
 			public const int SearchView_android_focusable = 0;
@@ -7362,17 +8680,17 @@ namespace XFGlossSample.Droid
 			public static int[] SnackbarLayout = new int[]
 			{
 					16843039,
-					2130772045,
-					2130772101};
+					2130772024,
+					2130772275};
 			
 			// aapt resource value: 0
 			public const int SnackbarLayout_android_maxWidth = 0;
 			
-			// aapt resource value: 2
-			public const int SnackbarLayout_elevation = 2;
-			
 			// aapt resource value: 1
-			public const int SnackbarLayout_maxActionInlineWidth = 1;
+			public const int SnackbarLayout_elevation = 1;
+			
+			// aapt resource value: 2
+			public const int SnackbarLayout_maxActionInlineWidth = 2;
 			
 			public static int[] Spinner = new int[]
 			{
@@ -7380,7 +8698,7 @@ namespace XFGlossSample.Droid
 					16843126,
 					16843131,
 					16843362,
-					2130772102};
+					2130772025};
 			
 			// aapt resource value: 3
 			public const int Spinner_android_dropDownWidth = 3;
@@ -7402,13 +8720,17 @@ namespace XFGlossSample.Droid
 					16843044,
 					16843045,
 					16843074,
-					2130772257,
-					2130772258,
-					2130772259,
-					2130772260,
-					2130772261,
-					2130772262,
-					2130772263};
+					2130772191,
+					2130772192,
+					2130772193,
+					2130772194,
+					2130772195,
+					2130772196,
+					2130772197,
+					2130772198,
+					2130772199,
+					2130772200,
+					2130772201};
 			
 			// aapt resource value: 1
 			public const int SwitchCompat_android_textOff = 1;
@@ -7419,26 +8741,38 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 2
 			public const int SwitchCompat_android_thumb = 2;
 			
+			// aapt resource value: 13
+			public const int SwitchCompat_showText = 13;
+			
+			// aapt resource value: 12
+			public const int SwitchCompat_splitTrack = 12;
+			
+			// aapt resource value: 10
+			public const int SwitchCompat_switchMinWidth = 10;
+			
+			// aapt resource value: 11
+			public const int SwitchCompat_switchPadding = 11;
+			
 			// aapt resource value: 9
-			public const int SwitchCompat_showText = 9;
+			public const int SwitchCompat_switchTextAppearance = 9;
 			
 			// aapt resource value: 8
-			public const int SwitchCompat_splitTrack = 8;
-			
-			// aapt resource value: 6
-			public const int SwitchCompat_switchMinWidth = 6;
-			
-			// aapt resource value: 7
-			public const int SwitchCompat_switchPadding = 7;
-			
-			// aapt resource value: 5
-			public const int SwitchCompat_switchTextAppearance = 5;
-			
-			// aapt resource value: 4
-			public const int SwitchCompat_thumbTextPadding = 4;
+			public const int SwitchCompat_thumbTextPadding = 8;
 			
 			// aapt resource value: 3
-			public const int SwitchCompat_track = 3;
+			public const int SwitchCompat_thumbTint = 3;
+			
+			// aapt resource value: 4
+			public const int SwitchCompat_thumbTintMode = 4;
+			
+			// aapt resource value: 5
+			public const int SwitchCompat_track = 5;
+			
+			// aapt resource value: 6
+			public const int SwitchCompat_trackTint = 6;
+			
+			// aapt resource value: 7
+			public const int SwitchCompat_trackTintMode = 7;
 			
 			public static int[] TabItem = new int[]
 			{
@@ -7457,22 +8791,22 @@ namespace XFGlossSample.Droid
 			
 			public static int[] TabLayout = new int[]
 			{
-					2130772046,
-					2130772047,
-					2130772048,
-					2130772049,
-					2130772050,
-					2130772051,
-					2130772052,
-					2130772053,
-					2130772054,
-					2130772055,
-					2130772056,
-					2130772057,
-					2130772058,
-					2130772059,
-					2130772060,
-					2130772061};
+					2130772276,
+					2130772277,
+					2130772278,
+					2130772279,
+					2130772280,
+					2130772281,
+					2130772282,
+					2130772283,
+					2130772284,
+					2130772285,
+					2130772286,
+					2130772287,
+					2130772288,
+					2130772289,
+					2130772290,
+					2130772291};
 			
 			// aapt resource value: 3
 			public const int TabLayout_tabBackground = 3;
@@ -7528,26 +8862,30 @@ namespace XFGlossSample.Droid
 					16842902,
 					16842903,
 					16842904,
+					16842906,
 					16843105,
 					16843106,
 					16843107,
 					16843108,
-					2130772112};
-			
-			// aapt resource value: 4
-			public const int TextAppearance_android_shadowColor = 4;
+					2130772039};
 			
 			// aapt resource value: 5
-			public const int TextAppearance_android_shadowDx = 5;
+			public const int TextAppearance_android_shadowColor = 5;
 			
 			// aapt resource value: 6
-			public const int TextAppearance_android_shadowDy = 6;
+			public const int TextAppearance_android_shadowDx = 6;
 			
 			// aapt resource value: 7
-			public const int TextAppearance_android_shadowRadius = 7;
+			public const int TextAppearance_android_shadowDy = 7;
+			
+			// aapt resource value: 8
+			public const int TextAppearance_android_shadowRadius = 8;
 			
 			// aapt resource value: 3
 			public const int TextAppearance_android_textColor = 3;
+			
+			// aapt resource value: 4
+			public const int TextAppearance_android_textColorHint = 4;
 			
 			// aapt resource value: 0
 			public const int TextAppearance_android_textSize = 0;
@@ -7558,22 +8896,27 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 1
 			public const int TextAppearance_android_typeface = 1;
 			
-			// aapt resource value: 8
-			public const int TextAppearance_textAllCaps = 8;
+			// aapt resource value: 9
+			public const int TextAppearance_textAllCaps = 9;
 			
 			public static int[] TextInputLayout = new int[]
 			{
 					16842906,
 					16843088,
-					2130772062,
-					2130772063,
-					2130772064,
-					2130772065,
-					2130772066,
-					2130772067,
-					2130772068,
-					2130772069,
-					2130772070};
+					2130772292,
+					2130772293,
+					2130772294,
+					2130772295,
+					2130772296,
+					2130772297,
+					2130772298,
+					2130772299,
+					2130772300,
+					2130772301,
+					2130772302,
+					2130772303,
+					2130772304,
+					2130772305};
 			
 			// aapt resource value: 1
 			public const int TextInputLayout_android_hint = 1;
@@ -7608,33 +8951,52 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 2
 			public const int TextInputLayout_hintTextAppearance = 2;
 			
+			// aapt resource value: 13
+			public const int TextInputLayout_passwordToggleContentDescription = 13;
+			
+			// aapt resource value: 12
+			public const int TextInputLayout_passwordToggleDrawable = 12;
+			
+			// aapt resource value: 11
+			public const int TextInputLayout_passwordToggleEnabled = 11;
+			
+			// aapt resource value: 14
+			public const int TextInputLayout_passwordToggleTint = 14;
+			
+			// aapt resource value: 15
+			public const int TextInputLayout_passwordToggleTintMode = 15;
+			
 			public static int[] Toolbar = new int[]
 			{
 					16842927,
 					16843072,
-					2130772078,
-					2130772081,
-					2130772085,
-					2130772097,
-					2130772098,
-					2130772099,
-					2130772100,
-					2130772102,
-					2130772264,
-					2130772265,
-					2130772266,
-					2130772267,
-					2130772268,
-					2130772269,
-					2130772270,
-					2130772271,
-					2130772272,
-					2130772273,
-					2130772274,
-					2130772275,
-					2130772276,
-					2130772277,
-					2130772278};
+					2130771999,
+					2130772002,
+					2130772006,
+					2130772018,
+					2130772019,
+					2130772020,
+					2130772021,
+					2130772022,
+					2130772023,
+					2130772025,
+					2130772202,
+					2130772203,
+					2130772204,
+					2130772205,
+					2130772206,
+					2130772207,
+					2130772208,
+					2130772209,
+					2130772210,
+					2130772211,
+					2130772212,
+					2130772213,
+					2130772214,
+					2130772215,
+					2130772216,
+					2130772217,
+					2130772218};
 			
 			// aapt resource value: 0
 			public const int Toolbar_android_gravity = 0;
@@ -7642,14 +9004,20 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 1
 			public const int Toolbar_android_minHeight = 1;
 			
-			// aapt resource value: 19
-			public const int Toolbar_collapseContentDescription = 19;
+			// aapt resource value: 21
+			public const int Toolbar_buttonGravity = 21;
 			
-			// aapt resource value: 18
-			public const int Toolbar_collapseIcon = 18;
+			// aapt resource value: 23
+			public const int Toolbar_collapseContentDescription = 23;
+			
+			// aapt resource value: 22
+			public const int Toolbar_collapseIcon = 22;
 			
 			// aapt resource value: 6
 			public const int Toolbar_contentInsetEnd = 6;
+			
+			// aapt resource value: 10
+			public const int Toolbar_contentInsetEndWithActions = 10;
 			
 			// aapt resource value: 7
 			public const int Toolbar_contentInsetLeft = 7;
@@ -7660,64 +9028,70 @@ namespace XFGlossSample.Droid
 			// aapt resource value: 5
 			public const int Toolbar_contentInsetStart = 5;
 			
+			// aapt resource value: 9
+			public const int Toolbar_contentInsetStartWithNavigation = 9;
+			
 			// aapt resource value: 4
 			public const int Toolbar_logo = 4;
 			
-			// aapt resource value: 22
-			public const int Toolbar_logoDescription = 22;
-			
-			// aapt resource value: 17
-			public const int Toolbar_maxButtonHeight = 17;
-			
-			// aapt resource value: 21
-			public const int Toolbar_navigationContentDescription = 21;
+			// aapt resource value: 26
+			public const int Toolbar_logoDescription = 26;
 			
 			// aapt resource value: 20
-			public const int Toolbar_navigationIcon = 20;
+			public const int Toolbar_maxButtonHeight = 20;
 			
-			// aapt resource value: 9
-			public const int Toolbar_popupTheme = 9;
+			// aapt resource value: 25
+			public const int Toolbar_navigationContentDescription = 25;
+			
+			// aapt resource value: 24
+			public const int Toolbar_navigationIcon = 24;
+			
+			// aapt resource value: 11
+			public const int Toolbar_popupTheme = 11;
 			
 			// aapt resource value: 3
 			public const int Toolbar_subtitle = 3;
 			
-			// aapt resource value: 11
-			public const int Toolbar_subtitleTextAppearance = 11;
+			// aapt resource value: 13
+			public const int Toolbar_subtitleTextAppearance = 13;
 			
-			// aapt resource value: 24
-			public const int Toolbar_subtitleTextColor = 24;
+			// aapt resource value: 28
+			public const int Toolbar_subtitleTextColor = 28;
 			
 			// aapt resource value: 2
 			public const int Toolbar_title = 2;
 			
-			// aapt resource value: 16
-			public const int Toolbar_titleMarginBottom = 16;
-			
 			// aapt resource value: 14
-			public const int Toolbar_titleMarginEnd = 14;
+			public const int Toolbar_titleMargin = 14;
 			
-			// aapt resource value: 13
-			public const int Toolbar_titleMarginStart = 13;
+			// aapt resource value: 18
+			public const int Toolbar_titleMarginBottom = 18;
+			
+			// aapt resource value: 16
+			public const int Toolbar_titleMarginEnd = 16;
 			
 			// aapt resource value: 15
-			public const int Toolbar_titleMarginTop = 15;
+			public const int Toolbar_titleMarginStart = 15;
+			
+			// aapt resource value: 17
+			public const int Toolbar_titleMarginTop = 17;
+			
+			// aapt resource value: 19
+			public const int Toolbar_titleMargins = 19;
 			
 			// aapt resource value: 12
-			public const int Toolbar_titleMargins = 12;
+			public const int Toolbar_titleTextAppearance = 12;
 			
-			// aapt resource value: 10
-			public const int Toolbar_titleTextAppearance = 10;
-			
-			// aapt resource value: 23
-			public const int Toolbar_titleTextColor = 23;
+			// aapt resource value: 27
+			public const int Toolbar_titleTextColor = 27;
 			
 			public static int[] View = new int[]
 			{
 					16842752,
 					16842970,
-					2130772279,
-					2130772280,
-					2130772281};
+					2130772219,
+					2130772220,
+					2130772221};
 			
 			// aapt resource value: 1
 			public const int View_android_focusable = 1;
@@ -7737,8 +9111,8 @@ namespace XFGlossSample.Droid
 			public static int[] ViewBackgroundHelper = new int[]
 			{
 					16842964,
-					2130772282,
-					2130772283};
+					2130772222,
+					2130772223};
 			
 			// aapt resource value: 0
 			public const int ViewBackgroundHelper_android_background = 0;

--- a/XFGlossSample.Droid/XFGlossSample.Droid.csproj
+++ b/XFGlossSample.Droid/XFGlossSample.Droid.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.props" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.props')" />
+  <Import Project="..\packages\Xamarin.Build.Download.0.4.4\build\Xamarin.Build.Download.props" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.4\build\Xamarin.Build.Download.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -154,7 +154,6 @@
   </ItemGroup>
   <Import Project="..\XFGlossSample.Shared\XFGlossSample.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.targets" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.targets')" />
   <Import Project="..\packages\Xamarin.Android.Support.Annotations.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Annotations.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Annotations.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Annotations.targets')" />
   <Import Project="..\packages\Xamarin.Android.Support.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Compat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Compat.targets')" />
   <Import Project="..\packages\Xamarin.Android.Support.Core.UI.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.UI.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Core.UI.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.UI.targets')" />
@@ -172,4 +171,5 @@
   <Import Project="..\packages\Xamarin.Android.Support.Design.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Design.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Design.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Design.targets')" />
   <Import Project="..\packages\Xamarin.Android.Support.v7.MediaRouter.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.MediaRouter.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.MediaRouter.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.MediaRouter.targets')" />
   <Import Project="..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\packages\Xamarin.Build.Download.0.4.4\build\Xamarin.Build.Download.targets" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.4\build\Xamarin.Build.Download.targets')" />
 </Project>

--- a/XFGlossSample.Droid/XFGlossSample.Droid.csproj
+++ b/XFGlossSample.Droid/XFGlossSample.Droid.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.props" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -8,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>XFGlossSample.Droid</RootNamespace>
     <AssemblyName>XFGlossSample.Droid</AssemblyName>
-    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <AndroidApplication>True</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
@@ -43,44 +44,68 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
+    <Reference Include="Xamarin.Android.Support.Annotations">
+      <HintPath>..\packages\Xamarin.Android.Support.Annotations.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Compat">
+      <HintPath>..\packages\Xamarin.Android.Support.Compat.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Compat.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Core.UI">
+      <HintPath>..\packages\Xamarin.Android.Support.Core.UI.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Core.UI.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Core.Utils">
+      <HintPath>..\packages\Xamarin.Android.Support.Core.Utils.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Core.Utils.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Media.Compat">
+      <HintPath>..\packages\Xamarin.Android.Support.Media.Compat.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Media.Compat.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Fragment">
+      <HintPath>..\packages\Xamarin.Android.Support.Fragment.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Fragment.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Transition">
+      <HintPath>..\packages\Xamarin.Android.Support.Transition.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Transition.dll</HintPath>
+    </Reference>
     <Reference Include="Xamarin.Android.Support.v4">
-      <HintPath>..\packages\Xamarin.Android.Support.v4.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Android.Support.Vector.Drawable">
-      <HintPath>..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.Vector.Drawable.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Android.Support.Animated.Vector.Drawable">
-      <HintPath>..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.Animated.Vector.Drawable.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Android.Support.v7.AppCompat">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.AppCompat.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Android.Support.v7.RecyclerView">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.RecyclerView.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.RecyclerView.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Android.Support.Design">
-      <HintPath>..\packages\Xamarin.Android.Support.Design.23.3.0\lib\MonoAndroid43\Xamarin.Android.Support.Design.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v4.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v4.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.CardView">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.CardView.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.CardView.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v7.CardView.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.CardView.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v7.Palette">
+      <HintPath>..\packages\Xamarin.Android.Support.v7.Palette.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.Palette.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v7.RecyclerView">
+      <HintPath>..\packages\Xamarin.Android.Support.v7.RecyclerView.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.RecyclerView.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Vector.Drawable">
+      <HintPath>..\packages\Xamarin.Android.Support.Vector.Drawable.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Vector.Drawable.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Animated.Vector.Drawable">
+      <HintPath>..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Animated.Vector.Drawable.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v7.AppCompat">
+      <HintPath>..\packages\Xamarin.Android.Support.v7.AppCompat.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Design">
+      <HintPath>..\packages\Xamarin.Android.Support.Design.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.Design.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.MediaRouter">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.MediaRouter.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.MediaRouter.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v7.MediaRouter.25.3.1\lib\MonoAndroid70\Xamarin.Android.Support.v7.MediaRouter.dll</HintPath>
     </Reference>
     <Reference Include="FormsViewGroup">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.Android">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -92,7 +117,6 @@
     <None Include="Resources\AboutResources.txt" />
     <None Include="Properties\AndroidManifest.xml" />
     <None Include="Assets\AboutAssets.txt" />
-    <None Include="packages.config" />
     <None Include="Resources\drawable\csharp.png" />
     <None Include="Resources\drawable\infocircle.png" />
     <None Include="Resources\drawable\xamlcode.png" />
@@ -105,6 +129,7 @@
     <None Include="Resources\drawable-xxhdpi\xamlcode.png" />
     <None Include="Resources\drawable-xxhdpi\csharp.png" />
     <None Include="Resources\drawable-xxhdpi\infocircle.png" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\layout\Tabbar.axml" />
@@ -129,6 +154,22 @@
   </ItemGroup>
   <Import Project="..\XFGlossSample.Shared\XFGlossSample.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets')" />
-  <Import Project="..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.targets" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.3\build\Xamarin.Build.Download.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Annotations.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Annotations.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Annotations.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Annotations.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Compat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Compat.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Core.UI.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.UI.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Core.UI.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.UI.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Core.Utils.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.Utils.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Core.Utils.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Core.Utils.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Media.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Media.Compat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Media.Compat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Media.Compat.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Fragment.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Fragment.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Fragment.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Fragment.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Transition.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Transition.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Transition.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Transition.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v4.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v4.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v4.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v4.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v7.CardView.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.CardView.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.CardView.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.CardView.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v7.Palette.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.Palette.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.Palette.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.Palette.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v7.RecyclerView.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.RecyclerView.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.RecyclerView.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.RecyclerView.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Vector.Drawable.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Vector.Drawable.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Vector.Drawable.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Animated.Vector.Drawable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Animated.Vector.Drawable.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v7.AppCompat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.AppCompat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.AppCompat.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.AppCompat.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Design.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Design.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Design.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.Design.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v7.MediaRouter.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.MediaRouter.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.MediaRouter.25.3.1\build\MonoAndroid70\Xamarin.Android.Support.v7.MediaRouter.targets')" />
+  <Import Project="..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/XFGlossSample.Droid/packages.config
+++ b/XFGlossSample.Droid/packages.config
@@ -16,6 +16,6 @@
   <package id="Xamarin.Android.Support.v7.Palette" version="25.3.1" targetFramework="monoandroid71" />
   <package id="Xamarin.Android.Support.v7.RecyclerView" version="25.3.1" targetFramework="monoandroid71" />
   <package id="Xamarin.Android.Support.Vector.Drawable" version="25.3.1" targetFramework="monoandroid71" />
-  <package id="Xamarin.Build.Download" version="0.4.3" targetFramework="monoandroid71" />
+  <package id="Xamarin.Build.Download" version="0.4.4" targetFramework="monoandroid71" />
   <package id="Xamarin.Forms" version="2.3.4.231" targetFramework="monoandroid71" />
 </packages>

--- a/XFGlossSample.Droid/packages.config
+++ b/XFGlossSample.Droid/packages.config
@@ -1,12 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="23.3.0" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.Android.Support.Design" version="23.3.0" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.Android.Support.v4" version="23.3.0" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.Android.Support.v7.AppCompat" version="23.3.0" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.Android.Support.v7.CardView" version="23.3.0" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.Android.Support.v7.MediaRouter" version="23.3.0" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.Android.Support.v7.RecyclerView" version="23.3.0" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.Android.Support.Vector.Drawable" version="23.3.0" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.Forms" version="2.3.3.193" targetFramework="monoandroid70" />
+  <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Annotations" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Compat" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Core.UI" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Core.Utils" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Design" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Fragment" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Media.Compat" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Transition" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v4" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.AppCompat" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.CardView" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.MediaRouter" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.Palette" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.v7.RecyclerView" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Android.Support.Vector.Drawable" version="25.3.1" targetFramework="monoandroid71" />
+  <package id="Xamarin.Build.Download" version="0.4.3" targetFramework="monoandroid71" />
+  <package id="Xamarin.Forms" version="2.3.4.231" targetFramework="monoandroid71" />
 </packages>

--- a/XFGlossSample.iOS/XFGlossSample.iOS.csproj
+++ b/XFGlossSample.iOS/XFGlossSample.iOS.csproj
@@ -22,8 +22,6 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
     <MtouchFastDev>true</MtouchFastDev>
-    <MtouchUseSGen>true</MtouchUseSGen>
-    <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchLink>None</MtouchLink>
     <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
@@ -39,8 +37,6 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <MtouchUseSGen>true</MtouchUseSGen>
-    <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
@@ -57,8 +53,6 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <MtouchUseSGen>true</MtouchUseSGen>
-    <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
@@ -77,8 +71,6 @@
     <DeviceSpecificBuild>true</DeviceSpecificBuild>
     <MtouchDebug>true</MtouchDebug>
     <MtouchFastDev>true</MtouchFastDev>
-    <MtouchUseSGen>true</MtouchUseSGen>
-    <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
@@ -93,16 +85,16 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.iOS">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -184,5 +176,5 @@
     <BundleResource Include="Resources\xamlcode%403x.png" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/XFGlossSample.iOS/packages.config
+++ b/XFGlossSample.iOS/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.3.3.193" targetFramework="xamarinios10" />
+  <package id="Xamarin.Forms" version="2.3.4.231" targetFramework="xamarinios10" />
 </packages>

--- a/XFGlossSample/Examples/DeviceExtensions.cs
+++ b/XFGlossSample/Examples/DeviceExtensions.cs
@@ -1,0 +1,39 @@
+﻿// /*
+//  * Copyright (C) 2016 Ansuria Solutions LLC & Tommy Baggett: 
+//  * http://github.com/tbaggett
+//  * http://twitter.com/tbaggett
+//  * http://tommyb.com
+//  * http://ansuria.com
+//  * 
+//  * The MIT License (MIT) see GitHub For more information
+//  *
+//  * Unless required by applicable law or agreed to in writing, software
+//  * distributed under the License is distributed on an "AS IS" BASIS,
+//  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  * See the License for the specific language governing permissions and
+//  * limitations under the License.
+//  */
+//
+using System;
+using Xamarin.Forms;
+
+namespace XFGlossSample.Examples
+{
+    public class DeviceExtensions
+    {
+        public static T OnPlatform<T>(T iOS, T android, T wp)
+		{
+
+			switch (Device.RuntimePlatform)
+			{
+				case Device.iOS:
+					return iOS;
+				case Device.Android:
+					return android;
+				case Device.WinPhone:
+					return wp;
+			}
+			return default(T);
+		}
+    }
+}

--- a/XFGlossSample/Examples/ViewModels/TintColorViewModel.cs
+++ b/XFGlossSample/Examples/ViewModels/TintColorViewModel.cs
@@ -18,58 +18,58 @@ using Xamarin.Forms;
 
 namespace XFGlossSample.Examples.ViewModels
 {
-	public class TintColorViewModel : IExamplesViewModel
-	{
-		public string PropertyDefault
-		{
-			get { return "Color.Default"; }
-		}
+    public class TintColorViewModel : IExamplesViewModel
+    {
+        public string PropertyDefault
+        {
+            get { return "Color.Default"; }
+        }
 
-		public string[] PropertyDescription
-		{
-			get
-			{
-				string result;
+        public string[] PropertyDescription
+        {
+            get
+            {
+                string result;
 
-				if (Device.OS == TargetPlatform.iOS)
-				{
-					result = "Specifies a numeric or named XF.Color value to apply to the cell's accessory view or " +
-							"the track/border portion of the Switch control when the control is in the \"Off\" " +
-							"position.";
-				}
-				else
-				{
-					result = "Specifies a numeric or named XF.Color value to apply to the track/border portion of " +
-								"the Switch control when the control is in the \"Off\" position.";
-				}
+                if (Device.RuntimePlatform == Device.iOS)
+                {
+                    result = "Specifies a numeric or named XF.Color value to apply to the cell's accessory view or " +
+                            "the track/border portion of the Switch control when the control is in the \"Off\" " +
+                            "position.";
+                }
+                else
+                {
+                    result = "Specifies a numeric or named XF.Color value to apply to the track/border portion of " +
+                                "the Switch control when the control is in the \"Off\" position.";
+                }
 
-				return new string[] { result };
-			}
-		}
+                return new string[] { result };
+            }
+        }
 
-		public string PropertyType
-		{
-			get { return "Xamarin.Forms.Color"; }
-		}
+        public string PropertyType
+        {
+            get { return "Xamarin.Forms.Color"; }
+        }
 
-		public string TargetClasses
-		{
-			get 
-			{
-				if (Device.OS == TargetPlatform.iOS)
-				{
-					return "EntryCell, ImageCell, Switch, SwitchCell, TextCell, ViewCell";
-				}
-				else
-				{
-					return "Switch, SwitchCell";
-				}
-			}
-		}
+        public string TargetClasses
+        {
+            get
+            {
+                if (Device.RuntimePlatform == Device.iOS)
+                {
+                    return "EntryCell, ImageCell, Switch, SwitchCell, TextCell, ViewCell";
+                }
+                else
+                {
+                    return "Switch, SwitchCell";
+                }
+            }
+        }
 
-		public bool isRunningiOS
-		{
-			get { return Device.OS == TargetPlatform.iOS; }
-		}
-	}
+        public bool isRunningiOS
+        {
+            get { return Device.RuntimePlatform == Device.iOS; }
+        }
+    }
 }

--- a/XFGlossSample/Examples/Views/CSharp/BackgroundColorPage.cs
+++ b/XFGlossSample/Examples/Views/CSharp/BackgroundColorPage.cs
@@ -32,7 +32,7 @@ namespace XFGlossSample.Examples.Views.CSharp
 			(https://forums.xamarin.com/discussion/18037/tablesection-w-out-header)
 			*/
 			TableSection section;
-			if (Device.OS == TargetPlatform.Android)
+			if (Device.RuntimePlatform == Device.Android)
 			{
 				section = new TableSection("Cell BackgroundColor values set in C#:");
 			}
@@ -54,14 +54,14 @@ namespace XFGlossSample.Examples.Views.CSharp
 			section.Add(cell);
 
 			var stack = new StackLayout();
-			if (Device.OS == TargetPlatform.iOS)
+			if (Device.RuntimePlatform == Device.iOS)
 			{
 				stack.Children.Add(new Label { Text = "Cell BackgroundColor values set in C#:", Margin = new Thickness(10) });
 			}
 			stack.Children.Add(new TableView
 			{
 				Intent = TableIntent.Data,
-				HeightRequest = Device.OnPlatform<double>(132, 190, 0),
+				HeightRequest = DeviceExtensions.OnPlatform<double>(132, 190, 0),
 				Root = new TableRoot
 				{
 					section
@@ -70,5 +70,7 @@ namespace XFGlossSample.Examples.Views.CSharp
 
 			Content = stack;
 		}
+
+
 	}
 }

--- a/XFGlossSample/Examples/Views/CSharp/BackgroundGradientPage.cs
+++ b/XFGlossSample/Examples/Views/CSharp/BackgroundGradientPage.cs
@@ -40,7 +40,7 @@ namespace XFGlossSample.Examples.Views.CSharp
 			(https://forums.xamarin.com/discussion/18037/tablesection-w-out-header)
 			*/
 			TableSection section;
-			if (Device.OS == TargetPlatform.Android)
+			if (Device.RuntimePlatform == Device.Android)
 			{
 				section = new TableSection("Cell BackgroundGradient values set in C#:");
 			}
@@ -53,7 +53,7 @@ namespace XFGlossSample.Examples.Views.CSharp
 
 			var stack = new StackLayout();
 
-			if (Device.OS == TargetPlatform.iOS)
+			if (Device.RuntimePlatform == Device.iOS)
 			{
 				stack.Children.Add(new Label { Text = "Cell BackgroundGradient values set in C#:", Margin = new Thickness(10) });
 			}
@@ -62,7 +62,7 @@ namespace XFGlossSample.Examples.Views.CSharp
 				Intent = TableIntent.Data,
 				BackgroundColor = Color.Transparent,
 				VerticalOptions = LayoutOptions.Start,
-				HeightRequest = Device.OnPlatform<double>(176, 232, 0),
+				HeightRequest = DeviceExtensions.OnPlatform<double>(176, 232, 0),
 				Root = new TableRoot
 				{
 					section

--- a/XFGlossSample/Examples/Views/CSharp/OnTintColorPage.cs
+++ b/XFGlossSample/Examples/Views/CSharp/OnTintColorPage.cs
@@ -31,7 +31,7 @@ namespace XFGlossSample.Examples.Views.CSharp
 			(https://forums.xamarin.com/discussion/18037/tablesection-w-out-header)
 			*/
 			TableSection section;
-			if (Device.OS == TargetPlatform.Android)
+			if (Device.RuntimePlatform == Device.Android)
 			{
 				section = new TableSection("SwitchCell OnTintColor values set in C#:");
 			}
@@ -44,7 +44,7 @@ namespace XFGlossSample.Examples.Views.CSharp
 			section.Add(CreateOnTintColorCell("Blue", Color.Blue));
 
 			var stack = new StackLayout();
-			if (Device.OS == TargetPlatform.iOS)
+			if (Device.RuntimePlatform == Device.iOS)
 			{
 				stack.Children.Add(new Label { Text = "SwitchCell OnTintColor values set in C#:", Margin = new Thickness(10) });
 			}
@@ -52,7 +52,7 @@ namespace XFGlossSample.Examples.Views.CSharp
 			stack.Children.Add(new TableView()
 			{
 				Intent = TableIntent.Data,
-				HeightRequest = Device.OnPlatform<double>(132, 190, 0),
+				HeightRequest = DeviceExtensions.OnPlatform<double>(132, 190, 0),
 				Root = new TableRoot()
 				{
 					section

--- a/XFGlossSample/Examples/Views/CSharp/ThumbOnTintColorPage.cs
+++ b/XFGlossSample/Examples/Views/CSharp/ThumbOnTintColorPage.cs
@@ -33,7 +33,7 @@ namespace XFGlossSample.Examples.Views.CSharp
 			(https://forums.xamarin.com/discussion/18037/tablesection-w-out-header)
 			*/
 			TableSection section;
-			if (Device.OS == TargetPlatform.Android)
+            if (Device.RuntimePlatform == Device.Android)
 			{
 				section = new TableSection("SwitchCell ThumbOnTintColor values set in C#:");
 			}
@@ -47,7 +47,7 @@ namespace XFGlossSample.Examples.Views.CSharp
 
 
 			var stack = new StackLayout();
-			if (Device.OS == TargetPlatform.iOS)
+			if (Device.RuntimePlatform == Device.iOS)
 			{
 				stack.Children.Add(new Label { Text = "SwitchCell ThumbOnTintColor values set in C#:", Margin = new Thickness(10) });
 			}

--- a/XFGlossSample/Examples/Views/CSharp/ThumbTintColorPage.cs
+++ b/XFGlossSample/Examples/Views/CSharp/ThumbTintColorPage.cs
@@ -31,7 +31,7 @@ namespace XFGlossSample.Examples.Views.CSharp
 			(https://forums.xamarin.com/discussion/18037/tablesection-w-out-header)
 			*/
 			TableSection section;
-			if (Device.OS == TargetPlatform.Android)
+			if (Device.RuntimePlatform == Device.Android)
 			{
 				section = new TableSection("SwitchCell ThumbTintColor values set in C#:");
 			}
@@ -52,14 +52,14 @@ namespace XFGlossSample.Examples.Views.CSharp
 			stack.Children.Add(CreateThumbTintColorSlider(50, Color.Green));
 			stack.Children.Add(CreateThumbTintColorSlider(75, Color.Blue));
 
-			if (Device.OS == TargetPlatform.iOS)
+			if (Device.RuntimePlatform == Device.iOS)
 			{
 				stack.Children.Add(new Label { Text = "SwitchCell ThumbTintColor values set in C#:", Margin = new Thickness(10) });
 			}
 
 			stack.Children.Add(new TableView()
 								{
-									HeightRequest = Device.OnPlatform<double>(132, 190, 0),
+									HeightRequest = DeviceExtensions.OnPlatform<double>(132, 190, 0),
 									Root = new TableRoot()
 									{
 										section

--- a/XFGlossSample/Examples/Views/CSharp/TintColorPage.cs
+++ b/XFGlossSample/Examples/Views/CSharp/TintColorPage.cs
@@ -29,7 +29,7 @@ namespace XFGlossSample.Examples.Views.CSharp
 			base.OnBindingContextChanged();
 
 			var stack = new StackLayout();
-			if (Device.OS == TargetPlatform.iOS)
+			if (Device.RuntimePlatform == Device.iOS)
 			{
 				stack.Children.Add(
 					new StackLayout
@@ -75,7 +75,7 @@ namespace XFGlossSample.Examples.Views.CSharp
 			(https://forums.xamarin.com/discussion/18037/tablesection-w-out-header)
 			*/
 			TableSection section;
-			if (Device.OS == TargetPlatform.Android)
+			if (Device.RuntimePlatform == Device.Android)
 			{
 				section = new TableSection("SwitchCell TintColor values set in C#:");
 			}
@@ -91,7 +91,7 @@ namespace XFGlossSample.Examples.Views.CSharp
 				new TableView()
 				{
 					Intent = TableIntent.Data,
-					HeightRequest = Device.OnPlatform<double>(132, 190, 0),
+					HeightRequest = DeviceExtensions.OnPlatform<double>(132, 190, 0),
 					Root = new TableRoot()
 					{
 						section
@@ -109,7 +109,7 @@ namespace XFGlossSample.Examples.Views.CSharp
 			stack.Children.Add(CreateTintColorSwitch("Green", Color.Green));
 			stack.Children.Add(CreateTintColorSwitch("Blue", Color.Blue));
 
-			if (Device.OS == TargetPlatform.iOS)
+			if (Device.RuntimePlatform == Device.iOS)
 			{
 				var scrollView = new ScrollView();
 				scrollView.Content = stack;

--- a/XFGlossSample/Examples/Views/XFGlossSampleViewFactory.cs
+++ b/XFGlossSample/Examples/Views/XFGlossSampleViewFactory.cs
@@ -74,7 +74,7 @@ namespace XFGlossSample.Examples.Views
 						TabbedPage examplePage = new TabbedPage();
 
 						// Assign icons (iOS only) and titles to be used by each of the tabs to the navigation pages
-						if (Device.OS == TargetPlatform.iOS)
+                        if (Device.RuntimePlatform == Device.iOS)
 						{
 							examplePage.Children.Add(new NavigationPage(infoPage) { Title = "Info", Icon = "infocircle.png" });
 							examplePage.Children.Add(new NavigationPage(xamlPage) { Title = "Xaml", Icon = "xamlcode.png" });

--- a/XFGlossSample/ViewModels/AppMenuViewModel.cs
+++ b/XFGlossSample/ViewModels/AppMenuViewModel.cs
@@ -57,7 +57,7 @@ namespace XFGlossSample.ViewModels
 			};
 
 			// Add iOS only entry if we're running on iOS
-			if (Device.OS == TargetPlatform.iOS)
+            if (Device.RuntimePlatform == Device.iOS)
 			{
 				menuItems[0].Insert(0, new AppMenuItem("AccessoryType (iOS only)", "AccessoryType"));
 			}

--- a/XFGlossSample/XFGlossSample.csproj
+++ b/XFGlossSample/XFGlossSample.csproj
@@ -158,6 +158,7 @@
     <Compile Include="PerfTests\Views\RetainBackgroundGradientPage.xaml.cs">
       <DependentUpon>RetainBackgroundGradientPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Examples\DeviceExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\XFGloss\XFGloss.csproj">
@@ -168,13 +169,13 @@
   <ItemGroup />
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.2.3.3.193\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -183,5 +184,5 @@
   <Import Project="..\XFGlossSample.Shared\XFGlossSample.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\packages\Xamarin.Forms.2.3.1.114\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.1.114\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
-  <Import Project="..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.3.193\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/XFGlossSample/packages.config
+++ b/XFGlossSample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.3.3.193" targetFramework="portable45-net45+win8+wp8" />
+  <package id="Xamarin.Forms" version="2.3.4.231" targetFramework="portable45-net45+win8+wp8" />
 </packages>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ assembly_info:
 install:
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/install-android-sdk.ps1?v=2'))
 - ps: $sdks = Get-AndroidSDKs |? { $_.name -like 'sdk platform*API 23*' -or $_.name -like 'Google APIs, Android API 23' } 
-- ps: Install-AndroidSDK -sdks $sdks
+- ps: Install-AndroidSDK --no-ui -sdks $sdks
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/fix-xamarin-4-2-2-11.ps1'))
 nuget:
   disable_publish_on_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ assembly_info:
   assembly_informational_version: '{version}'
 install:
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/install-android-sdk.ps1?v=2'))
-- ps: $sdks = Get-AndroidSDKs |? { $_.name -like 'sdk platform*API 25*' -or $_.name -like 'Google APIs, Android API 25' } 
+- ps: $sdks = Get-AndroidSDKs |? { $_.name -like 'sdk platform*API 23*' -or $_.name -like 'Google APIs, Android API 23' } 
 - ps: Install-AndroidSDK -sdks $sdks
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/fix-xamarin-4-2-2-11.ps1'))
 nuget:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,9 @@ assembly_info:
   assembly_file_version: '{version}'
   assembly_informational_version: '{version}'
 install:
-- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/install-android-sdk.ps1'))
+- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/install-android-sdk.ps1?v=2'))
+- ps: $sdks = Get-AndroidSDKs |? { $_.name -like 'sdk platform*API 25*' -or $_.name -like 'Google APIs, Android API 25' } 
+- ps: Install-AndroidSDK -sdks $sdks
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/fix-xamarin-4-2-2-11.ps1'))
 nuget:
   disable_publish_on_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,8 @@ assembly_info:
   assembly_informational_version: '{version}'
 install:
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/install-android-sdk.ps1?v=2'))
-- ps: $sdks = Get-AndroidSDKs |? { $_.name -like 'sdk platform*API 23*' -or $_.name -like 'Google APIs, Android API 23' } 
-- ps: Install-AndroidSDK --no-ui -sdks $sdks
+- ps: $sdks = Get-AndroidSDKs |? { $_.name -like 'sdk platform*API 24*' -or $_.name -like 'Google APIs, Android API 24' } 
+- ps: Install-AndroidSDK -sdks $sdks
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/fix-xamarin-4-2-2-11.ps1'))
 nuget:
   disable_publish_on_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,9 @@ assembly_info:
   assembly_informational_version: '{version}'
 install:
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/install-android-sdk.ps1?v=2'))
-- ps: $sdks25 = Get-AndroidSDKs |? { $_.name -like '*SDK*Platform*25*' } 
+- ps: $sdks25 = Get-AndroidSDKs |? { $_.name -like '*SDK*Platform*23*' } 
 - ps: Install-AndroidSDK -sdks $sdks25
-- ps: $sdks23 = Get-AndroidSDKs |? { $_.name -like '*SDK*Platform*23*' } 
+- ps: $sdks23 = Get-AndroidSDKs |? { $_.name -like '*SDK*Platform*24*' } 
 - ps: Install-AndroidSDK -sdks $sdks23
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/fix-xamarin-4-2-2-11.ps1'))
 nuget:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,10 @@ assembly_info:
   assembly_informational_version: '{version}'
 install:
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/install-android-sdk.ps1?v=2'))
-- ps: $sdks = Get-AndroidSDKs |? { $_.name -like 'sdk platform*API 23*' -or $_.name -like 'Google APIs, Android API 23' } 
-- ps: echo y | Install-AndroidSDK -sdks $sdks
+- ps: $sdks1 = Get-AndroidSDKs |? { $_.name -like 'sdk platform*API 23*' -or $_.name -like 'Android API 23' } 
+- ps: Install-AndroidSDK -sdks $sdks1
+- ps: $sdks2 = Get-AndroidSDKs |? { $_.name -like 'sdk platform*API 23*' -or $_.name -like 'Google APIs' } 
+- ps: Install-AndroidSDK -sdks $sdks2
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/fix-xamarin-4-2-2-11.ps1'))
 nuget:
   disable_publish_on_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,12 +12,10 @@ assembly_info:
   assembly_informational_version: '{version}'
 install:
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/install-android-sdk.ps1?v=2'))
-- ps: $sdks25 = Get-AndroidSDKs |? { $_.name -like 'SDK Platform*25' } 
+- ps: $sdks25 = Get-AndroidSDKs |? { $_.name -like '*SDK*Platform*25*' } 
 - ps: Install-AndroidSDK -sdks $sdks25
-- ps: $sdks23 = Get-AndroidSDKs |? { $_.name -like 'Android SDK Platform 23' } 
+- ps: $sdks23 = Get-AndroidSDKs |? { $_.name -like '*SDK*Platform*23*' } 
 - ps: Install-AndroidSDK -sdks $sdks23
-- ps: $sdks25Build = Get-AndroidSDKs |? { $_.name -like 'Android SDK Build-Tools 25*' } 
-- ps: Install-AndroidSDK -sdks $sdks25Build
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/fix-xamarin-4-2-2-11.ps1'))
 nuget:
   disable_publish_on_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,8 @@ assembly_info:
   assembly_informational_version: '{version}'
 install:
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/install-android-sdk.ps1?v=2'))
-- ps: $sdks = Get-AndroidSDKs |? { $_.name -like 'sdk platform*API 24*' -or $_.name -like 'Google APIs, Android API 24' } 
-- ps: Install-AndroidSDK -sdks $sdks
+- ps: $sdks = Get-AndroidSDKs |? { $_.name -like 'sdk platform*API 23*' -or $_.name -like 'Google APIs, Android API 23' } 
+- ps: echo y | Install-AndroidSDK -sdks $sdks
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/fix-xamarin-4-2-2-11.ps1'))
 nuget:
   disable_publish_on_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ assembly_info:
   assembly_file_version: '{version}'
   assembly_informational_version: '{version}'
 install:
+- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/install-android-sdk.ps1'))
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/fix-xamarin-4-2-2-11.ps1'))
 nuget:
   disable_publish_on_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ assembly_info:
   assembly_informational_version: '{version}'
 install:
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/install-android-sdk.ps1?v=2'))
-- ps: $sdks25 = Get-AndroidSDKs |? { $_.name -like 'SDK Platform*25' } 
+- ps: $sdks25 = Get-AndroidSDKs |? { $_.name -like 'SDK Platform Android 7.1.1, API 25, revision 3' } 
 - ps: Install-AndroidSDK -sdks $sdks25
 - ps: $sdks23 = Get-AndroidSDKs |? { $_.name -like 'Android SDK Platform 23' } 
 - ps: Install-AndroidSDK -sdks $sdks23

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,12 @@ assembly_info:
   assembly_informational_version: '{version}'
 install:
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/install-android-sdk.ps1?v=2'))
-- ps: $sdks1 = Get-AndroidSDKs |? { $_.name -like 'sdk platform*API 23*' -or $_.name -like 'Android API 23' } 
-- ps: Install-AndroidSDK -sdks $sdks1
-- ps: $sdks2 = Get-AndroidSDKs |? { $_.name -like 'sdk platform*API 23*' -or $_.name -like 'Google APIs' } 
-- ps: Install-AndroidSDK -sdks $sdks2
+- ps: $sdks25 = Get-AndroidSDKs |? { $_.name -like 'Android SDK Platform 25' } 
+- ps: Install-AndroidSDK -sdks $sdks25
+- ps: $sdks23 = Get-AndroidSDKs |? { $_.name -like 'Android SDK Platform 23' } 
+- ps: Install-AndroidSDK -sdks $sdks23
+- ps: $sdks25Build = Get-AndroidSDKs |? { $_.name -like 'Android SDK Build-Tools 25*' } 
+- ps: Install-AndroidSDK -sdks $sdks25Build
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/fix-xamarin-4-2-2-11.ps1'))
 nuget:
   disable_publish_on_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ assembly_info:
   assembly_informational_version: '{version}'
 install:
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/install-android-sdk.ps1?v=2'))
-- ps: $sdks25 = Get-AndroidSDKs |? { $_.name -like 'Android SDK Platform 25' } 
+- ps: $sdks25 = Get-AndroidSDKs |? { $_.name -like 'SDK Platform*25' } 
 - ps: Install-AndroidSDK -sdks $sdks25
 - ps: $sdks23 = Get-AndroidSDKs |? { $_.name -like 'Android SDK Platform 23' } 
 - ps: Install-AndroidSDK -sdks $sdks23

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ assembly_info:
   assembly_informational_version: '{version}'
 install:
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/install-android-sdk.ps1?v=2'))
-- ps: $sdks25 = Get-AndroidSDKs |? { $_.name -like 'SDK Platform Android 7.1.1, API 25, revision 3' } 
+- ps: $sdks25 = Get-AndroidSDKs |? { $_.name -like 'SDK Platform*25' } 
 - ps: Install-AndroidSDK -sdks $sdks25
 - ps: $sdks23 = Get-AndroidSDKs |? { $_.name -like 'Android SDK Platform 23' } 
 - ps: Install-AndroidSDK -sdks $sdks23


### PR DESCRIPTION
First off, I would like to show my appreciation of your awesome work! Thank you for making this package!!

### Reasons for Forking
I was getting a lot of warnings because Android module was built against an older version of Xamarin.Forms package. 

### Changes
- updated Xamarin.Forms package to latest version
- changed obsolete method calls and properties to suitable new values.

Examples:
~~~
-			if (Device.OS == TargetPlatform.iOS)
+			if (Device.RuntimePlatform == Device.iOS)
~~~

~~~
-				HeightRequest = Device.OnPlatform<double>(132, 190, 0),
+				HeightRequest = DeviceExtensions.OnPlatform<double>(132, 190, 0),
~~~

### Current Issues
AppVeyor is unable to build it. Based on stack overflow, it looks like AppVeyor may not have API 23 of Android. 


